### PR TITLE
🐛 Fix: gradle 버전 수정

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## ❗ 버그 설명
빌드에러를 해결하기 위해 gradle 버전을 낮췄습니다.

## 📸 에러 로그 or 캡처 (선택)
> 필요 시 에러 로그 일부 또는 화면 캡처 첨부
FAILURE: Build failed with an exception.

* Where:
Initialization script 'C:\Users\USER\AppData\Local\Temp\EgobookBeApplication_main__1.gradle' line: 27

* What went wrong:
A problem occurred configuring root project 'Egobook_BE'.
> Could not get unknown property 'convention' for root project 'Egobook_BE' of type org.gradle.api.Project.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to generate a Build Scan (powered by Develocity).
> Get more help at https://help.gradle.org.

BUILD FAILED in 15s