### PR TITLE
✨ Feat: 친구 최대 10명만 가능하도록

### DIFF
--- a/src/main/java/com/example/egobook_be/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/example/egobook_be/domain/friend/controller/FriendController.java
@@ -127,7 +127,7 @@ public class FriendController {
                 """
     )
     @GetMapping("/requests/incoming")
-    public ResponseEntity<GlobalResponse<List<FriendRequestListResDto>>> getIncomingRequests(
+    public ResponseEntity<GlobalResponse<FriendRequestListWithCountResDto>> getIncomingRequests(
             @AuthenticationPrincipal(expression = "userAuthDto.userId") Long userId
     ) {
         return ResponseEntity.ok(

--- a/src/main/java/com/example/egobook_be/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/example/egobook_be/domain/friend/controller/FriendController.java
@@ -1,9 +1,6 @@
 package com.example.egobook_be.domain.friend.controller;
 
-import com.example.egobook_be.domain.friend.dto.FriendRequestCreateReqDto;
-import com.example.egobook_be.domain.friend.dto.FriendRequestListResDto;
-import com.example.egobook_be.domain.friend.dto.FriendResDto;
-import com.example.egobook_be.domain.friend.dto.FriendSearchResDto;
+import com.example.egobook_be.domain.friend.dto.*;
 import com.example.egobook_be.domain.friend.service.FriendService;
 import com.example.egobook_be.global.response.GlobalResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -52,6 +49,7 @@ public class FriendController {
                 받은 친구 신청을 수락합니다.
                 
                 - 수락 시 양방향 친구 관계가 생성됩니다.
+                - 친구는 최대 10명까지만 추가할 수 있으며, 초과 시 수락이 실패합니다.
                 """
     )
     @PostMapping("/requests/{requestId}/accept")
@@ -168,7 +166,7 @@ public class FriendController {
             """
     )
     @GetMapping
-    public ResponseEntity<GlobalResponse<List<FriendResDto>>> getFriends(
+    public ResponseEntity<GlobalResponse<FriendListResDto>> getFriends(
             @AuthenticationPrincipal(expression = "userAuthDto.userId")
             @Parameter(hidden = true) Long userId
     ) {

--- a/src/main/java/com/example/egobook_be/domain/friend/dto/FriendListResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/friend/dto/FriendListResDto.java
@@ -1,0 +1,12 @@
+package com.example.egobook_be.domain.friend.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record FriendListResDto(
+        int count,
+        List<FriendResDto> friends
+) {
+}

--- a/src/main/java/com/example/egobook_be/domain/friend/dto/FriendRequestListResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/friend/dto/FriendRequestListResDto.java
@@ -9,6 +9,7 @@ public record FriendRequestListResDto(
         Long requestId,
         Long userId,
         String nickname,
+        Integer level,
         LocalDateTime requestedAt
 ) {
 }

--- a/src/main/java/com/example/egobook_be/domain/friend/dto/FriendRequestListWithCountResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/friend/dto/FriendRequestListWithCountResDto.java
@@ -1,0 +1,12 @@
+package com.example.egobook_be.domain.friend.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record FriendRequestListWithCountResDto(
+        int totalCount,
+        List<FriendRequestListResDto> requests
+) {
+}

--- a/src/main/java/com/example/egobook_be/domain/friend/dto/FriendResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/friend/dto/FriendResDto.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 @Builder
 public record FriendResDto(
         Long friendId,
-        String nickname
+        String nickname,
+        Integer level
 ) {
 }

--- a/src/main/java/com/example/egobook_be/domain/friend/exception/FriendErrorCode.java
+++ b/src/main/java/com/example/egobook_be/domain/friend/exception/FriendErrorCode.java
@@ -20,6 +20,7 @@ public enum FriendErrorCode implements BaseErrorCode {
      */
     ALREADY_FRIEND(HttpStatus.CONFLICT, "이미 친구 관계입니다."),
     ALREADY_REQUESTED(HttpStatus.CONFLICT, "이미 친구 신청을 보낸 상태입니다."),
+    FRIEND_LIMIT_EXCEEDED(HttpStatus.CONFLICT, "친구는 최대 10명까지만 추가할 수 있습니다."),
 
     /**
      * 400 BAD_REQUEST

--- a/src/main/java/com/example/egobook_be/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/friend/repository/FriendRepository.java
@@ -17,6 +17,8 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
 
     List<Friend> findByUser(User user);
 
+    long countByUser(User user);
+
     @Query("""
         select f.friend.id
         from Friend f

--- a/src/main/java/com/example/egobook_be/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/friend/repository/FriendRepository.java
@@ -25,4 +25,14 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
         where f.user = :user
     """)
     List<Long> findFriendIdsByUser(@Param("user") User user);
+
+    @Query("""
+        select f
+        from Friend f
+        join fetch f.friend u
+        where f.user = :user
+    """)
+    List<Friend> findByUserWithFriend(
+            @Param("user") User user
+    );
 }

--- a/src/main/java/com/example/egobook_be/domain/friend/repository/FriendRequestRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/friend/repository/FriendRequestRepository.java
@@ -25,4 +25,9 @@ public interface FriendRequestRepository extends JpaRepository<FriendRequest, Lo
     List<FriendRequest> findByReceiverAndStatus(User receiver, FriendRequestStatus status);
 
     List<FriendRequest> findBySenderAndStatus(User sender, FriendRequestStatus status);
+
+    long countByReceiverAndStatus(
+            User receiver,
+            FriendRequestStatus status
+    );
 }

--- a/src/main/java/com/example/egobook_be/domain/friend/repository/FriendRequestRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/friend/repository/FriendRequestRepository.java
@@ -4,6 +4,8 @@ import com.example.egobook_be.domain.friend.entity.FriendRequest;
 import com.example.egobook_be.domain.friend.enums.FriendRequestStatus;
 import com.example.egobook_be.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -29,5 +31,17 @@ public interface FriendRequestRepository extends JpaRepository<FriendRequest, Lo
     long countByReceiverAndStatus(
             User receiver,
             FriendRequestStatus status
+    );
+
+    @Query("""
+        select fr
+        from FriendRequest fr
+        join fetch fr.receiver r
+        where fr.sender = :sender
+          and fr.status = :status
+    """)
+    List<FriendRequest> findBySenderAndStatusWithReceiver(
+            @Param("sender") User sender,
+            @Param("status") FriendRequestStatus status
     );
 }

--- a/src/main/java/com/example/egobook_be/domain/friend/service/FriendService.java
+++ b/src/main/java/com/example/egobook_be/domain/friend/service/FriendService.java
@@ -1,9 +1,6 @@
 package com.example.egobook_be.domain.friend.service;
 
-import com.example.egobook_be.domain.friend.dto.FriendRequestCreateReqDto;
-import com.example.egobook_be.domain.friend.dto.FriendRequestListResDto;
-import com.example.egobook_be.domain.friend.dto.FriendResDto;
-import com.example.egobook_be.domain.friend.dto.FriendSearchResDto;
+import com.example.egobook_be.domain.friend.dto.*;
 import com.example.egobook_be.domain.friend.entity.Friend;
 import com.example.egobook_be.domain.friend.entity.FriendRequest;
 import com.example.egobook_be.domain.friend.enums.FriendRequestStatus;
@@ -86,6 +83,14 @@ public class FriendService {
         FriendRequest request = friendRequestRepository
                 .findByIdAndReceiver(requestId, receiver)
                 .orElseThrow(() -> new CustomException(FriendErrorCode.FRIEND_REQUEST_NOT_FOUND));
+
+        User sender = request.getSender();
+
+        // 친구 수 제한 체크 (양쪽 모두)
+        if (friendRepository.countByUser(receiver) >= 10
+                || friendRepository.countByUser(sender) >= 10) {
+            throw new CustomException(FriendErrorCode.FRIEND_LIMIT_EXCEEDED);
+        }
 
         request.accept();
 
@@ -189,12 +194,12 @@ public class FriendService {
 
     /** 친구 리스트 **/
     @Transactional(readOnly = true)
-    public List<FriendResDto> getFriends(Long userId) {
+    public FriendListResDto getFriends(Long userId) {
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(FriendErrorCode.USER_NOT_FOUND));
 
-        return friendRepository.findByUser(user)
+        List<FriendResDto> friends = friendRepository.findByUser(user)
                 .stream()
                 .map(friend -> FriendResDto.builder()
                         .friendId(friend.getFriend().getId())
@@ -202,6 +207,11 @@ public class FriendService {
                         .build()
                 )
                 .toList();
+
+        return FriendListResDto.builder()
+                .count(friends.size())
+                .friends(friends)
+                .build();
     }
 
     /** 친구 검색 **/

--- a/src/main/java/com/example/egobook_be/domain/friend/service/FriendService.java
+++ b/src/main/java/com/example/egobook_be/domain/friend/service/FriendService.java
@@ -198,7 +198,7 @@ public class FriendService {
                 .orElseThrow(() -> new CustomException(FriendErrorCode.USER_NOT_FOUND));
 
         return friendRequestRepository
-                .findBySenderAndStatus(sender, FriendRequestStatus.PENDING)
+                .findBySenderAndStatusWithReceiver(sender, FriendRequestStatus.PENDING)
                 .stream()
                 .map(req -> {
                     User receiver = req.getReceiver();
@@ -221,10 +221,10 @@ public class FriendService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(FriendErrorCode.USER_NOT_FOUND));
 
-        List<FriendResDto> friends = friendRepository.findByUser(user)
+        List<FriendResDto> friends = friendRepository.findByUserWithFriend(user)
                 .stream()
                 .map(friend -> {
-                    var friendUser = friend.getFriend();
+                    User friendUser = friend.getFriend();
 
                     return FriendResDto.builder()
                             .friendId(friendUser.getId())

--- a/src/main/java/com/example/egobook_be/domain/friend/service/FriendService.java
+++ b/src/main/java/com/example/egobook_be/domain/friend/service/FriendService.java
@@ -153,24 +153,6 @@ public class FriendService {
 
 
     /** 내가 받은 친구 신청 목록 (승인 대기) **/
-//    @Transactional(readOnly = true)
-//    public List<FriendRequestListResDto> getIncomingRequests(Long userId) {
-//
-//        User receiver = userRepository.findById(userId)
-//                .orElseThrow(() -> new CustomException(FriendErrorCode.USER_NOT_FOUND));
-//
-//        return friendRequestRepository
-//                .findByReceiverAndStatus(receiver, FriendRequestStatus.PENDING)
-//                .stream()
-//                .map(req -> FriendRequestListResDto.builder()
-//                        .requestId(req.getId())
-//                        .userId(req.getSender().getId())
-//                        .nickname(req.getSender().getNickname())
-//                        .requestedAt(req.getCreatedAt())
-//                        .build()
-//                )
-//                .toList();
-//    }
     @Transactional(readOnly = true)
     public FriendRequestListWithCountResDto getIncomingRequests(Long userId) {
 
@@ -189,13 +171,17 @@ public class FriendService {
         );
 
         List<FriendRequestListResDto> list = requests.stream()
-                .map(req -> FriendRequestListResDto.builder()
-                        .requestId(req.getId())
-                        .userId(req.getSender().getId())
-                        .nickname(req.getSender().getNickname())
-                        .requestedAt(req.getCreatedAt())
-                        .build()
-                )
+                .map(req -> {
+                    User sender = req.getSender();
+
+                    return FriendRequestListResDto.builder()
+                            .requestId(req.getId())
+                            .userId(sender.getId())
+                            .nickname(sender.getNickname())
+                            .level(sender.getLevel())
+                            .requestedAt(req.getCreatedAt())
+                            .build();
+                })
                 .toList();
 
         return FriendRequestListWithCountResDto.builder()
@@ -214,13 +200,17 @@ public class FriendService {
         return friendRequestRepository
                 .findBySenderAndStatus(sender, FriendRequestStatus.PENDING)
                 .stream()
-                .map(req -> FriendRequestListResDto.builder()
-                        .requestId(req.getId())
-                        .userId(req.getReceiver().getId())
-                        .nickname(req.getReceiver().getNickname())
-                        .requestedAt(req.getCreatedAt())
-                        .build()
-                )
+                .map(req -> {
+                    User receiver = req.getReceiver();
+
+                    return FriendRequestListResDto.builder()
+                            .requestId(req.getId())
+                            .userId(receiver.getId())
+                            .nickname(receiver.getNickname())
+                            .level(receiver.getLevel())
+                            .requestedAt(req.getCreatedAt())
+                            .build();
+                })
                 .toList();
     }
 

--- a/src/main/java/com/example/egobook_be/domain/friend/service/FriendService.java
+++ b/src/main/java/com/example/egobook_be/domain/friend/service/FriendService.java
@@ -233,11 +233,15 @@ public class FriendService {
 
         List<FriendResDto> friends = friendRepository.findByUser(user)
                 .stream()
-                .map(friend -> FriendResDto.builder()
-                        .friendId(friend.getFriend().getId())
-                        .nickname(friend.getFriend().getNickname())
-                        .build()
-                )
+                .map(friend -> {
+                    var friendUser = friend.getFriend();
+
+                    return FriendResDto.builder()
+                            .friendId(friendUser.getId())
+                            .nickname(friendUser.getNickname())
+                            .level(friendUser.getLevel())
+                            .build();
+                })
                 .toList();
 
         return FriendListResDto.builder()

--- a/src/main/java/com/example/egobook_be/domain/friend/service/FriendService.java
+++ b/src/main/java/com/example/egobook_be/domain/friend/service/FriendService.java
@@ -153,15 +153,42 @@ public class FriendService {
 
 
     /** 내가 받은 친구 신청 목록 (승인 대기) **/
+//    @Transactional(readOnly = true)
+//    public List<FriendRequestListResDto> getIncomingRequests(Long userId) {
+//
+//        User receiver = userRepository.findById(userId)
+//                .orElseThrow(() -> new CustomException(FriendErrorCode.USER_NOT_FOUND));
+//
+//        return friendRequestRepository
+//                .findByReceiverAndStatus(receiver, FriendRequestStatus.PENDING)
+//                .stream()
+//                .map(req -> FriendRequestListResDto.builder()
+//                        .requestId(req.getId())
+//                        .userId(req.getSender().getId())
+//                        .nickname(req.getSender().getNickname())
+//                        .requestedAt(req.getCreatedAt())
+//                        .build()
+//                )
+//                .toList();
+//    }
     @Transactional(readOnly = true)
-    public List<FriendRequestListResDto> getIncomingRequests(Long userId) {
+    public FriendRequestListWithCountResDto getIncomingRequests(Long userId) {
 
         User receiver = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(FriendErrorCode.USER_NOT_FOUND));
 
-        return friendRequestRepository
-                .findByReceiverAndStatus(receiver, FriendRequestStatus.PENDING)
-                .stream()
+        List<FriendRequest> requests =
+                friendRequestRepository.findByReceiverAndStatus(
+                        receiver,
+                        FriendRequestStatus.PENDING
+                );
+
+        int totalCount = (int) friendRequestRepository.countByReceiverAndStatus(
+                receiver,
+                FriendRequestStatus.PENDING
+        );
+
+        List<FriendRequestListResDto> list = requests.stream()
                 .map(req -> FriendRequestListResDto.builder()
                         .requestId(req.getId())
                         .userId(req.getSender().getId())
@@ -170,6 +197,11 @@ public class FriendService {
                         .build()
                 )
                 .toList();
+
+        return FriendRequestListWithCountResDto.builder()
+                .totalCount(totalCount)
+                .requests(list)
+                .build();
     }
 
     /** 내가 보낸 친구 신청 목록 **/


### PR DESCRIPTION
## #️⃣연관된 이슈
- close #22 

## 📝작업 내용
- 친구 목록, 신청 한 목록, 신청 받은 목록 조회할 떄 각 친구의 레벨이 같이 조회되도록 수정하였습니다.
- 친구 추가는 최대 10명만 가능하도록 수정하였습니다.
- 피그마를 확인했을 때 친구 목록, 나에게 온 신청 목록을 조회에는 총 몇명인지 같이 조회가 되어야 해서 count도 같이 조회되도록 수정하였습니다.

## 📝 기타 참고사항
