### PR TITLE
✨ Feat: 이용 약관 API 개발

### DIFF
--- a/src/main/java/com/example/egobook_be/domain/auth/sevice/AuthService.java
+++ b/src/main/java/com/example/egobook_be/domain/auth/sevice/AuthService.java
@@ -7,6 +7,11 @@ import com.example.egobook_be.domain.shop.entity.UserItem;
 import com.example.egobook_be.domain.shop.enums.ShopErrorCode;
 import com.example.egobook_be.domain.shop.repository.ItemRepository;
 import com.example.egobook_be.domain.shop.repository.UserItemRepository;
+import com.example.egobook_be.domain.terms.entity.Term;
+import com.example.egobook_be.domain.terms.entity.UserTerm;
+import com.example.egobook_be.domain.terms.enums.TermErrorCode;
+import com.example.egobook_be.domain.terms.repository.TermRepository;
+import com.example.egobook_be.domain.terms.repository.UserTermRepository;
 import com.example.egobook_be.domain.user.entity.Ability;
 import com.example.egobook_be.domain.user.enums.RoleType;
 import com.example.egobook_be.domain.user.repository.AbilityRepository;
@@ -33,6 +38,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -53,6 +59,8 @@ public class AuthService {
     private final HashingUtil hashingUtil;
     private final UserNicknameGenerator userNicknameGenerator;
     private final RedisUtil redisUtil;
+    private final TermRepository termRepository;
+    private final UserTermRepository userTermRepository;
 
     @Value("${app.data.purge-duration-in-ms}")
     private Long purgeDurationInMs;
@@ -634,6 +642,7 @@ public class AuthService {
      * 사용자가 회원가입을 한 뒤, 기본적으로 사용자에게 할당해줘야할 것들을 할당해주는 함수.
      *  (1) 기본 UserItem 인스턴스 생성
      *  (2) 기본 Ability 인스턴스 생성
+     *  (3) UserTerm 인스턴스 생성
      * @param user
      */
     private void allocateUser(User user){
@@ -642,6 +651,9 @@ public class AuthService {
 
         // 2. 사용자 Ability 생성
         Ability ability = createDefaultAbility(user);
+
+        // 3. 사용자 약관 동의
+        List<UserTerm> userTerms = createDefaultUserTerms(user);
     }
 
 
@@ -682,5 +694,26 @@ public class AuthService {
                 .emotionRegulation(0)
                 .build();
         return abilityRepository.save(ability);
+    }
+
+    /**
+     * user 생성 시 할당해줄
+     */
+    private List<UserTerm> createDefaultUserTerms(User user){
+        // 1. 모든 약관들을 가져온다.
+        List<Term> terms = termRepository.findAll();
+        if(terms.isEmpty()){throw new CustomException(TermErrorCode.TERMS_NOT_FOUND);}
+
+        // 2. 새로 만든 User와 가져온 Term들을 연결한다.
+        List<UserTerm> userTerms = new ArrayList<>();
+        for(Term term : terms){
+            userTerms.add(
+                    UserTerm.builder()
+                            .term(term)
+                            .user(user)
+                            .build()
+            );
+        }
+        return userTermRepository.saveAll(userTerms);
     }
 }

--- a/src/main/java/com/example/egobook_be/domain/diary/entity/Diary.java
+++ b/src/main/java/com/example/egobook_be/domain/diary/entity/Diary.java
@@ -37,6 +37,7 @@ public class Diary extends BaseTimeEntity {
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "diary_type", joinColumns = @JoinColumn(name = "diary_id"))
     @Enumerated(EnumType.STRING)
+    @Builder.Default
     @Column(nullable = false)
     private Set<DiaryType> type = EnumSet.noneOf(DiaryType.class);
 

--- a/src/main/java/com/example/egobook_be/domain/shop/loader/ItemInitializer.java
+++ b/src/main/java/com/example/egobook_be/domain/shop/loader/ItemInitializer.java
@@ -8,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +20,7 @@ import java.util.stream.Collectors;
 @Slf4j
 @Component
 @RequiredArgsConstructor
+@Order(value = 2) // 실행 순서
 public class ItemInitializer implements ApplicationRunner {
     private final ItemRepository itemRepository;
     @Value("${spring.cloud.aws.cloudfront.domain}")

--- a/src/main/java/com/example/egobook_be/domain/terms/controller/TermController.java
+++ b/src/main/java/com/example/egobook_be/domain/terms/controller/TermController.java
@@ -1,0 +1,29 @@
+package com.example.egobook_be.domain.terms.controller;
+
+import com.example.egobook_be.domain.terms.dto.TermResDto;
+import com.example.egobook_be.domain.terms.service.TermService;
+import com.example.egobook_be.global.response.GlobalResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class TermController implements TermControllerDocs{
+    private final TermService termService;
+
+    /**
+     * [약관들 일괄 조회]
+     * GET /terms
+     */
+    @Override
+    public ResponseEntity<GlobalResponse<List<TermResDto>>> getTerms(){
+        List<TermResDto> terms = termService.getTerms();
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(GlobalResponse.success(terms));
+    }
+}

--- a/src/main/java/com/example/egobook_be/domain/terms/controller/TermControllerDocs.java
+++ b/src/main/java/com/example/egobook_be/domain/terms/controller/TermControllerDocs.java
@@ -1,0 +1,38 @@
+package com.example.egobook_be.domain.terms.controller;
+
+import com.example.egobook_be.domain.terms.dto.TermResDto;
+import com.example.egobook_be.global.response.GlobalResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
+
+@Tag(name = "Terms Controller", description = "약관(이용약관, 개인정보 처리방침 등) 관련 API")
+@RequestMapping("/terms")
+public interface TermControllerDocs {
+    @Operation(
+            summary = "전체 이용 약관 목록 조회",
+            description = "회원가입 시 사용자에게 보여줄 **최신 버전의 모든 약관 목록**을 조회합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "요청 성공",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = TermResDto.class))
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 내부 오류",
+                    content = @Content(schema = @Schema(hidden = true))
+            )
+    })
+    @GetMapping("")
+    ResponseEntity<GlobalResponse<List<TermResDto>>> getTerms();
+}

--- a/src/main/java/com/example/egobook_be/domain/terms/dto/TermResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/terms/dto/TermResDto.java
@@ -1,0 +1,30 @@
+package com.example.egobook_be.domain.terms.dto;
+
+import com.example.egobook_be.domain.terms.enums.TermType;
+import com.example.egobook_be.domain.terms.enums.TermVersion;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "약관 상세 정보 응답 DTO")
+public class TermResDto {
+    @Schema(description = "약관 고유 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "약관 타입 (서비스 이용약관, 개인정보 처리방침 등)", example = "SERVICE_USE")
+    private TermType termType;
+
+    @Schema(description = "약관 버전", example = "V1")
+    private TermVersion termVersion;
+
+    @Schema(description = "약관 제목(설명)", example = "서비스 이용 약관")
+    private String description;
+
+    @Schema(description = "약관 본문 (HTML 또는 Markdown)", example = "제1조 (목적)...")
+    private String context;
+
+    @Schema(description = "필수 동의 여부", example = "true")
+    private boolean required;
+}

--- a/src/main/java/com/example/egobook_be/domain/terms/entity/Term.java
+++ b/src/main/java/com/example/egobook_be/domain/terms/entity/Term.java
@@ -1,0 +1,68 @@
+package com.example.egobook_be.domain.terms.entity;
+
+import com.example.egobook_be.domain.terms.enums.TermTemplate;
+import com.example.egobook_be.domain.terms.enums.TermType;
+import com.example.egobook_be.domain.terms.enums.TermVersion;
+import com.example.egobook_be.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "term")
+public class Term extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "term_type", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private TermType termType;
+
+    @Column(name = "description", nullable = false)
+    private String description; // 해당 약관 한국어 텍스트
+
+    @Column(name = "term_version", nullable = false)
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    private TermVersion termVersion = TermVersion.V1;
+
+    // 대용량 텍스트 저장을 위해 Lob 사용
+    @Lob
+    @Column(name = "context", nullable = false, columnDefinition = "LONGTEXT")
+    private String context;
+
+    @Column(name = "required", nullable = false)
+    private boolean required;
+
+
+    public Term(TermTemplate termTemplate, TermVersion termVersion) {
+        this.termType = termTemplate.getTermType();
+        this.description = termTemplate.getDescription();
+        this.termVersion = termVersion;
+        this.context = termTemplate.getContext();
+        this.required = termTemplate.isRequired();
+    }
+
+    /**
+     * 해당 약관의 내용을 전부 수정하는 함수
+     */
+    public void updateTerm(TermTemplate termTemplate, TermVersion termVersion) {
+        this.termType = termTemplate.getTermType();
+        this.description = termTemplate.getDescription();
+        this.termVersion = termVersion;
+        this.context = termTemplate.getContext();
+        this.required = termTemplate.isRequired();
+    }
+
+    /**
+     * 약관의 내용 & 버전을 변경하는 함수
+     */
+    public void updateContext(String context, TermVersion termVersion) {
+        this.context = context;
+        this.termVersion = termVersion;
+    }
+}

--- a/src/main/java/com/example/egobook_be/domain/terms/entity/UserTerm.java
+++ b/src/main/java/com/example/egobook_be/domain/terms/entity/UserTerm.java
@@ -1,0 +1,30 @@
+package com.example.egobook_be.domain.terms.entity;
+
+import com.example.egobook_be.domain.user.entity.User;
+import com.example.egobook_be.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_term",
+    uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "term_id"})
+    }
+)
+public class UserTerm extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "term_id", nullable = false)
+    private Term term;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+}

--- a/src/main/java/com/example/egobook_be/domain/terms/enums/TermErrorCode.java
+++ b/src/main/java/com/example/egobook_be/domain/terms/enums/TermErrorCode.java
@@ -1,0 +1,18 @@
+package com.example.egobook_be.domain.terms.enums;
+
+import com.example.egobook_be.global.exception.model.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum TermErrorCode implements BaseErrorCode {
+    /**
+     * 404 NOT_FOUND
+     */
+    TERMS_NOT_FOUND(HttpStatus.NOT_FOUND, "약관들을 찾지 못했습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/example/egobook_be/domain/terms/enums/TermTemplate.java
+++ b/src/main/java/com/example/egobook_be/domain/terms/enums/TermTemplate.java
@@ -1,0 +1,39 @@
+package com.example.egobook_be.domain.terms.enums;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TermTemplate {
+    TERM_OF_SERVICE(
+            TermType.TERM_OF_SERVICE,
+            "서비스 이용 약관",
+            """
+                    서비스 이용 약관 임시 내용
+                    """,
+            true
+    ),
+    TERM_OF_PRIVACY_POLICY(
+            TermType.TERM_OF_PRIVACY_POLICY,
+            "개인정보 처리 방침",
+            """
+                    개인정보 처리 방침 임시 내용
+                    """,
+            true
+    ),
+    TERM_OF_PERSONAL_INFO_CONSENT(
+            TermType.TERM_OF_PERSONAL_INFO_CONSENT,
+            "개인정보 이용 동의 약관",
+            """
+                    개인정보 이용 동의 약관 임시 내용
+                    """,
+            false
+    );
+
+    private final TermType termType;
+    private final String description;
+    private final String context;
+    private final boolean required;
+}

--- a/src/main/java/com/example/egobook_be/domain/terms/enums/TermType.java
+++ b/src/main/java/com/example/egobook_be/domain/terms/enums/TermType.java
@@ -1,0 +1,10 @@
+package com.example.egobook_be.domain.terms.enums;
+
+/**
+ * 약관 타입
+ */
+public enum TermType {
+    TERM_OF_SERVICE, // 서비스 이용 약관
+    TERM_OF_PRIVACY_POLICY,   // 개인정보 처리 방침
+    TERM_OF_PERSONAL_INFO_CONSENT // 개인정보 이용 동의 약관
+}

--- a/src/main/java/com/example/egobook_be/domain/terms/enums/TermVersion.java
+++ b/src/main/java/com/example/egobook_be/domain/terms/enums/TermVersion.java
@@ -1,0 +1,8 @@
+package com.example.egobook_be.domain.terms.enums;
+
+/**
+ * 약관 버전
+ */
+public enum TermVersion {
+    V1, V2
+}

--- a/src/main/java/com/example/egobook_be/domain/terms/loader/TermInitializer.java
+++ b/src/main/java/com/example/egobook_be/domain/terms/loader/TermInitializer.java
@@ -1,0 +1,49 @@
+package com.example.egobook_be.domain.terms.loader;
+
+import com.example.egobook_be.domain.terms.entity.Term;
+import com.example.egobook_be.domain.terms.enums.TermTemplate;
+import com.example.egobook_be.domain.terms.enums.TermVersion;
+import com.example.egobook_be.domain.terms.repository.TermRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.Arrays;
+
+/**
+ * 서버 시작 시, DB를 확인하여 약관 내용이 있으면 추가, 없으면 수정하는 클래스
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Order(value = 1) // 실행 순서
+public class TermInitializer implements ApplicationRunner {
+    private final TermRepository termRepository;
+    private final TermVersion termVersion = TermVersion.V1;
+
+    @Override
+    @Transactional
+    public void run(ApplicationArguments args){
+        log.info("🚀 사용자 약관 목록을 DB에 최신화합니다.");
+        Arrays.stream(TermTemplate.values()).forEach(termTemplate -> {
+            // 1. TermTemplate Enum 클래스에서, 각각의 항목들의 데이터가 Term table에 존재하는지 확인한다.
+            Term existTerm = termRepository.findByTermType(termTemplate.getTermType()).orElse(null);
+
+            // 2. 만약 해당 약관이 아직 Term Table에 존재하지 않다면, 해당 테이블에 추가한다.
+            if(existTerm == null){
+                Term newTerm = new Term(termTemplate, termVersion);
+                termRepository.save(newTerm);
+                log.info("✅ 약관 등록 완료: {}({})", termTemplate.getDescription(), termVersion);
+            }
+            // 3. 만약 해당 약관이 term Table에 존재한다면, 기존 term 내용을 새로운 값으로 수정한다.
+            else{
+                existTerm.updateTerm(termTemplate, termVersion);
+                log.info("✅ 약관 수정 완료: {}({})", termTemplate.getDescription(), termVersion);
+            }
+        });
+        log.info("🚀 약관 데이터 동기화 완료.");
+    }
+}

--- a/src/main/java/com/example/egobook_be/domain/terms/repository/TermRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/terms/repository/TermRepository.java
@@ -1,0 +1,15 @@
+package com.example.egobook_be.domain.terms.repository;
+
+import com.example.egobook_be.domain.terms.entity.Term;
+import com.example.egobook_be.domain.terms.enums.TermType;
+import com.example.egobook_be.domain.terms.enums.TermVersion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TermRepository extends JpaRepository<Term, Integer> {
+    /**
+     * TermType으로 해당 약관이 존재하는지 찾는 함수
+     */
+    Optional<Term> findByTermType(TermType termType);
+}

--- a/src/main/java/com/example/egobook_be/domain/terms/repository/TermRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/terms/repository/TermRepository.java
@@ -5,9 +5,10 @@ import com.example.egobook_be.domain.terms.enums.TermType;
 import com.example.egobook_be.domain.terms.enums.TermVersion;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
-public interface TermRepository extends JpaRepository<Term, Integer> {
+public interface TermRepository extends JpaRepository<Term, Long> {
     /**
      * TermType으로 해당 약관이 존재하는지 찾는 함수
      */

--- a/src/main/java/com/example/egobook_be/domain/terms/repository/UserTermRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/terms/repository/UserTermRepository.java
@@ -1,0 +1,7 @@
+package com.example.egobook_be.domain.terms.repository;
+
+import com.example.egobook_be.domain.terms.entity.UserTerm;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserTermRepository extends JpaRepository<UserTerm, Long> {
+}

--- a/src/main/java/com/example/egobook_be/domain/terms/service/TermService.java
+++ b/src/main/java/com/example/egobook_be/domain/terms/service/TermService.java
@@ -15,7 +15,7 @@ import java.util.List;
 public class TermService {
     private final TermRepository termRepository;
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<TermResDto> getTerms(){
         List<Term> terms = termRepository.findAll();
         List<TermResDto> termResDtoList = new ArrayList<>();

--- a/src/main/java/com/example/egobook_be/domain/terms/service/TermService.java
+++ b/src/main/java/com/example/egobook_be/domain/terms/service/TermService.java
@@ -1,0 +1,36 @@
+package com.example.egobook_be.domain.terms.service;
+
+import com.example.egobook_be.domain.terms.dto.TermResDto;
+import com.example.egobook_be.domain.terms.entity.Term;
+import com.example.egobook_be.domain.terms.repository.TermRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TermService {
+    private final TermRepository termRepository;
+
+    @Transactional
+    public List<TermResDto> getTerms(){
+        List<Term> terms = termRepository.findAll();
+        List<TermResDto> termResDtoList = new ArrayList<>();
+        terms.forEach(term ->
+                termResDtoList.add(
+                    TermResDto.builder()
+                        .id(term.getId())
+                        .termType(term.getTermType())
+                        .termVersion(term.getTermVersion())
+                        .description(term.getDescription())
+                        .context(term.getContext())
+                        .required(term.isRequired())
+                        .build()
+                )
+        );
+        return termResDtoList;
+    }
+}

--- a/src/main/java/com/example/egobook_be/domain/user/entity/User.java
+++ b/src/main/java/com/example/egobook_be/domain/user/entity/User.java
@@ -1,6 +1,7 @@
 package com.example.egobook_be.domain.user.entity;
 
 import com.example.egobook_be.domain.shop.entity.UserItem;
+import com.example.egobook_be.domain.terms.entity.Term;
 import com.example.egobook_be.domain.user.enums.RoleType;
 import com.example.egobook_be.domain.user.enums.UserStatus;
 import com.example.egobook_be.domain.user.enums.WeeklyReportStyle;

--- a/src/main/java/com/example/egobook_be/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/egobook_be/global/config/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
      */
     private static final String[] AUTH_WHITELIST = {
             "/auth/**", // /auth로 오는 요청은 전부 허용
+            "/terms", // 약관 조회 요청은 허용
             "/v3/api-docs/**",  // Swagger JSON 데이터
             "/swagger-ui/**",   // Swagger UI CSS, JS, 이미지
             "/swagger-ui-custom.html",  // Swagger UI 메인 페이지


### PR DESCRIPTION
## #️⃣연관된 이슈
- #45 

## 📝작업 내용
- 서버 시작 시 Term 테이블 확인 후, 약관 내용이 없으면 ```Insert```, 약관 내용이 있으면 ```Update```하는 ApplicationRunner 생성
<img width="1246" height="34" alt="image" src="https://github.com/user-attachments/assets/f5a809c8-de86-4056-97c4-7f51eb0dc98a" />
<img width="1259" height="27" alt="image" src="https://github.com/user-attachments/assets/fa2721e3-9d8a-43f7-aa13-134124e1187c" />
<img width="1289" height="49" alt="image" src="https://github.com/user-attachments/assets/773eb6d7-0ab5-4ff5-95a1-30cac410b613" />

- Term 테이블에 있는 약관들을 일괄 조회하는 API 개발
  - ```GET /terms```

- 사용자 회원가입 시 약관에 자동으로 동의하도록 설정

## 💬리뷰 요구사항
- SecurityConfig에 ```/terms``` 경로를 permitAll()로 열어놨는데, 이게 나중에 api 기능을 확장할 때(ex: 사용자가 동의한 약관 조회) 적절한 구조인지에 대한 피드백이 필요할 것 같습니다