### PR TITLE
✨ Feat: Diary 저장일시 처리 방식 수정

### DIFF
--- a/src/main/java/com/example/egobook_be/domain/diary/controller/DiaryController.java
+++ b/src/main/java/com/example/egobook_be/domain/diary/controller/DiaryController.java
@@ -46,7 +46,7 @@ public class DiaryController implements DiaryControllerDocs{
             @RequestParam
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
             @RequestParam(required = false) DiaryType type,
-            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
         return ResponseEntity.ok(

--- a/src/main/java/com/example/egobook_be/domain/diary/controller/DiaryControllerDocs.java
+++ b/src/main/java/com/example/egobook_be/domain/diary/controller/DiaryControllerDocs.java
@@ -24,7 +24,7 @@ public interface DiaryControllerDocs {
             
             - '감정' 선택 시, 감정 단계를 선택해야 합니다.
             - 텍스트 최대 400자 작성 가능합니다.
-            - 일기 저장 날짜 변경 가능합니다.
+            - 일기 저장 날짜, 시간 변경 가능합니다.
             - 하루 최대 48번 일기 저장 가능합니다. (기준: 저장 날짜)
             - 리워드 규칙 (기준: 실제 작성 날짜)
               1. 오늘 최초 일기 작성 시, 잉크 +1
@@ -68,6 +68,7 @@ public interface DiaryControllerDocs {
             - 날짜를 제외한 일기 타입, 텍스트 내용을 수정 가능합니다.
             - '감정' 선택 시, 감정 단계를 선택해야 합니다.
             - 텍스트 최대 400자 작성 가능합니다.
+            - 일기 내부 시간은 수정일시로 자동 업데이트됩니다.
             """)
     @PatchMapping("/{diaryId}")
     ResponseEntity<GlobalResponse<DiaryResDto>> updateDiary(

--- a/src/main/java/com/example/egobook_be/domain/diary/dto/DiaryCreateReqDto.java
+++ b/src/main/java/com/example/egobook_be/domain/diary/dto/DiaryCreateReqDto.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.Builder;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Set;
 
 @Builder
@@ -19,5 +19,5 @@ public record DiaryCreateReqDto(
         Integer emotionLevel,
         @NotBlank
         String content,
-        LocalDate date
+        LocalDateTime dateTime
 ) {}

--- a/src/main/java/com/example/egobook_be/domain/diary/entity/Diary.java
+++ b/src/main/java/com/example/egobook_be/domain/diary/entity/Diary.java
@@ -11,6 +11,7 @@ import jakarta.validation.constraints.NotEmpty;
 import lombok.*;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.EnumSet;
 import java.util.Set;
@@ -27,6 +28,8 @@ public class Diary extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    private LocalDate date;
 
     private Integer emotionLevel;
 
@@ -52,5 +55,6 @@ public class Diary extends BaseTimeEntity {
         this.content = content;
         this.type = type;
         this.emotionLevel = emotionLevel;
+        this.writtenAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/example/egobook_be/domain/diary/mapper/DiaryMapper.java
+++ b/src/main/java/com/example/egobook_be/domain/diary/mapper/DiaryMapper.java
@@ -5,7 +5,6 @@ import com.example.egobook_be.domain.diary.entity.Diary;
 import com.example.egobook_be.domain.diary.enums.ExportFormat;
 import com.example.egobook_be.domain.diary.repository.DiaryRepository;
 import com.example.egobook_be.global.response.SliceResponse;
-import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -19,7 +18,7 @@ public class DiaryMapper {
     public static DiaryResDto toDiaryDto(Diary diary) {
         return DiaryResDto.builder()
                 .diaryId(diary.getId())
-                .date(diary.getWrittenAt().toLocalDate())
+                .date(diary.getDate())
                 .writtenAt(diary.getWrittenAt())
                 .type(diary.getType())
                 .emotionLevel(diary.getEmotionLevel())

--- a/src/main/java/com/example/egobook_be/domain/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/diary/repository/DiaryRepository.java
@@ -16,8 +16,6 @@ import java.util.Set;
 
 @Repository
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
-    int countByUserAndWrittenAtBetween(User user, LocalDateTime writtenAtAfter, LocalDateTime writtenAtBefore);
-
     boolean existsByUserAndCreatedAtBetween(User user, LocalDateTime startOfToday, LocalDateTime endOfToday);
 
     boolean existsByUserAndTypeContainingAndCreatedAtBetween(User user, DiaryType diaryType, LocalDateTime startOfToday, LocalDateTime endOfToday);
@@ -27,35 +25,35 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
     List<Diary> findAllByUserAndWrittenAtBetween(User user, LocalDateTime start, LocalDateTime end);
 
     @Query("""
-    SELECT d
-    FROM Diary d 
-    WHERE d.user = :user 
-      AND d.writtenAt BETWEEN :start AND :end\n
-      AND (:type IS NULL OR :type MEMBER OF d.type) ORDER BY d.writtenAt DESC
-    """)
-    Slice<Diary> findAllByUserAndTypeAndWrittenAtBetween(
-            User user, DiaryType type, LocalDateTime start, LocalDateTime end, Pageable pageable
-    );
-
-    @Query("""
     SELECT
-        DATE(d.writtenAt) AS date,
+        d.date AS date,
         d.emotionLevel AS emotionLevel,
         COUNT(d) AS count,
         MAX(d.writtenAt) AS latest
     FROM Diary d
     WHERE d.user = :user
       AND d.emotionLevel IS NOT NULL
-      AND d.writtenAt BETWEEN :start AND :end
-    GROUP BY DATE(d.writtenAt), d.emotionLevel
-    ORDER BY DATE(d.writtenAt), count DESC, latest DESC
+      AND d.date BETWEEN :start AND :end
+    GROUP BY d.date, d.emotionLevel
+    ORDER BY d.date, count DESC, latest DESC
     """)
-    List<DailyEmotionCount> findDailyEmotions(User user, LocalDateTime start, LocalDateTime end);
+    List<DailyEmotionCount> findDailyEmotions(User user, LocalDate start, LocalDate end);
+
+    @Query("""
+    SELECT d 
+    FROM Diary d 
+    JOIN d.type t 
+    WHERE d.user = :user 
+      AND d.date = :date 
+      AND (:type IS NULL OR :type MEMBER OF d.type)
+    ORDER BY d.writtenAt DESC
+""")
+    Slice<Diary> findAllByUserAndTypeAndDate(User user, DiaryType type, LocalDate date, Pageable pageable);
+
+    int countByUserAndDate(User user, LocalDate date);
 
     interface DailyEmotionCount {
         LocalDate getDate();
         Integer getEmotionLevel();
-        Long getCount();
-        LocalDateTime getLatest();
     }
 }

--- a/src/main/java/com/example/egobook_be/domain/diary/service/DiaryExportService.java
+++ b/src/main/java/com/example/egobook_be/domain/diary/service/DiaryExportService.java
@@ -89,9 +89,9 @@ public class DiaryExportService {
 
             // 날짜 그룹화
             Map<LocalDate, List<Diary>> diariesByDate = diaries.stream()
-                    .sorted(Comparator.comparing(Diary::getWrittenAt))
+                    .sorted(Comparator.comparing(Diary::getDate))
                     .collect(Collectors.groupingBy(
-                            diary -> diary.getWrittenAt().toLocalDate(),
+                            Diary::getDate,
                             LinkedHashMap::new,
                             Collectors.toList()
                     ));
@@ -222,7 +222,8 @@ public class DiaryExportService {
 
         Map<LocalDate, List<Diary>> diariesByDate = diaries.stream()
                 .collect(Collectors.groupingBy(
-                        diary -> diary.getWrittenAt().toLocalDate(),
+                        Diary::getDate,
+                        TreeMap::new,
                         Collectors.toList()
                 ));
 

--- a/src/main/java/com/example/egobook_be/domain/diary/service/DiaryService.java
+++ b/src/main/java/com/example/egobook_be/domain/diary/service/DiaryService.java
@@ -8,14 +8,17 @@ import com.example.egobook_be.domain.diary.enums.RewardType;
 import com.example.egobook_be.domain.diary.exception.DiaryErrorCode;
 import com.example.egobook_be.domain.diary.mapper.DiaryMapper;
 import com.example.egobook_be.domain.diary.repository.DiaryRepository;
+import com.example.egobook_be.domain.notification.entity.Notification;
+import com.example.egobook_be.domain.notification.mapper.NotificationMapper;
 import com.example.egobook_be.domain.user.entity.Ability;
 import com.example.egobook_be.domain.user.entity.User;
-import com.example.egobook_be.domain.user.repository.UserRepository;
 import com.example.egobook_be.global.exception.CustomException;
+import com.example.egobook_be.global.exception.GlobalErrorCode;
 import com.example.egobook_be.global.response.SliceResponse;
 import com.example.egobook_be.infra.s3.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
@@ -28,7 +31,6 @@ import java.util.*;
 @RequiredArgsConstructor
 public class DiaryService {
 
-    private final UserRepository userRepository;
     private final DiaryRepository diaryRepository;
     private final DiaryExportService diaryExportService;
     private final DiaryQueryService diaryQueryService;
@@ -64,14 +66,13 @@ public class DiaryService {
         }
 
         // 일기 저장 날짜 설정
-        LocalDateTime writtenAt = (dto.date() != null) ?
-                LocalDateTime.of(dto.date(), LocalTime.now()) : LocalDateTime.now();
+        LocalDateTime writtenAt = (dto.dateTime() != null) ?
+                dto.dateTime() : LocalDateTime.now();
 
-        LocalDateTime startOfDay = writtenAt.toLocalDate().atStartOfDay();
-        LocalDateTime endOfDay = writtenAt.toLocalDate().atTime(LocalTime.MAX);
+        LocalDate diaryDate = writtenAt.toLocalDate();
 
         // 일기 작성 가능 여부
-        if (diaryRepository.countByUserAndWrittenAtBetween(user, startOfDay, endOfDay) >= 48) {
+        if (diaryRepository.countByUserAndDate(user, diaryDate) >= 48) {
             throw new CustomException(DiaryErrorCode.DIARY_DAILY_LIMIT_EXCEEDED);
         }
 
@@ -100,6 +101,7 @@ public class DiaryService {
 
         Diary diary = diaryRepository.save(Diary.builder()
                 .user(user)
+                .date(diaryDate)
                 .type(dto.type())
                 .content(dto.content())
                 .emotionLevel(dto.emotionLevel())
@@ -194,27 +196,31 @@ public class DiaryService {
 
         User user = diaryQueryService.getUserById(userId);
 
-        LocalDateTime startOfDay = date.atStartOfDay();
-        LocalDateTime endOfDay = date.atTime(LocalTime.MAX);
+        if (page < 1) {
+            throw new CustomException(GlobalErrorCode.INVALID_SLICE_VALUE);
+        }
 
-        PageRequest pageable = PageRequest.of(
-                page,
+        if (size < 1 || size > 100) {
+            throw new CustomException(GlobalErrorCode.INVALID_SIZE_VALUE);
+        }
+
+        Pageable pageable = PageRequest.of(
+                page - 1,
                 size,
                 Sort.by(Sort.Direction.DESC, "writtenAt")
         );
 
-        Slice<Diary> slice = diaryRepository.findAllByUserAndTypeAndWrittenAtBetween(
+        Slice<Diary> slice = diaryRepository.findAllByUserAndTypeAndDate(
                 user,
                 type,
-                startOfDay,
-                endOfDay,
+                date,
                 pageable
         );
 
         SliceResponse<DiaryResDto> diaries = SliceResponse.of(slice, DiaryMapper::toDiaryDto);
 
-        // 오늘 작성한 일기 개수 계산
-        int dailyCount = diaryRepository.countByUserAndWrittenAtBetween(user, startOfDay, endOfDay);
+        // 선택 날짜 일기 개수
+        int dailyCount = diaryRepository.countByUserAndDate(user, date);
 
         return DiaryMapper.toDiaryListDto(diaries, dailyCount);
     }
@@ -225,8 +231,8 @@ public class DiaryService {
 
         User user = diaryQueryService.getUserById(userId);
 
-        LocalDateTime startOfMonth = month.atDay(1).atStartOfDay();
-        LocalDateTime endOfMonth = month.atEndOfMonth().atTime(LocalTime.MAX);
+        LocalDate startOfMonth = month.atDay(1);
+        LocalDate endOfMonth = month.atEndOfMonth();
 
         List<DiaryRepository.DailyEmotionCount> dailyEmotions =
                 diaryRepository.findDailyEmotions(user, startOfMonth, endOfMonth);
@@ -234,7 +240,7 @@ public class DiaryService {
         return DiaryMapper.toDiaryCalendarDto(month, dailyEmotions);
     }
 
-    /** 감정 일기 내보네기 */
+    /** 감정 일기 내보내기 */
     public DiaryExportResDto exportDiaries(Long userId, DiaryExportReqDto dto) {
 
         User user = diaryQueryService.getUserById(userId);


### PR DESCRIPTION
## #️⃣연관된 이슈
- #44 

## 📝작업 내용
일기 작성
- 사용자가 선택한 날짜를 기준으로 해당 날짜의 일기로 저장
- 내부 저장 일시: 사용자가 선택한 날짜 + 시간으로 설정

일기 수정 
- 최초 작성 시 선택한 날짜 수정 불가
- 수정 시 내부 저장 일시는 수정된 시점의 날짜 + 시간으로 자동 업데이트

전체 수정
- 기존 writtenAt에서 LocalDate 추출하던 방식 -> 새로 추가한 엔티티 date 필드를 활용하도록 변경
- 일기 목록 조회 시 페이지 기본값을 1부터 시작하도록 수정

## 💬리뷰 요구사항
- 새로 추가한 `date` 필드를 활용하여 전체적으로 잘 반영되었는지 검토 부탁드립니다!