### PR TITLE
✨ Feat: User API 개발

### DIFF
--- a/src/main/java/com/example/egobook_be/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/egobook_be/domain/auth/controller/AuthController.java
@@ -47,7 +47,7 @@ public class AuthController implements AuthControllerDocs{
      */
     @Override
     public ResponseEntity<GlobalResponse<JwtTokenResDto>> refreshAccessToken(@RequestBody @Valid RefreshReqDto reqDto) {
-        JwtTokenResDto jwtTokenResDto = authService.refreshGuestToken(reqDto);
+        JwtTokenResDto jwtTokenResDto = authService.refreshToken(reqDto);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(GlobalResponse.success("Access Token이 정상적으로 재발급되었습니다.", jwtTokenResDto));

--- a/src/main/java/com/example/egobook_be/domain/auth/controller/AuthControllerDocs.java
+++ b/src/main/java/com/example/egobook_be/domain/auth/controller/AuthControllerDocs.java
@@ -40,6 +40,10 @@ public interface AuthControllerDocs {
 
     @Operation(summary = "Access Token 재발급", description = """
             Access Token이 만료되었을 때, Refresh Token을 이용하여 토큰을 갱신합니다.
+            [ 입력값 ]
+            1. AccessToken: 만료되었거나 만료되지 않은, 기존에 사용하던 Access Token (Bearer 제외)
+            - 기존에 사용하던 AccessToken을 Redis의 블랙리스트에 등록하기 위함입니다.
+            2. RefreshToken: 만료되지 않은 Refresh Token (Bearer 제외)
             
             - **기능**: 유효한 Refresh Token을 검증하고, **새로운 Access Token**을 발급합니다.
             - **실패 시**: 401 Unauthorized 리턴 -> 클라이언트는 [Guest 복구(Recertification)] API를 호출해야 합니다.

--- a/src/main/java/com/example/egobook_be/domain/auth/dto/req/GoogleRecertificationReqDto.java
+++ b/src/main/java/com/example/egobook_be/domain/auth/dto/req/GoogleRecertificationReqDto.java
@@ -8,6 +8,10 @@ public record GoogleRecertificationReqDto(
         @Schema(description = "안드로이드가 구글로부터 받아온 ID Token", example = "ID Token")
         @NotBlank(message = "Google Refresh Token을 재발급 받기 위해서는 ID Token값이 필수입니다.")
         @JsonProperty("idToken")
-        String idToken // 안드로이드가 구글에서 받아온 ID Token
+        String idToken, // 안드로이드가 구글에서 받아온 ID Token
+
+        @Schema(description = "만료되었거나 만료되지 않은, 기존에 사용하던 Access Token (Bearer 제외)", example = "eyJhbGciOiJIUzI1NiJ9...")
+        @NotBlank(message = "Access Token은 필수입니다.")
+        String accessToken
 ) {
 }

--- a/src/main/java/com/example/egobook_be/domain/auth/dto/req/GuestRecertificationReqDto.java
+++ b/src/main/java/com/example/egobook_be/domain/auth/dto/req/GuestRecertificationReqDto.java
@@ -14,6 +14,10 @@ public record GuestRecertificationReqDto(
         @JsonProperty("deviceUid")
         String deviceUid,
 
+        @Schema(description = "만료되었거나 만료되지 않은, 기존에 사용하던 Access Token (Bearer 제외)", example = "eyJhbGciOiJIUzI1NiJ9...")
+        @NotBlank(message = "Access Token은 필수입니다.")
+        String accessToken,
+
         @Schema(description = "Refresh Token을 재발급하기 위한 Recover Token", example = "eaifiiehig-afe...")
         @NotBlank(message = "Recover Token은 필수입니다.")
         @JsonProperty("recoverToken")

--- a/src/main/java/com/example/egobook_be/domain/auth/dto/req/RefreshReqDto.java
+++ b/src/main/java/com/example/egobook_be/domain/auth/dto/req/RefreshReqDto.java
@@ -12,6 +12,10 @@ import lombok.extern.jackson.Jacksonized;
 @Builder
 @Jacksonized
 public record RefreshReqDto(
+        @Schema(description = "만료되었거나 만료되지 않은, 기존에 사용하던 Access Token (Bearer 제외)", example = "eyJhbGciOiJIUzI1NiJ9...")
+        @NotBlank(message = "Access Token은 필수입니다.")
+        String accessToken,
+
         @Schema(description = "만료되지 않은 Refresh Token (Bearer 제외)", example = "eyJhbGciOiJIUzI1NiJ9...")
         @NotBlank(message = "Refresh Token은 필수입니다.")
         String refreshToken

--- a/src/main/java/com/example/egobook_be/domain/auth/enums/AuthErrorCode.java
+++ b/src/main/java/com/example/egobook_be/domain/auth/enums/AuthErrorCode.java
@@ -21,6 +21,12 @@ public enum AuthErrorCode implements BaseErrorCode {
     INVALID_GOOGLE_TOKEN(HttpStatus.BAD_REQUEST, "Google Token이 null이거나 유효하지 않습니다."),
 
     /**
+     * 403 FORBIDDEN
+     */
+    RECERTIFICATION_FAIL_USER_WITHDRAW_PENDING(HttpStatus.FORBIDDEN, "사용자가 탈퇴 대기중이기 때문에, 해당 토큰으로 재인증할 수 없습니다."),
+    RECERTIFICATION_FAIL_USER_WITHDRAWN(HttpStatus.FORBIDDEN, "사용자가 탈퇴했기 때문에, 해당 토큰으로 재인증할 수 없습니다."),
+
+    /**
      * 401 UNAUTHORIZED: 인증되지 않음
      */
     ACCESS_WITH_NON_ACCESS_TYPE_TOKEN(HttpStatus.UNAUTHORIZED, "Access Token이 아닌 토큰으로 접근을 시도하였습니다."),

--- a/src/main/java/com/example/egobook_be/domain/auth/enums/AuthErrorCode.java
+++ b/src/main/java/com/example/egobook_be/domain/auth/enums/AuthErrorCode.java
@@ -32,6 +32,7 @@ public enum AuthErrorCode implements BaseErrorCode {
      * 404 NOT_FOUND: 리소스 없음
      */
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),
+    USER_AUTH_ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자의 인증 정보를 찾을 수 없습니다."),
     AUTH_ACCOUNT_NOT_FOUND_IN_REFRESH_TOKEN_BACKUP(HttpStatus.NOT_FOUND , "Refresh Token Backup Table에서 해당 Auth Account 인스턴스를 찾을 수 없습니다."),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 Refresh Token에 대한 정보를 서버에서 찾을 수 없습니다. Recover Token을 사용하여 Refresh Token을 재발급받으세요."),
 

--- a/src/main/java/com/example/egobook_be/domain/auth/enums/AuthErrorCode.java
+++ b/src/main/java/com/example/egobook_be/domain/auth/enums/AuthErrorCode.java
@@ -21,6 +21,11 @@ public enum AuthErrorCode implements BaseErrorCode {
     INVALID_GOOGLE_TOKEN(HttpStatus.BAD_REQUEST, "Google Token이 null이거나 유효하지 않습니다."),
 
     /**
+     * 401 UNAUTHORIZED
+     */
+    BLACKLISTED_TOKEN(HttpStatus.UNAUTHORIZED, "블랙리스트에 등록된 토큰입니다. 해당 토큰을 사용할 수 없습니다."),
+
+    /**
      * 403 FORBIDDEN
      */
     RECERTIFICATION_FAIL_USER_WITHDRAW_PENDING(HttpStatus.FORBIDDEN, "사용자가 탈퇴 대기중이기 때문에, 해당 토큰으로 재인증할 수 없습니다."),

--- a/src/main/java/com/example/egobook_be/domain/auth/repository/AuthAccountRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/auth/repository/AuthAccountRepository.java
@@ -31,7 +31,10 @@ public interface AuthAccountRepository extends JpaRepository<AuthAccount, Long> 
      * @param provider Provider
      * @return Optional<AuthAccount></AuthAccount>
      */
-    Optional<AuthAccount> findByHashedDeviceUidAndProvider(String hashedDeviceUid, Provider provider);
+    @Query("select a from AuthAccount a " +
+            "join fetch a.user u " +
+            "where a.hashedDeviceUid = :hashedDeviceUid and a.provider = :provider")
+    Optional<AuthAccount> findByHashedDeviceUidAndProvider(@Param("hashedDeviceUid") String hashedDeviceUid, @Param("provider") Provider provider);
     /**
      * 특정 유저의 특정 Provider 계정 조회 (Guest 계정 찾기용)
      */

--- a/src/main/java/com/example/egobook_be/domain/auth/repository/AuthAccountRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/auth/repository/AuthAccountRepository.java
@@ -4,10 +4,13 @@ import com.example.egobook_be.domain.auth.entity.AuthAccount;
 import com.example.egobook_be.domain.auth.enums.Provider;
 import com.example.egobook_be.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -49,6 +52,8 @@ public interface AuthAccountRepository extends JpaRepository<AuthAccount, Long> 
      */
     boolean existsByHashedDeviceUidAndProvider(String hashedDeviceUid, Provider provider);
 
-    /** 사용자와 연관된 AuthAccount 레코드를 삭제하는 함수*/
-    boolean deleteByUser(User user);
+    /** 사용자 리스트 안에 있는 User이면 삭제하는 함수 */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM AuthAccount a WHERE a.user IN :users")
+    void bulkDeleteByUserIn(@Param("users") List<User> users);
 }

--- a/src/main/java/com/example/egobook_be/domain/auth/repository/AuthAccountRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/auth/repository/AuthAccountRepository.java
@@ -2,6 +2,7 @@ package com.example.egobook_be.domain.auth.repository;
 
 import com.example.egobook_be.domain.auth.entity.AuthAccount;
 import com.example.egobook_be.domain.auth.enums.Provider;
+import com.example.egobook_be.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -35,12 +36,16 @@ public interface AuthAccountRepository extends JpaRepository<AuthAccount, Long> 
      * 특정 유저의 특정 Provider 계정 조회 (Guest 계정 찾기용)
      */
     Optional<AuthAccount> findByUserIdAndProvider(Long userId, Provider provider);
+    Optional<AuthAccount> findByUser(User user);
 
     /**
      * DeviceUid & Provider로 해당 인증 정보가 존재하는지 찾는 함수 (중복 가입 방지용)
-     * @param hashedDeviceUid : 기기 고유 Uid
+     * @param hashedDeviceUid : 기기 고유 Uid / Google 고유 ID(토큰 Sub)
      * @param provider : 요청 제공자 GUEST, GOOGLE
      * @return
      */
     boolean existsByHashedDeviceUidAndProvider(String hashedDeviceUid, Provider provider);
+
+    /** 사용자와 연관된 AuthAccount 레코드를 삭제하는 함수*/
+    boolean deleteByUser(User user);
 }

--- a/src/main/java/com/example/egobook_be/domain/auth/repository/RefreshTokenBackupRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/auth/repository/RefreshTokenBackupRepository.java
@@ -2,9 +2,14 @@ package com.example.egobook_be.domain.auth.repository;
 
 import com.example.egobook_be.domain.auth.entity.AuthAccount;
 import com.example.egobook_be.domain.auth.entity.RefreshTokenBackup;
+import com.example.egobook_be.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -33,5 +38,7 @@ public interface RefreshTokenBackupRepository extends JpaRepository<RefreshToken
     Optional<RefreshTokenBackup> findByHashedTokenValue(String hashedRefreshToken);
 
     /** AuthAccount와 연관된 RefreshTokenBackup 레코드를 삭제하는 함수 */
-    boolean deleteByAuthAccount(AuthAccount authAccount);
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM RefreshTokenBackup rtb WHERE rtb.authAccount.id IN (SELECT a.id FROM AuthAccount a WHERE a.user IN :users)")
+    void bulkDeleteByAuthAccountUserIn(@Param("users") List<User> users);
 }

--- a/src/main/java/com/example/egobook_be/domain/auth/repository/RefreshTokenBackupRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/auth/repository/RefreshTokenBackupRepository.java
@@ -31,4 +31,7 @@ public interface RefreshTokenBackupRepository extends JpaRepository<RefreshToken
      * @return
      */
     Optional<RefreshTokenBackup> findByHashedTokenValue(String hashedRefreshToken);
+
+    /** AuthAccount와 연관된 RefreshTokenBackup 레코드를 삭제하는 함수 */
+    boolean deleteByAuthAccount(AuthAccount authAccount);
 }

--- a/src/main/java/com/example/egobook_be/domain/auth/repository/RefreshTokenBackupRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/auth/repository/RefreshTokenBackupRepository.java
@@ -21,7 +21,7 @@ public interface RefreshTokenBackupRepository extends JpaRepository<RefreshToken
      * @return RefreshTokenBackup
      */
     Optional<RefreshTokenBackup> findByAuthAccount(AuthAccount authAccount);
-
+    List<RefreshTokenBackup> findAllByAuthAccount(AuthAccount authAccount);
     /**
      * 해당 테이블에 AuthAccount PK가 존재하는지 확인하는 함수
      * RefreshTokenBackup 테이블에서는 authAccount PK는 unique하다.
@@ -41,4 +41,6 @@ public interface RefreshTokenBackupRepository extends JpaRepository<RefreshToken
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("DELETE FROM RefreshTokenBackup rtb WHERE rtb.authAccount.id IN (SELECT a.id FROM AuthAccount a WHERE a.user IN :users)")
     void bulkDeleteByAuthAccountUserIn(@Param("users") List<User> users);
+
+    void deleteByAuthAccount(AuthAccount authAccount);
 }

--- a/src/main/java/com/example/egobook_be/domain/auth/sevice/AuthService.java
+++ b/src/main/java/com/example/egobook_be/domain/auth/sevice/AuthService.java
@@ -16,6 +16,7 @@ import com.example.egobook_be.domain.terms.repository.TermRepository;
 import com.example.egobook_be.domain.terms.repository.UserTermRepository;
 import com.example.egobook_be.domain.user.entity.Ability;
 import com.example.egobook_be.domain.user.enums.RoleType;
+import com.example.egobook_be.domain.user.enums.UserStatus;
 import com.example.egobook_be.domain.user.repository.AbilityRepository;
 import com.example.egobook_be.global.util.*;
 import com.example.egobook_be.global.util.module.TokenInfo;
@@ -274,8 +275,9 @@ public class AuthService {
     }
 
     /**
-     * Guest RefreshToken 재발급
-     * Refresh Token이 만료되었을 때, 기기에 영구 저장된 Recover Token을 검증하여 세션을 복구하는 함수
+     * [ Guest RefreshToken 재발급 ]
+     * - 사용자의 상태가 "삭제 대기" 상태라면 사용자 재인증 금지
+     * - Refresh Token이 만료되었을 때, 기기에 영구 저장된 Recover Token을 검증하여 세션을 복구하는 함수
      */
     @Transactional
     public JwtTokenResDto recertificationGuestToken(GuestRecertificationReqDto reqDto){
@@ -298,12 +300,20 @@ public class AuthService {
         }
 
         /*
+         * 4. 해당 인증 정보를 갖고 있는 User의 Status가 삭제 대기 상태인지 확인한다.
+         * - findAuthAccountByHashedDeviceUidAndProvider에서 User도 Fetch Join으로 가져와 같은 영속성 컨텍스트에 있으므로, N+1이 발생하지 않는다.
+         */
+        User user = authAccount.getUser();
+        if(user.getStatus().equals(UserStatus.WITHDRAW_PENDING)){
+            throw new CustomException(AuthErrorCode.RECERTIFICATION_FAIL_USER_WITHDRAW_PENDING);
+        }
+
+        /*
          * 4. 검증 통과 시, 새로운 Access, Refresh, Recover Token 생성
          * - User 정보를 로드하여 토큰 생성에 필요한 Subject, Role 획득
          * - recoverTokenInfo는 CustomUserDetails 객체가 있어야 하므로 생성
          * - AuthAccount의 hashedRecoverToken 업데이트
          */
-        User user = authAccount.getUser();
         CustomUserDetails userDetails = buildCustomUserDetails(user, authAccount);
         String subject = jwtUtil.createSubject(authAccount.getProvider(), authAccount.getHashedDeviceUid()); // 토큰에 넣을 subject 생성
         TokenInfo newAccessTokenInfo = jwtUtil.createAccessToken(user.getId(), authAccount.getId(), subject, user.getRole());
@@ -351,17 +361,24 @@ public class AuthService {
         AuthAccount authAccount = authAccountRepository.findByHashedDeviceUidAndProvider(hashedGoogleSub, Provider.GOOGLE)
                 .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
 
+        /*
+         * 3. 해당 인증 정보를 갖고 있는 User의 Status가 삭제 대기 상태인지 확인한다.
+         * - findAuthAccountByHashedDeviceUidAndProvider에서 User도 Fetch Join으로 가져와 같은 영속성 컨텍스트에 있으므로, N+1이 발생하지 않는다.
+         */
         User user = authAccount.getUser();
+        if(user.getStatus().equals(UserStatus.WITHDRAW_PENDING)){
+            throw new CustomException(AuthErrorCode.RECERTIFICATION_FAIL_USER_WITHDRAW_PENDING);
+        }
 
-        // 3. 토큰 재발급 (Access + Refresh)
+        // 4. 토큰 재발급 (Access + Refresh)
         CustomUserDetails userDetails = buildCustomUserDetails(user, authAccount);
         TokenInfo accessTokenInfo = jwtUtil.createAccessToken(userDetails);
         TokenInfo refreshTokenInfo = jwtUtil.createRefreshToken(userDetails);
 
-        // 4. Refresh Token 저장 (DB + Redis)
+        // 5. Refresh Token 저장 (DB + Redis)
         processRefreshTokenSaving(user, authAccount, refreshTokenInfo);
 
-        // 5. 반환
+        // 6. 반환
         return buildJwtTokenResDto(accessTokenInfo.token(), refreshTokenInfo.token(), null);
     }
 

--- a/src/main/java/com/example/egobook_be/domain/auth/sevice/AuthService.java
+++ b/src/main/java/com/example/egobook_be/domain/auth/sevice/AuthService.java
@@ -33,6 +33,7 @@ import com.example.egobook_be.global.exception.CustomException;
 import com.example.egobook_be.global.security.CustomUserDetails;
 import com.example.egobook_be.global.util.module.RedisValue;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -215,10 +216,10 @@ public class AuthService {
      * @return JwtTokenResDto
      */
     @Transactional
-    public JwtTokenResDto refreshGuestToken(RefreshReqDto reqDto){
+    public JwtTokenResDto refreshToken(RefreshReqDto reqDto){
         // 1. 전달받은 Refresh Token Hashing
         String hashedRefreshToken = hashingUtil.hashingValue(reqDto.refreshToken());
-
+        
         /*
          * 2. Redis에서 조회 시도
          * - 조회를 성공한 경우, RedisValue Record Class에 담겨있는 값으로 Access Token을 재발급한다.
@@ -226,6 +227,8 @@ public class AuthService {
          */
         RedisValue redisValue = redisUtil.getHashedRefreshTokenValue(hashedRefreshToken);
         if(redisValue != null){
+            // 기존 AccessToken Redis 블랙리스트에 추가
+            addAccessTokenInRedisBlackList(reqDto.accessToken());
             TokenInfo newAccessTokenInfo = jwtUtil.createAccessToken(redisValue.userId(), redisValue.authAccountId(), redisValue.subject(), redisValue.role());
             return buildJwtTokenResDto(newAccessTokenInfo.token(), reqDto.refreshToken(), null);
         }
@@ -267,11 +270,32 @@ public class AuthService {
         RedisValue restoreRedisValue = buildRedisValue(user.getId(), authAccount.getId(), subject, user.getRole(), backup.getExpiresAt()); // RedisValue 생성
         registerToRedis(hashedRefreshToken, restoreRedisValue, backup.getExpiresAt()); // Redis에 해당 데이터들 복구
 
-        /*
-         * 6. Access Token 재생성 후 Access, Refresh Token 반환
-         */
+        // 6. 기존 Access Token Redis의 BlackList에 추가
+        addAccessTokenInRedisBlackList(reqDto.accessToken());
+
+        // 7. Access Token 재생성 후 Access, Refresh Token 반환
         TokenInfo newAccessTokenInfo = jwtUtil.createAccessToken(user.getId(), authAccount.getId(), subject, user.getRole());
         return buildJwtTokenResDto(newAccessTokenInfo.token(), reqDto.refreshToken(), null);
+    }
+
+    /** HttpServletRequest에 들어있는 AccessToken 추출 및 블랙리스트 등록 */
+    private void addAccessTokenInRedisBlackList(String accessToken){
+            // 만료되지 않은 토큰이라도 강제로 블랙리스트 처리
+            redisUtil.setTokenInBlacklist(accessToken);
+            log.info("🪪 재발급 요청에 사용된 기존 Access Token을 블랙리스트에 등록했습니다.");
+    }
+
+    private void deleteOldRefreshTokenFromRedis(AuthAccount authAccount) {
+        // DB에 백업된 정보가 있는지 확인
+        refreshTokenBackupRepository.findByAuthAccount(authAccount).ifPresent(backup -> {
+            String oldHashedToken = backup.getHashedTokenValue();
+
+            // RedisUtil을 통해 삭제 (존재하면 삭제, 없으면 무시됨)
+            if (oldHashedToken != null) {
+                redisUtil.deleteHashedRefreshToken(oldHashedToken);
+                log.info("🔄 [Rotation] 기존 Refresh Token을 Redis에서 삭제했습니다. User: {}", authAccount.getId());
+            }
+        });
     }
 
     /**
@@ -309,7 +333,15 @@ public class AuthService {
         }
 
         /*
-         * 4. 검증 통과 시, 새로운 Access, Refresh, Recover Token 생성
+         * 5. Redis 상태 업데이트
+         * (1) 기존에 사용되던 AccessToken 블랙리스트에 등록
+         * (2) 기존에 Refresh Token Backup 테이블에 있던 Refresh Token Redis에서 삭제 (아직 만료되지 않은 상태에서 복구 로직이 실행될 수도 있으므로)
+         */
+        addAccessTokenInRedisBlackList(reqDto.accessToken());
+        deleteOldRefreshTokenFromRedis(authAccount);
+
+        /*
+         * 6. 검증 통과 시, 새로운 Access, Refresh, Recover Token 생성
          * - User 정보를 로드하여 토큰 생성에 필요한 Subject, Role 획득
          * - recoverTokenInfo는 CustomUserDetails 객체가 있어야 하므로 생성
          * - AuthAccount의 hashedRecoverToken 업데이트
@@ -322,23 +354,23 @@ public class AuthService {
         authAccount.updateHashedRecoverToken(hashingUtil.hashingValue(newRecoverTokenInfo.token())); // authAccount Table의 HashedRecoverToken값 최신화
 
         /*
-         * 5. Refresh Token 백업 테이블 업데이트
+         * 7. Refresh Token 백업 테이블 업데이트
          * - 기존에 만료된 Refresh Token 정보를 새로운 토큰 정보로 덮어씌운다.
          */
-        String hashedRefreshToken = hashingUtil.hashingValue(newRefreshTokenInfo.token());
+        String newHashedRefreshToken = hashingUtil.hashingValue(newRefreshTokenInfo.token());
         updateRefreshTokenBackupTable(
                 authAccount,
-                hashedRefreshToken,
+                newHashedRefreshToken,
                 newRefreshTokenInfo.expiresAt());
 
         /*
-         * 6. Redis 업데이트
+         * 8. Redis 업데이트
          * - 새로운 Refresh Token을 Redis에 등록하여 바로 사용 가능하도록 처리
          */
         RedisValue newRedisValue = buildRedisValue(user.getId(), authAccount.getId(), subject, user.getRole(), newRefreshTokenInfo.expiresAt());
-        registerToRedis(hashedRefreshToken, newRedisValue, newRefreshTokenInfo.expiresAt());
+        registerToRedis(newHashedRefreshToken, newRedisValue, newRefreshTokenInfo.expiresAt());
 
-        // 7. 결과 반환
+        // 9. 결과 반환
         return buildJwtTokenResDto(newAccessTokenInfo.token(), newRefreshTokenInfo.token(), newRecoverTokenInfo.token());
     }
 
@@ -370,7 +402,15 @@ public class AuthService {
             throw new CustomException(AuthErrorCode.RECERTIFICATION_FAIL_USER_WITHDRAW_PENDING);
         }
 
-        // 4. 토큰 재발급 (Access + Refresh)
+        /*
+         * 4. Redis 상태 업데이트
+         * (1) 기존에 사용되던 AccessToken 블랙리스트에 등록
+         * (2) 기존에 Refresh Token Backup 테이블에 있던 Refresh Token Redis에서 삭제 (아직 만료되지 않은 상태에서 복구 로직이 실행될 수도 있으므로)
+         */
+        addAccessTokenInRedisBlackList(reqDto.accessToken());
+        deleteOldRefreshTokenFromRedis(authAccount);
+
+        // 5. 토큰 재발급 (Access + Refresh)
         CustomUserDetails userDetails = buildCustomUserDetails(user, authAccount);
         TokenInfo accessTokenInfo = jwtUtil.createAccessToken(userDetails);
         TokenInfo refreshTokenInfo = jwtUtil.createRefreshToken(userDetails);

--- a/src/main/java/com/example/egobook_be/domain/auth/sevice/AuthService.java
+++ b/src/main/java/com/example/egobook_be/domain/auth/sevice/AuthService.java
@@ -223,7 +223,7 @@ public class AuthService {
          * - 조회를 성공한 경우, RedisValue Record Class에 담겨있는 값으로 Access Token을 재발급한다.
          * - 재발급 시 Recover Token은 안준다.
          */
-        RedisValue redisValue = redisUtil.getRefreshTokenValue(hashedRefreshToken);
+        RedisValue redisValue = redisUtil.getHashedRefreshTokenValue(hashedRefreshToken);
         if(redisValue != null){
             TokenInfo newAccessTokenInfo = jwtUtil.createAccessToken(redisValue.userId(), redisValue.authAccountId(), redisValue.subject(), redisValue.role());
             return buildJwtTokenResDto(newAccessTokenInfo.token(), reqDto.refreshToken(), null);
@@ -293,7 +293,7 @@ public class AuthService {
          */
         if(!authAccount.getHashedRecoverToken().equals(hashedRecoverToken)){
             log.warn("[Class:AuthService]: HashedDeviceUid: {}, 옳지 않은 Recover Token로 Refresh Token 복구 시도를 하였습니다..", hashedDeviceUid);
-            authAccount.getUser().deleteUser(purgeDurationInMs); // 사용자 삭제(실제로는 삭제 예정으로 상태 변경)
+            authAccount.getUser().withdrawUser(purgeDurationInMs); // 사용자 삭제(실제로는 삭제 예정으로 상태 변경)
             throw new CustomException(AuthErrorCode.INVALID_RECOVER_TOKEN);
         }
 
@@ -334,7 +334,7 @@ public class AuthService {
 
     /**
      * Google RefreshToken 재발급
-     * Refresh Token이 만료되었을 때, 프론트엔드가 Google Slient Login 후 받은 ID Token으로 호출하는 API
+     * Refresh Token이 만료되었을 때, 프론트엔드가 Google Silent Login 후 받은 ID Token으로 호출하는 API
      * - 회원가입(Register)과 달리, 이미 존재하는 계정이어야만 성공한다.
      * - Recover Token은 여전히 null이다.
      */
@@ -403,7 +403,7 @@ public class AuthService {
 
         // 4-2. Redis 삭제 (기존 토큰이 있었다면)
         if (oldHashedRefreshToken != null) {
-            redisUtil.deleteRefreshToken(oldHashedRefreshToken); // RedisUtil에 delete 메서드 필요 (없으면 setTTL(0))
+            redisUtil.deleteHashedRefreshToken(oldHashedRefreshToken); // RedisUtil에 delete 메서드 필요 (없으면 setTTL(0))
         }
 
         /*
@@ -545,7 +545,7 @@ public class AuthService {
             ttlInMillis = 0;
         }
         if(ttlInMillis > 0){
-            redisUtil.setRefreshTokenValue(key, value, ttlInMillis);
+            redisUtil.setHashedRefreshTokenValue(key, value, ttlInMillis);
         }
     }
 
@@ -595,7 +595,7 @@ public class AuthService {
      */
     private AuthAccount findAuthAccountByHashedDeviceUidAndProvider(String hashedDeviceUid, Provider provider){
         return authAccountRepository.findByHashedDeviceUidAndProvider(hashedDeviceUid, provider)
-                .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(AuthErrorCode.USER_AUTH_ACCOUNT_NOT_FOUND));
     }
 
     /**

--- a/src/main/java/com/example/egobook_be/domain/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/diary/repository/DiaryRepository.java
@@ -6,6 +6,7 @@ import com.example.egobook_be.domain.user.entity.User;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -25,7 +26,6 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
     boolean existsByUserAndTypeInAndCreatedAtBetween(User user, Set<DiaryType> praise, LocalDateTime startOfToday, LocalDateTime endOfToday);
 
     List<Diary> findAllByUserAndWrittenAtBetween(User user, LocalDateTime start, LocalDateTime end);
-
 
     @Query("""
     SELECT
@@ -61,6 +61,9 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
         LocalDate getDate();
         Integer getEmotionLevel();
     }
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM Diary d WHERE d.user IN :users")
+    void bulkDeleteByUserIn(@Param("users") List<User> users);
 
     @Query("SELECT AVG(d.emotionLevel) FROM Diary d WHERE d.user.id = :userId AND d.writtenAt BETWEEN :start AND :end AND d.emotionLevel > 0")
     Double findAvgEmotionLevel(@Param("userId") Long userId, @Param("start") LocalDateTime start, @Param("end") LocalDateTime end);

--- a/src/main/java/com/example/egobook_be/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/friend/repository/FriendRepository.java
@@ -4,6 +4,7 @@ package com.example.egobook_be.domain.friend.repository;
 import com.example.egobook_be.domain.friend.entity.Friend;
 import com.example.egobook_be.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -35,4 +36,9 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
     List<Friend> findByUserWithFriend(
             @Param("user") User user
     );
+
+    /** 해당 레코드가 "user_id in User List", "friend_id in Friend List"인 경우 Bulk 삭제하는 함수 */
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Friend f WHERE f.user IN :users OR f.friend IN :friends")
+    void bulkDeleteByUsersInOrFriendsIn(@Param("users") List<User> users, @Param("friends") List<User> friends);
 }

--- a/src/main/java/com/example/egobook_be/domain/friend/repository/FriendRequestRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/friend/repository/FriendRequestRepository.java
@@ -4,6 +4,7 @@ import com.example.egobook_be.domain.friend.entity.FriendRequest;
 import com.example.egobook_be.domain.friend.enums.FriendRequestStatus;
 import com.example.egobook_be.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -44,4 +45,9 @@ public interface FriendRequestRepository extends JpaRepository<FriendRequest, Lo
             @Param("sender") User sender,
             @Param("status") FriendRequestStatus status
     );
+
+    /** Sender in Senders || Receiver in Receivers 인 경우 bulk 삭제하는 함수 */
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM FriendRequest fr WHERE fr.sender IN :senders OR fr.receiver IN :receivers")
+    void bulkDeleteBySenderInOrReceiverIn(@Param("senders")List<User> senders, @Param("receivers") List<User> receivers);
 }

--- a/src/main/java/com/example/egobook_be/domain/home/repository/MissionRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/home/repository/MissionRepository.java
@@ -5,7 +5,9 @@ import com.example.egobook_be.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MissionRepository extends JpaRepository<Mission, Long> {
@@ -28,4 +30,8 @@ public interface MissionRepository extends JpaRepository<Mission, Long> {
             "m.dailyLetterWritten = false, " +
             "m.dailyQuestionAnswered = false ")
     void resetAllDailyMissions();
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM Mission m WHERE m.user IN :users")
+    void bulkDeleteByUserIn(@Param("users") List<User> users);
 }

--- a/src/main/java/com/example/egobook_be/domain/letters/entity/PlazaLetter.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/entity/PlazaLetter.java
@@ -20,7 +20,7 @@ public class PlazaLetter {
     @Column(nullable = false)
     private Long threadId;
 
-    @Column(nullable = false)
+    @Column
     private Long senderId;
 
     @Column

--- a/src/main/java/com/example/egobook_be/domain/letters/entity/PlazaLetterReply.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/entity/PlazaLetterReply.java
@@ -2,6 +2,8 @@ package com.example.egobook_be.domain.letters.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import java.time.OffsetDateTime;
 
@@ -17,10 +19,12 @@ public class PlazaLetterReply {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long replyId;
 
-    @Column(nullable = false)
-    private Long letterId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "letter_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE) // 편지가 삭제되면 답장도 자동 삭제
+    private PlazaLetter letter;
 
-    @Column(nullable = false)
+    @Column
     private Long replierId;
 
     @Column(nullable = false)

--- a/src/main/java/com/example/egobook_be/domain/letters/entity/PlazaLetterReplyReport.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/entity/PlazaLetterReplyReport.java
@@ -2,6 +2,8 @@ package com.example.egobook_be.domain.letters.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import java.time.OffsetDateTime;
 
@@ -18,17 +20,19 @@ public class PlazaLetterReplyReport {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "reply_id")
+    @OnDelete(action = OnDeleteAction.CASCADE) // 답장이 삭제되면 신고 내역도 자동 삭제
     private PlazaLetterReply reply;
 
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "letter_id")
+    @OnDelete(action = OnDeleteAction.CASCADE) // 편지가 삭제되면 신고 내역도 자동 삭제
     private PlazaLetter letter;
 
     @Column(nullable = false)
     private Long reporterId;
 
-    private Long replierId;
+    private Long replierId; // 신고를 받은 편지를 작성한 작성자의 User PK
 
     @Enumerated(EnumType.STRING)
     private ReplyReportReason reason;

--- a/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterReplyReportRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterReplyReportRepository.java
@@ -2,7 +2,9 @@ package com.example.egobook_be.domain.letters.repository;
 
 import com.example.egobook_be.domain.letters.entity.PlazaLetterReplyReport;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -19,4 +21,13 @@ public interface PlazaLetterReplyReportRepository extends JpaRepository<PlazaLet
           and r.reply.replyId in :replyIds
     """)
     List<Long> findReportedReplyIds(Long reporterId, List<Long> replyIds);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM PlazaLetterReplyReport r WHERE r.reporterId IN :reporterIds")
+    void bulkDeleteByReporterIdIn(@Param("reporterIds") List<Long> reporterIds);
+
+    /** 내가 신고당한 내역에서는 Replier ID를 Null로 익명화한다. */
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE PlazaLetterReplyReport r SET r.replierId = NULL WHERE r.replierId IN :replierIds")
+    void bulkNullifyReplierId(@Param("replierIds") List<Long> replierIds);
 }

--- a/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterReplyRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterReplyRepository.java
@@ -1,29 +1,34 @@
 package com.example.egobook_be.domain.letters.repository;
 
+import com.example.egobook_be.domain.letters.entity.PlazaLetter;
 import com.example.egobook_be.domain.letters.entity.PlazaLetterReply;
 import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface PlazaLetterReplyRepository extends JpaRepository<PlazaLetterReply, Long> {
-    boolean existsByLetterId(Long letterId);
+    boolean existsByLetter(PlazaLetter letter);
 
+    @Query("SELECT r FROM PlazaLetterReply r JOIN FETCH r.letter WHERE r.replyId = :replyId")
+    Optional<PlazaLetterReply> findByIdWithLetter(@Param("replyId") Long replyId);
 
     Slice<PlazaLetterReply> findByReplierIdOrderByReplyIdDesc(Long replierId, Pageable pageable);
 
-    Optional<PlazaLetterReply> findByLetterId(Long letterId);
+    Optional<PlazaLetterReply> findByLetter(PlazaLetter letter);
 
     void deleteByThreadId(Long threadId);
 
     @Query("""
         select r
         from PlazaLetterReply r
-        join PlazaLetter l on r.letterId = l.letterId
+        join fetch r.letter l
         where l.senderId = :userId
         order by r.createdAt desc
     """)
@@ -33,4 +38,9 @@ public interface PlazaLetterReplyRepository extends JpaRepository<PlazaLetterRep
     );
 
     boolean existsByReplierIdAndCreatedAtBetween(Long replierId, OffsetDateTime createdAtAfter, OffsetDateTime createdAtBefore);
+
+    // 내가 쓴 답장의 작성자 ID를 NULL로 익명화
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE PlazaLetterReply r SET r.replierId = NULL, r.isAiGenerated = false WHERE r.replierId IN :replierIds")
+    void bulkNullifyReplierId(@Param("replierIds") List<Long> replierIds);
 }

--- a/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterRepository.java
@@ -58,5 +58,20 @@ public interface PlazaLetterRepository extends JpaRepository<PlazaLetter, Long> 
             Pageable pageable
     );
 
+    /** 탈퇴한 Sender의 ID를 NULL로 변경 (익명화) */
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE PlazaLetter l SET l.senderId = NULL WHERE l.senderId IN :senderIds")
+    void bulkNullifySenderId(@Param("senderIds") List<Long> senderIds);
+
+    /** 탈퇴한 Receiver의 ID를 NULL로 변경 */
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE PlazaLetter l SET l.receiverId = NULL WHERE l.receiverId IN :receiverIds")
+    void bulkNullifyReceiverId(@Param("receiverIds") List<Long> receiverIds);
+
+    /** Sender와 Receiver가 모두 사라진(NULL) "완전 고아 편지" 삭제(이 메서드는 두 ID가 모두 NULL인 데이터만 지웁니다) */
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM PlazaLetter l WHERE l.senderId IS NULL AND l.receiverId IS NULL")
+    void bulkDeleteOrphanedLetters();
+
 }
 

--- a/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterThreadRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterThreadRepository.java
@@ -2,6 +2,16 @@ package com.example.egobook_be.domain.letters.repository;
 
 import com.example.egobook_be.domain.letters.entity.PlazaLetterThread;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PlazaLetterThreadRepository extends JpaRepository<PlazaLetterThread, Long> {
+    /**
+     * 연결된 편지(PlazaLetter)가 하나도 없는 빈 쓰레드를 일괄 삭제합니다.
+     * (고아 쓰레드 정리)
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM PlazaLetterThread t WHERE NOT EXISTS (SELECT 1 FROM PlazaLetter l WHERE l.threadId = t.threadId)")
+    void bulkDeleteEmptyThreads();
 }
+

--- a/src/main/java/com/example/egobook_be/domain/letters/service/PlazaLetterQueryService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/PlazaLetterQueryService.java
@@ -68,7 +68,7 @@ public class PlazaLetterQueryService {
                 Sort.by(Sort.Direction.DESC, "createdAt")
         );
 
-
+        // 1. 답장 목록 조회
         Slice<PlazaLetterReply> slice =
                 plazaLetterReplyRepository.findRepliesForMyLetters(userId, pageable);
 
@@ -76,19 +76,7 @@ public class PlazaLetterQueryService {
             return SliceResponse.of(slice, r -> null);
         }
 
-        List<Long> letterIds = slice.getContent().stream()
-                .map(PlazaLetterReply::getLetterId)
-                .distinct()
-                .toList();
-
-        List<PlazaLetter> letters = plazaLetterRepository.findByLetterIdIn(letterIds);
-
-        java.util.Map<Long, PlazaLetter> letterMap = letters.stream()
-                .collect(java.util.stream.Collectors.toMap(
-                        PlazaLetter::getLetterId,
-                        l -> l
-                ));
-
+        // 2. 신고 상태 확인 (내가 신고한 답장 ID 목록 가져옴)
         List<Long> replyIds = slice.getContent().stream()
                 .map(PlazaLetterReply::getReplyId)
                 .toList();
@@ -97,8 +85,9 @@ public class PlazaLetterQueryService {
                 ? java.util.Collections.emptySet()
                 : new java.util.HashSet<>(replyReportRepository.findReportedReplyIds(userId, replyIds));
 
+        // 3. DTO 변환
         return SliceResponse.of(slice, reply -> {
-            PlazaLetter letter = letterMap.get(reply.getLetterId());
+            PlazaLetter letter = reply.getLetter();
             if (letter == null) {
                 throw new CustomException(LettersErrorCode.LETTER_NOT_FOUND);
             }
@@ -122,7 +111,7 @@ public class PlazaLetterQueryService {
 
         // 답장은 없을 수도 있음
         PlazaLetterReply reply =
-                plazaLetterReplyRepository.findByLetterId(letterId).orElse(null);
+                plazaLetterReplyRepository.findByLetter(letter).orElse(null);
 
         boolean reported = false;
         if (reply != null) {

--- a/src/main/java/com/example/egobook_be/domain/letters/service/PlazaLetterService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/PlazaLetterService.java
@@ -257,7 +257,7 @@ public class PlazaLetterService {
         validateReplyable(letter, now);
 
         // 5. 해당 편지에 대해 답장이 이미 되어있는 상태인지 확인
-        if (plazaLetterReplyRepository.existsByLetterId(letter.getLetterId())) {
+        if (plazaLetterReplyRepository.existsByLetter(letter)) {
             throw new CustomException(LettersErrorCode.ALREADY_REPLIED);
         }
 
@@ -272,7 +272,7 @@ public class PlazaLetterService {
 
         plazaLetterReplyRepository.save(PlazaLetterReply.builder()
                 .threadId(letter.getThreadId())
-                .letterId(letter.getLetterId())
+                .letter(letter)
                 .replierId(userId)
                 .text(text)
                 .isAiGenerated(false)
@@ -437,7 +437,7 @@ public class PlazaLetterService {
     private ReplyItemDto toReplyItemDto(PlazaLetterReply reply) {
         return ReplyItemDto.builder()
                 .replyId(reply.getReplyId())
-                .letterId(reply.getLetterId())
+                .letterId(reply.getLetter().getLetterId())
                 .replyText(reply.getText())
                 .createdAt(reply.getCreatedAt())
                 .build();

--- a/src/main/java/com/example/egobook_be/domain/letters/service/ReplyReportService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/ReplyReportService.java
@@ -34,13 +34,12 @@ public class ReplyReportService {
         }
 
         // 신고 대상 답장과 편지를 가져오기
-        PlazaLetterReply reply = plazaLetterReplyRepository.findById(replyId)
+        PlazaLetterReply reply = plazaLetterReplyRepository.findByIdWithLetter(replyId)
                 .orElseThrow(() -> new CustomException(LettersErrorCode.LETTER_NOT_FOUND));
 
-        PlazaLetter letter = plazaLetterRepository.findById(reply.getLetterId())
-                .orElseThrow(() -> new CustomException(LettersErrorCode.LETTER_NOT_FOUND));
+        PlazaLetter letter = reply.getLetter();
 
-        if (!userId.equals(letter.getReceiverId())) {
+        if (userId.equals(letter.getReceiverId())) {
             throw new CustomException(LettersErrorCode.FORBIDDEN);
         }
 

--- a/src/main/java/com/example/egobook_be/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/notification/repository/NotificationRepository.java
@@ -5,15 +5,22 @@ import com.example.egobook_be.domain.user.entity.User;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
     Slice<Notification> findAllByUser(User user, Pageable pageable);
 
-    /**
-     * 해당 사용자가 아직 읽지 않은 알림의 개수를 반환하는 함수 
-     */
+    /** 해당 사용자가 아직 읽지 않은 알림의 개수를 반환하는 함수 */
     Integer countByUserAndIsReadIsFalse(User user);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM Notification n WHERE n.user IN :users")
+    void bulkDeleteByUserIn(@Param("users") List<User> users);
 }

--- a/src/main/java/com/example/egobook_be/domain/psychology/repository/UserKnowledgeRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/psychology/repository/UserKnowledgeRepository.java
@@ -8,6 +8,8 @@ import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -28,4 +30,8 @@ public interface UserKnowledgeRepository extends JpaRepository<UserKnowledge, Lo
     void deleteAllByUserId(Long userId);
 
     List<UserKnowledge> findAllByUser(User user);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM UserKnowledge uk WHERE uk.user IN :users")
+    void bulkDeleteByUserIn(@Param("users") List<User> users);
 }

--- a/src/main/java/com/example/egobook_be/domain/question/repository/QuestionAnswerRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/question/repository/QuestionAnswerRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -90,5 +91,5 @@ public interface QuestionAnswerRepository extends JpaRepository<QuestionAnswer, 
             @Param("questionId") Long questionId
     );
 
-    boolean existsByUserAndCreatedAtBetween(User user, OffsetDateTime startOfDay, OffsetDateTime endOfDay);
+    boolean existsByUserAndCreatedAtBetween(User user, LocalDateTime startOfDay, LocalDateTime endOfDay);
 }

--- a/src/main/java/com/example/egobook_be/domain/question/repository/QuestionAnswerRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/question/repository/QuestionAnswerRepository.java
@@ -8,6 +8,7 @@ import com.example.egobook_be.domain.user.entity.User;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -92,4 +93,9 @@ public interface QuestionAnswerRepository extends JpaRepository<QuestionAnswer, 
     );
 
     boolean existsByUserAndCreatedAtBetween(User user, LocalDateTime startOfDay, LocalDateTime endOfDay);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM QuestionAnswer qa WHERE qa.user IN :users")
+    void bulkDeleteByUserIn(@Param("users") List<User> users);
+
 }

--- a/src/main/java/com/example/egobook_be/domain/question/service/TodayQuestionService.java
+++ b/src/main/java/com/example/egobook_be/domain/question/service/TodayQuestionService.java
@@ -31,6 +31,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -113,8 +114,8 @@ public class TodayQuestionService {
         // 오늘 처음 "오늘의 질문"에 답변했는지 여부 확인
         ZoneId zoneId = ZoneId.of("Asia/Seoul");
         LocalDate today = LocalDate.now(zoneId);
-        OffsetDateTime startOfDay = today.atStartOfDay(zoneId).toOffsetDateTime();
-        OffsetDateTime endOfDay = today.plusDays(1).atStartOfDay(zoneId).toOffsetDateTime();
+        LocalDateTime startOfDay = today.atStartOfDay(zoneId).toLocalDateTime();
+        LocalDateTime endOfDay = today.plusDays(1).atStartOfDay(zoneId).toLocalDateTime();
         boolean isFirstAnswerToday = !questionAnswerRepository.existsByUserAndCreatedAtBetween(user, startOfDay, endOfDay);
 
         // 해당 사용자의 오늘의 답변 저장

--- a/src/main/java/com/example/egobook_be/domain/shop/repository/UserItemRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/shop/repository/UserItemRepository.java
@@ -3,6 +3,7 @@ package com.example.egobook_be.domain.shop.repository;
 import com.example.egobook_be.domain.shop.dto.UserItemStatusDto;
 import com.example.egobook_be.domain.shop.entity.UserItem;
 import com.example.egobook_be.domain.shop.enums.ItemCategory;
+import com.example.egobook_be.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -38,5 +39,5 @@ public interface UserItemRepository extends JpaRepository<UserItem, Long> {
     List<UserItem> findEquippedItemsByCategory(@Param("userId") Long userId,
                                                @Param("category") ItemCategory category);
 
-
+    void deleteByUserIn(List<User> users);
 }

--- a/src/main/java/com/example/egobook_be/domain/terms/repository/UserTermRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/terms/repository/UserTermRepository.java
@@ -1,7 +1,16 @@
 package com.example.egobook_be.domain.terms.repository;
 
 import com.example.egobook_be.domain.terms.entity.UserTerm;
+import com.example.egobook_be.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface UserTermRepository extends JpaRepository<UserTerm, Long> {
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM UserTerm ut WHERE ut.user IN :users")
+    void bulkDeleteByUserIn(@Param("users") List<User> users);
 }

--- a/src/main/java/com/example/egobook_be/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/egobook_be/domain/user/controller/UserController.java
@@ -17,6 +17,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -48,11 +49,13 @@ public class UserController implements UserControllerDocs{
 
     @Override
     public ResponseEntity<GlobalResponse<Void>> withdrawAccount(
-            @Parameter(hidden = true) @AuthenticationPrincipal(expression = "userAuthDto.userId") Long userId
+            @Parameter(hidden = true) @AuthenticationPrincipal(expression = "userAuthDto.userId") Long userId,
+            @Parameter(hidden = true) @RequestHeader("Authorization") String accessToken
     ){
+        userService.withDrawAccount(userId, accessToken);
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .body(null);
+                .body(GlobalResponse.success("회원 탈퇴 성공", null));
     }
 
 }

--- a/src/main/java/com/example/egobook_be/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/egobook_be/domain/user/controller/UserController.java
@@ -3,8 +3,10 @@ package com.example.egobook_be.domain.user.controller;
 import com.example.egobook_be.domain.auth.dto.req.GoogleJoinReqDto;
 import com.example.egobook_be.domain.auth.dto.res.JwtTokenResDto;
 import com.example.egobook_be.domain.auth.sevice.AuthService;
-import com.example.egobook_be.domain.user.dto.WithdrawReqDto;
-import com.example.egobook_be.domain.user.dto.WithdrawResDto;
+import com.example.egobook_be.domain.user.dto.UserNicknameResDto;
+import com.example.egobook_be.domain.user.dto.UserNicknameUpdateReqDto;
+import com.example.egobook_be.domain.user.repository.UserRepository;
+import com.example.egobook_be.domain.user.service.UserService;
 import com.example.egobook_be.global.response.GlobalResponse;
 import io.swagger.v3.oas.annotations.Parameter;
 
@@ -13,15 +15,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.time.LocalDateTime;
 
 @RestController
 @RequiredArgsConstructor
 public class UserController implements UserControllerDocs{
     private final AuthService authService;
+    private final UserService userService;
 
     @Override
     public ResponseEntity<GlobalResponse<JwtTokenResDto>> linkGoogleAccount(
@@ -34,16 +36,23 @@ public class UserController implements UserControllerDocs{
     }
 
     @Override
-    public ResponseEntity<GlobalResponse<WithdrawResDto>> withdrawUser(
+    public ResponseEntity<GlobalResponse<UserNicknameResDto>> updateNickname(
             @Parameter(hidden = true) @AuthenticationPrincipal(expression = "userAuthDto.userId") Long userId,
-            @RequestBody @Valid WithdrawReqDto reqDto
+            @RequestBody @Valid UserNicknameUpdateReqDto reqDto
+    ){
+        UserNicknameResDto resDto = userService.updateNickname(userId, reqDto);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(GlobalResponse.success("사용자 닉네임 업데이트 성공", resDto));
+    }
+
+    @Override
+    public ResponseEntity<GlobalResponse<Void>> withdrawAccount(
+            @Parameter(hidden = true) @AuthenticationPrincipal(expression = "userAuthDto.userId") Long userId
     ){
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .body(GlobalResponse.success("회원 탈퇴가 정상적으로 처리되었습니다.",
-                        WithdrawResDto.builder()
-                                .deletedAt(LocalDateTime.now())
-                                .graceDays(7)
-                                .build()));
+                .body(null);
     }
+
 }

--- a/src/main/java/com/example/egobook_be/domain/user/controller/UserControllerDocs.java
+++ b/src/main/java/com/example/egobook_be/domain/user/controller/UserControllerDocs.java
@@ -2,10 +2,9 @@ package com.example.egobook_be.domain.user.controller;
 
 import com.example.egobook_be.domain.auth.dto.req.GoogleJoinReqDto;
 import com.example.egobook_be.domain.auth.dto.res.JwtTokenResDto;
-import com.example.egobook_be.domain.user.dto.WithdrawReqDto;
-import com.example.egobook_be.domain.user.dto.WithdrawResDto;
+import com.example.egobook_be.domain.user.dto.UserNicknameResDto;
+import com.example.egobook_be.domain.user.dto.UserNicknameUpdateReqDto;
 import com.example.egobook_be.global.response.GlobalResponse;
-import com.example.egobook_be.global.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -19,6 +18,7 @@ import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -57,29 +57,62 @@ public interface UserControllerDocs {
             @RequestBody @Valid GoogleJoinReqDto reqDto
     );
 
-    // [신규 추가] 회원 탈퇴 API Docs
-    @Operation(summary = "회원 탈퇴", description = """
-            현재 로그인된 사용자의 계정을 탈퇴 처리합니다.
+    @Operation(summary = "사용자 닉네임 변경", description = """
+            로그인된 사용자의 **닉네임(Nickname)**을 변경합니다.
             
             - **기능**:
-              1. DB에서 사용자 정보를 Soft Delete 처리합니다.
-              2. 사용자가 회원탈퇴한 후 7일 뒤에 사용자 데이터가 완전히 삭제됩니다.
+              1. 입력된 닉네임의 형식(길이, 특수문자 등)을 검증합니다.
+              2. 데이터베이스 내 **닉네임 중복 여부**를 확인합니다.
+              3. 유효할 경우 영속성 컨텍스트를 업데이트하고 성공을 반환합니다.
             
-            - **주의사항**:
-              탈퇴 후에는 복구가 불가능할 수 있으며, 접근 토큰은 만료 처리됩니다.
+            - **제약 사항**:
+              1. 중복된 닉네임은 사용할 수 없습니다.
+              2. 닉네임 정책(예: 2~8자 한글/영문/숫자)을 준수해야 합니다.
             """)
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "탈퇴 성공",
-                    content = @Content(schema = @Schema(implementation = String.class, example = "회원 탈퇴가 완료되었습니다."))),
-            @ApiResponse(responseCode = "401", description = "인증 실패 (Access 토큰 필요)",
+            @ApiResponse(responseCode = "200", description = "닉네임 변경 성공",
+                    content = @Content(schema = @Schema(implementation = GlobalResponse.class))),
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 닉네임 형식",
+                    content = @Content),
+            @ApiResponse(responseCode = "401", description = "인증 실패 (토큰 누락 또는 만료)",
+                    content = @Content),
+            @ApiResponse(responseCode = "409", description = "이미 사용 중인 닉네임 (중복)",
                     content = @Content)
     })
     @SecurityRequirement(name = "bearerAuth")
-    @DeleteMapping("/withdraw") // DELETE /users/withdraw
-    ResponseEntity<GlobalResponse<WithdrawResDto>> withdrawUser(
+    @PatchMapping("/nickname")
+    ResponseEntity<GlobalResponse<UserNicknameResDto>> updateNickname(
             @Parameter(hidden = true) @AuthenticationPrincipal(expression = "userAuthDto.userId") Long userId,
-            @RequestBody @Valid WithdrawReqDto reqDto
+            @RequestBody @Valid UserNicknameUpdateReqDto reqDto
     );
 
+    @Operation(summary = "사용자 회원 탈퇴", description = """
+            현재 로그인된 사용자의 **계정을 삭제(탈퇴)** 처리합니다.
+            
+            - **기능**:
+              1. 사용자의 모든 식별 정보를 삭제하거나 비식별화(Anonymization) 처리합니다.
+              2. **Redis에 저장된 Refresh Token을 즉시 삭제**하여 모든 기기에서 로그아웃 시킵니다.
+              3. 발급받은 AccessToken의 jti를 Redis의 BlackList에 해당 Token의 유효시간동안 등록하여, 추가적인 접근을 막습니다. 
+              4. 해당 계정의 RefreshTokenBackup, AuthAccount 테이블의 레코드를 삭제함으로써, Recovery Token으로 Refresh Token을 재발급받지 못하게 합니다.
+              5. 더 이상 다른 사용자들은 해당 사용자에게 편지 작성, 친구 추가 등의 작업을 할 수 없습니다.   
+              6. 탈퇴된 계정은 7일 뒤 완전히 정보가 삭제됩니다. 
+            
+            - **주의**: 
+            탈퇴 처리된 계정은 복구가 불가능하며, 동일한 소셜 계정으로 재가입 시 신규 사용자로 처리됩니다.
+            계정 복구를 원할 시, 고객센터로 연락해 복구해야합니다.
+            """)
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "회원 탈퇴 성공 (Resource Deleted)",
+                    content = @Content(schema = @Schema(implementation = GlobalResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패",
+                    content = @Content),
+            @ApiResponse(responseCode = "404", description = "사용자 정보를 찾을 수 없음",
+                    content = @Content)
+    })
+    @SecurityRequirement(name = "bearerAuth")
+    @DeleteMapping("/withdraw")
+    ResponseEntity<GlobalResponse<Void>> withdrawAccount(
+            @Parameter(hidden = true) @AuthenticationPrincipal(expression = "userAuthDto.userId") Long userId
+    );
 
 }

--- a/src/main/java/com/example/egobook_be/domain/user/controller/UserControllerDocs.java
+++ b/src/main/java/com/example/egobook_be/domain/user/controller/UserControllerDocs.java
@@ -17,10 +17,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "User Controller", description = "사용자 관련 API")
 @RequestMapping("/users")
@@ -93,7 +90,7 @@ public interface UserControllerDocs {
               1. 사용자의 모든 식별 정보를 삭제하거나 비식별화(Anonymization) 처리합니다.
               2. **Redis에 저장된 Refresh Token을 즉시 삭제**하여 모든 기기에서 로그아웃 시킵니다.
               3. 발급받은 AccessToken의 jti를 Redis의 BlackList에 해당 Token의 유효시간동안 등록하여, 추가적인 접근을 막습니다. 
-              4. 해당 계정의 RefreshTokenBackup, AuthAccount 테이블의 레코드를 삭제함으로써, Recovery Token으로 Refresh Token을 재발급받지 못하게 합니다.
+              4. 해당 계정의 RefreshTokenBackup 테이블의 레코드를 삭제 및 사용자의 상태를 변화시킴으로써, Recovery Token으로 Refresh Token을 재발급받지 못하게 합니다.
               5. 더 이상 다른 사용자들은 해당 사용자에게 편지 작성, 친구 추가 등의 작업을 할 수 없습니다.   
               6. 탈퇴된 계정은 7일 뒤 완전히 정보가 삭제됩니다. 
             
@@ -112,7 +109,8 @@ public interface UserControllerDocs {
     @SecurityRequirement(name = "bearerAuth")
     @DeleteMapping("/withdraw")
     ResponseEntity<GlobalResponse<Void>> withdrawAccount(
-            @Parameter(hidden = true) @AuthenticationPrincipal(expression = "userAuthDto.userId") Long userId
+            @Parameter(hidden = true) @AuthenticationPrincipal(expression = "userAuthDto.userId") Long userId,
+            @Parameter(hidden = true) @RequestHeader("Authorization") String accessToken
     );
 
 }

--- a/src/main/java/com/example/egobook_be/domain/user/dto/UserNicknameResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/user/dto/UserNicknameResDto.java
@@ -1,0 +1,9 @@
+package com.example.egobook_be.domain.user.dto;
+
+import lombok.Builder;
+
+@Builder
+public record UserNicknameResDto(
+        String newNickname
+) {
+}

--- a/src/main/java/com/example/egobook_be/domain/user/dto/UserNicknameUpdateReqDto.java
+++ b/src/main/java/com/example/egobook_be/domain/user/dto/UserNicknameUpdateReqDto.java
@@ -1,0 +1,18 @@
+package com.example.egobook_be.domain.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record UserNicknameUpdateReqDto(
+        @Schema(description = "변경할 새로운 닉네임", example = "에고북123")
+        @NotBlank(message = "닉네임은 필수 입력 항목입니다.")
+        @Size(min = 2, max = 8, message = "닉네임은 2자 이상 8자 이하로 입력해주세요.")
+        @Pattern(
+                regexp = "^[a-zA-Z0-9가-힣]*$",
+                message = "닉네임은 한글, 영문, 숫자만 사용할 수 있으며 공백이나 특수문자는 허용되지 않습니다."
+        )
+        String nickname
+) {
+}

--- a/src/main/java/com/example/egobook_be/domain/user/entity/User.java
+++ b/src/main/java/com/example/egobook_be/domain/user/entity/User.java
@@ -135,12 +135,19 @@ public class User extends BaseTimeEntity {
     public void updateEmail(String newEmail) {this.email = newEmail;}
     /**
      * 사용자가 탈퇴를 수행했을 때, 바로 삭제하지 않고 실제 삭제 예정 날짜를 설정하는 함수입니다.
+     * (1) status -> WITHDRAW_PENDING
+     * (2) deletedAt(삭제 요청 시각) 최신화
+     * (3) purgeAt(완전 삭제 예정 시각) 최신화
+     * (4) dailPraise (AI 칭찬서 수신 여부) false
+     * (5) notificationEnabled (알림 설정) false
      * @param purgeDurationInMs : 완전 삭제까지의 기간(일주일)
      */
-    public void deleteUser(Long purgeDurationInMs) {
-        this.status = UserStatus.DELETED_PENDING;
+    public void withdrawUser(Long purgeDurationInMs) {
+        this.status = UserStatus.WITHDRAW_PENDING;
         this.deletedAt = LocalDateTime.now();
         this.purgeAt = this.deletedAt.plus(purgeDurationInMs, ChronoUnit.MILLIS);
+        this.dailyPraise = false;
+        this.notificationEnabled = false;
     }
 
     public void addInk(int amount) {

--- a/src/main/java/com/example/egobook_be/domain/user/enums/UserErrorCode.java
+++ b/src/main/java/com/example/egobook_be/domain/user/enums/UserErrorCode.java
@@ -9,6 +9,11 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum UserErrorCode implements BaseErrorCode {
     /*
+     * 400
+     */
+    ALREADY_WITHDRAW_PENDING(HttpStatus.CONFLICT, "해당 사용자는 이미 탈퇴 대기 상태입니다."),
+
+    /*
      * 404 NOT FOUND
      */
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾지 못했습니다."),

--- a/src/main/java/com/example/egobook_be/domain/user/enums/UserStatus.java
+++ b/src/main/java/com/example/egobook_be/domain/user/enums/UserStatus.java
@@ -3,6 +3,6 @@ package com.example.egobook_be.domain.user.enums;
 public enum UserStatus {
     ACTIVE,         // 활동 중
     DORMANT,        // 휴면
-    DELETED_PENDING,// 삭제 대기 (완전 삭제 전 유예 기간)
-    DELETED         // 삭제됨
+    WITHDRAW_PENDING,// 탈퇴 대기 (완전 삭제 전 유예 기간)
+    WITHDRAW         // 탈퇴됨
 }

--- a/src/main/java/com/example/egobook_be/domain/user/repository/AbilityRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/user/repository/AbilityRepository.java
@@ -5,9 +5,11 @@ import com.example.egobook_be.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface AbilityRepository extends JpaRepository<Ability, Long> {
     Optional<Ability> findByUser(User user);
+    void deleteByUserIn(List<User> users);
 }

--- a/src/main/java/com/example/egobook_be/domain/user/repository/InkLogRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/user/repository/InkLogRepository.java
@@ -4,10 +4,18 @@ import com.example.egobook_be.domain.user.entity.InkLog;
 import com.example.egobook_be.domain.user.entity.InkLogType;
 import com.example.egobook_be.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Repository
 public interface InkLogRepository extends JpaRepository<InkLog, Long> {
     boolean existsByUserAndReasonAndCreatedAtAfter(User user, InkLogType reason, LocalDateTime startOfDay);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM InkLog i WHERE i.user IN :users")
+    void bulkDeleteByUserIn(@Param("users") List<User> users);
 }

--- a/src/main/java/com/example/egobook_be/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/user/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package com.example.egobook_be.domain.user.repository;
 
 import com.example.egobook_be.domain.user.entity.User;
+import com.example.egobook_be.domain.user.enums.UserStatus;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
@@ -9,6 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -43,6 +45,9 @@ public interface UserRepository extends JpaRepository<User, Long>,UserRepository
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select u from User u where u.id = :userId")
     Optional<User> findByIdWithLock(@Param("userId") Long userId);
+
+    /** 삭제 대상 유저 조회 (PurgeAt이 현재 시간보다 과거인 경우) */
+    List<User> findByStatusAndPurgeAtBefore(UserStatus status, LocalDateTime now);
 
     // 수신에 동의한 유저만 조회
     List<User> findByDailyPraiseTrue();

--- a/src/main/java/com/example/egobook_be/domain/user/service/UserService.java
+++ b/src/main/java/com/example/egobook_be/domain/user/service/UserService.java
@@ -17,6 +17,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -67,18 +70,31 @@ public class UserService {
         user.withdrawUser(purgeDurationInMs);
 
         // 4. 발급 받은 Access Token JTI Redis BlackList에 등록
-        redisUtil.setTokenInBlacklist(accessToken);
+
+        redisUtil.setTokenInBlacklist(resolveToken(accessToken));
 
         /*
          * 5. Redis에 저장된 Refresh Token 즉시 삭제 & 사용자와 연관된 RefreshTokenBackup 테이블 데이터 삭제
          * - 만약 refreshTokenBackup 테이블에 해당 내용이 없더라도, 회원탈퇴 로직을 계속해서 수행해야함
          * - 해당 사용자와 연관된 AuthAccount는 아직 삭제하지 않는다.(7일 뒤 스케줄러로 삭제한다)
          */
-        refreshTokenBackupRepository.findByAuthAccount(userAuthAccount)
-                .ifPresent(backup -> {
-                    redisUtil.deleteHashedRefreshToken(backup.getHashedTokenValue());
-                    refreshTokenBackupRepository.delete(backup);
-                });
+        List<RefreshTokenBackup> backups = refreshTokenBackupRepository.findAllByAuthAccount(userAuthAccount);
+
+        // 5-1. Redis에서 각 토큰 삭제 (반복문)
+        for (RefreshTokenBackup backup : backups) {
+            redisUtil.deleteHashedRefreshToken(backup.getHashedTokenValue());
+        }
+
+        // 5-2. orphanRemoval 설정 활용하여 refreshTokenBackup 객체 삭제
+        userAuthAccount.updateRefreshTokenBackup(null);
+
+    }
+
+    private String resolveToken(String token) {
+        if (StringUtils.hasText(token) && token.startsWith("Bearer ")) {
+            return token.substring(7);
+        }
+        return token;
     }
 
 

--- a/src/main/java/com/example/egobook_be/domain/user/service/UserService.java
+++ b/src/main/java/com/example/egobook_be/domain/user/service/UserService.java
@@ -1,12 +1,20 @@
 package com.example.egobook_be.domain.user.service;
 
+import com.example.egobook_be.domain.auth.entity.AuthAccount;
+import com.example.egobook_be.domain.auth.entity.RefreshTokenBackup;
+import com.example.egobook_be.domain.auth.enums.AuthErrorCode;
+import com.example.egobook_be.domain.auth.repository.AuthAccountRepository;
+import com.example.egobook_be.domain.auth.repository.RefreshTokenBackupRepository;
 import com.example.egobook_be.domain.user.dto.UserNicknameResDto;
 import com.example.egobook_be.domain.user.dto.UserNicknameUpdateReqDto;
 import com.example.egobook_be.domain.user.entity.User;
 import com.example.egobook_be.domain.user.enums.UserErrorCode;
+import com.example.egobook_be.domain.user.enums.UserStatus;
 import com.example.egobook_be.domain.user.repository.UserRepository;
 import com.example.egobook_be.global.exception.CustomException;
+import com.example.egobook_be.global.util.RedisUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,6 +22,12 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
+    private final AuthAccountRepository authAccountRepository;
+    private final RefreshTokenBackupRepository refreshTokenBackupRepository;
+    private final RedisUtil redisUtil;
+
+    @Value("${app.data.purge-duration-in-ms}")
+    private Long purgeDurationInMs;
 
     @Transactional
     public UserNicknameResDto updateNickname(Long userId, UserNicknameUpdateReqDto reqDto) {
@@ -25,4 +39,47 @@ public class UserService {
 
         return UserNicknameResDto.builder().newNickname(user.getNickname()).build();
     }
+
+    /**
+     * 회원 탈퇴 로직을 수행하는 함수 (Soft Delete + 사용자 인증 데이터 삭제)
+     * @param userId 탈퇴한 사용자 ID
+     * @param accessToken 현재 요청에 사용된 Access Token
+     */
+    @Transactional
+    public void withDrawAccount(Long userId, String accessToken){
+        // 1. 사용자 인스턴스 가져오기 (비관적 락), 해당 사용자의 인증 정보 가져오기
+        User user = userRepository.findByIdWithLock(userId).orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+        AuthAccount userAuthAccount = authAccountRepository.findByUser(user).orElseThrow(() -> new CustomException(AuthErrorCode.USER_AUTH_ACCOUNT_NOT_FOUND));
+
+        // 2. 이미 탈퇴 대기 중인 상태인지 확인(멱등성 보장)
+        if(user.getStatus().equals(UserStatus.WITHDRAW_PENDING)){
+            throw new CustomException(UserErrorCode.ALREADY_WITHDRAW_PENDING);
+        }
+
+        /*
+         * 3. 해당 사용자 상태 최신화(비식별화)
+         * (1) status -> WITHDRAW_PENDING
+         * (2) deletedAt(삭제 요청 시각) 최신화
+         * (3) purgeAt(완전 삭제 예정 시각) 최신화
+         * (4) dailPraise (AI 칭찬서 수신 여부) false
+         * (5) notificationEnabled (알림 설정) false
+         */
+        user.withdrawUser(purgeDurationInMs);
+
+        // 4. 발급 받은 Access Token JTI Redis BlackList에 등록
+        redisUtil.setTokenInBlacklist(accessToken);
+
+        /*
+         * 5. Redis에 저장된 Refresh Token 즉시 삭제 & 사용자와 연관된 RefreshTokenBackup 테이블 데이터 삭제
+         * - 만약 refreshTokenBackup 테이블에 해당 내용이 없더라도, 회원탈퇴 로직을 계속해서 수행해야함
+         * - 해당 사용자와 연관된 AuthAccount는 아직 삭제하지 않는다.(7일 뒤 스케줄러로 삭제한다)
+         */
+        refreshTokenBackupRepository.findByAuthAccount(userAuthAccount)
+                .ifPresent(backup -> {
+                    redisUtil.deleteHashedRefreshToken(backup.getHashedTokenValue());
+                    refreshTokenBackupRepository.delete(backup);
+                });
+    }
+
+
 }

--- a/src/main/java/com/example/egobook_be/domain/user/service/UserService.java
+++ b/src/main/java/com/example/egobook_be/domain/user/service/UserService.java
@@ -1,0 +1,28 @@
+package com.example.egobook_be.domain.user.service;
+
+import com.example.egobook_be.domain.user.dto.UserNicknameResDto;
+import com.example.egobook_be.domain.user.dto.UserNicknameUpdateReqDto;
+import com.example.egobook_be.domain.user.entity.User;
+import com.example.egobook_be.domain.user.enums.UserErrorCode;
+import com.example.egobook_be.domain.user.repository.UserRepository;
+import com.example.egobook_be.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+
+    @Transactional
+    public UserNicknameResDto updateNickname(Long userId, UserNicknameUpdateReqDto reqDto) {
+        // 1. User 가져오기
+        User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+
+        // 2. 닉네임 업데이트 (해당 닉네임의 스타일은 이미 Dto 레벨에서 검증되었음)
+        user.updateNickname(reqDto.nickname());
+
+        return UserNicknameResDto.builder().newNickname(user.getNickname()).build();
+    }
+}

--- a/src/main/java/com/example/egobook_be/global/scheduler/DailySchedular.java
+++ b/src/main/java/com/example/egobook_be/global/scheduler/DailySchedular.java
@@ -10,6 +10,7 @@ import com.example.egobook_be.domain.letters.entity.PlazaLetterReplyReport;
 import com.example.egobook_be.domain.letters.repository.PlazaLetterReplyReportRepository;
 import com.example.egobook_be.domain.letters.repository.PlazaLetterReplyRepository;
 import com.example.egobook_be.domain.letters.repository.PlazaLetterRepository;
+import com.example.egobook_be.domain.letters.repository.PlazaLetterThreadRepository;
 import com.example.egobook_be.domain.notification.repository.NotificationRepository;
 import com.example.egobook_be.domain.psychology.repository.UserKnowledgeRepository;
 import com.example.egobook_be.domain.question.repository.QuestionAnswerRepository;
@@ -49,6 +50,7 @@ public class DailySchedular {
     private final UserKnowledgeRepository userKnowledgeRepository;
     private final QuestionAnswerRepository questionAnswerRepository;
     private final InkLogRepository inkLogRepository;
+    private final PlazaLetterThreadRepository plazaLetterThreadRepository;
 
     /**
      * 모든 사용자들의 일일 미션을 초기화하는 스케줄러 함수
@@ -82,7 +84,7 @@ public class DailySchedular {
      * 사용자들 중 purgeAt이 지난 사용자 데이터들을 모두 삭제하는 스케줄러
      * - 매일 자정(00:00:00)에 실행
      */
-    @Scheduled(cron = "0 0 0 * * *")
+    @Scheduled(cron = "10 17 17 * * *")
     @Transactional
     public void purgeUsers() {
         log.info("🕛 [DailySchedular] 탈퇴한 사용자들의 정보들 일괄 삭제 작업 시작");
@@ -164,10 +166,13 @@ public class DailySchedular {
          * (1) 탈퇴하는 user가 보낸(Sender) 편지의 senderId를 Null로 변경
          * (2) 탈퇴하는 user가 받은(Receiver) 편지의 receiverId를 null로 변경
          * (3) Sender, Receiver가 모두 null이 된(양쪽 다 탈퇴한) 편지는 DB에서 삭제
+         * (4) 편지가 모두 삭제되어, 자식 객체들이 모두 사라져버린 Thread 삭제
          */
         plazaLetterRepository.bulkNullifySenderId(users.stream().map(User::getId).toList());
         plazaLetterRepository.bulkNullifyReceiverId(users.stream().map(User::getId).toList());
         plazaLetterRepository.bulkDeleteOrphanedLetters();
+        plazaLetterThreadRepository.bulkDeleteEmptyThreads();
+
 
         // 11. 사용자가 받은 알림 정보 삭제
         notificationRepository.bulkDeleteByUserIn(users);

--- a/src/main/java/com/example/egobook_be/global/scheduler/DailySchedular.java
+++ b/src/main/java/com/example/egobook_be/global/scheduler/DailySchedular.java
@@ -1,6 +1,25 @@
 package com.example.egobook_be.global.scheduler;
 
+import com.example.egobook_be.domain.auth.repository.AuthAccountRepository;
+import com.example.egobook_be.domain.auth.repository.RefreshTokenBackupRepository;
+import com.example.egobook_be.domain.diary.repository.DiaryRepository;
+import com.example.egobook_be.domain.friend.repository.FriendRepository;
+import com.example.egobook_be.domain.friend.repository.FriendRequestRepository;
 import com.example.egobook_be.domain.home.repository.MissionRepository;
+import com.example.egobook_be.domain.letters.entity.PlazaLetterReplyReport;
+import com.example.egobook_be.domain.letters.repository.PlazaLetterReplyReportRepository;
+import com.example.egobook_be.domain.letters.repository.PlazaLetterReplyRepository;
+import com.example.egobook_be.domain.letters.repository.PlazaLetterRepository;
+import com.example.egobook_be.domain.notification.repository.NotificationRepository;
+import com.example.egobook_be.domain.psychology.repository.UserKnowledgeRepository;
+import com.example.egobook_be.domain.question.repository.QuestionAnswerRepository;
+import com.example.egobook_be.domain.shop.mapper.UserItemMapper;
+import com.example.egobook_be.domain.shop.repository.UserItemRepository;
+import com.example.egobook_be.domain.terms.repository.UserTermRepository;
+import com.example.egobook_be.domain.user.entity.User;
+import com.example.egobook_be.domain.user.enums.UserStatus;
+import com.example.egobook_be.domain.user.repository.AbilityRepository;
+import com.example.egobook_be.domain.user.repository.InkLogRepository;
 import com.example.egobook_be.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -8,12 +27,28 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class DailySchedular {
+    private final RefreshTokenBackupRepository refreshTokenBackupRepository;
     private final MissionRepository missionRepository;
     private final UserRepository userRepository;
+    private final AuthAccountRepository authAccountRepository;
+    private final UserTermRepository userTermRepository;
+    private final DiaryRepository diaryRepository;
+    private final FriendRepository friendRepository;
+    private final FriendRequestRepository friendRequestRepository;
+    private final PlazaLetterReplyReportRepository plazaLetterReplyReportRepository;
+    private final PlazaLetterReplyRepository plazaLetterReplyRepository;
+    private final NotificationRepository notificationRepository;
+    private final PlazaLetterRepository plazaLetterRepository;
+    private final UserKnowledgeRepository userKnowledgeRepository;
+    private final QuestionAnswerRepository questionAnswerRepository;
+    private final InkLogRepository inkLogRepository;
 
     /**
      * 모든 사용자들의 일일 미션을 초기화하는 스케줄러 함수
@@ -42,4 +77,109 @@ public class DailySchedular {
         long endTime = System.currentTimeMillis();
         log.info("🕛 [DailySchedular] 사용자 일일 출석 보상 설정 작업 종료. (소요시간: {}ms)", endTime-startTime);
     }
+
+    /**
+     * 사용자들 중 purgeAt이 지난 사용자 데이터들을 모두 삭제하는 스케줄러
+     * - 매일 자정(00:00:00)에 실행
+     */
+    @Scheduled(cron = "0 0 0 * * *")
+    @Transactional
+    public void purgeUsers() {
+        log.info("🕛 [DailySchedular] 탈퇴한 사용자들의 정보들 일괄 삭제 작업 시작");
+        long startTime = System.currentTimeMillis();
+
+        // 1. 삭제 대상 조회 (삭제 예정일이 지났고, 상태가 WITHDRAW_PENDING인 유저)
+        LocalDateTime now = LocalDateTime.now();
+        List<User> targetUsers = userRepository.findByStatusAndPurgeAtBefore(UserStatus.WITHDRAW_PENDING, now);
+
+        if (targetUsers.isEmpty()) {
+            log.info("🕛 [DailySchedular] 삭제 대상이 없습니다. 작업을 종료합니다.");
+            return;
+        }
+
+        // 2. 삭제 대상들 전부 삭제
+        int count = targetUsers.size();
+        deleteUsers(targetUsers);
+
+        long endTime = System.currentTimeMillis();
+        log.info("🕛 [DailySchedular] 총 {}명의 사용자 및 연관 데이터 삭제 완료. (소요시간: {}ms)", count, endTime - startTime);
+    }
+
+    /**
+     * 사용자들과 연관된 데이터들을 모두 삭제하는 함수
+     * [ 삭제 순서 ]
+     * (0) Refresh Token Backup 테이블 삭제 (RefreshTokenBackup)
+     * (1) 사용자 인증 정보 삭제 (AuthAccount)
+     * (2) 사용자 약관 정보 삭제 (UserTerm)
+     * (3) 사용자가 보유한 아이템 삭제 (UserItem)
+     * (4) 사용자가 작성한 일기 삭제 (Diary)
+     * (5) 사용자의 친구 연결 삭제 (Friend) -> 해당 친구가 기준 사용자인 레코드도 삭제
+     * (6) 사용자가 보낸/받은 친구 연결 신청 삭제 (FriendRequest)
+     * (7) 사용자의 미션 상태 정보 삭제 (Mission)
+     * (8) 사용자가 신고한 편지 답장 정보 삭제 (PlazaLetterReplyReport)
+     * (9) 사용자가 답장한 편지 정보에서 Replier(답장자) 비식별화 (PlazaLetterReply) -> Replier가 탈퇴하면 답장을 지우지 않고, PlazaLetterReply.replierId를 null로 만든다.
+     * (10) 사용자가 작성한 편지 정보 삭제 (PlazaLetter) -> Thread는 삭제하지 않음.
+     * (11) 사용자가 받은 알림 정보 삭제 (Notification)
+     * (12) 사용자가 받은 오늘의 심리지식 정보들 삭제 (UserKnowledge)
+     * (13) 사용자가 작성한 오늘의 질문에 대한 답변들 삭제 (QuestionAnswer)
+     * (14) 사용자의 능력치 정보 삭제 (Ability)
+     * (15) 사용자의 Ink 획득 기록 삭제 (InkLog)
+     * (16) 최종 사용자 정보 삭제 (User)
+     */
+    private void deleteUsers(List<User> users) {
+        refreshTokenBackupRepository.bulkDeleteByAuthAccountUserIn(users);
+        // 1. 사용자 인증 정보 삭제 (AuthAccount)
+        authAccountRepository.bulkDeleteByUserIn(users);
+        // 2. 사용자 약관 정보 삭제
+        userTermRepository.bulkDeleteByUserIn(users);
+        // 3. 사용자가 보유한 아이템 삭제(Cascade로 처리됨)
+        // 4. 사용자가 작성한 일기 삭제
+        diaryRepository.bulkDeleteByUserIn(users);
+        /*
+         * 5. 사용자의 친구 연결 삭제 (해당 친구가 기준 사용자인 레코드도 삭제)
+         * - 내가 user_id(기준 사용자)이거나, 내가 friend_id(친구)인 모든 데이터를 삭제한다.
+         */
+        friendRepository.bulkDeleteByUsersInOrFriendsIn(users, users);
+        // 6. 해당 사용자가 보낸/받은 친구 연결 신청 삭제
+        friendRequestRepository.bulkDeleteBySenderInOrReceiverIn(users, users);
+        // 7. 사용자의 미션 상태 정보 삭제
+        missionRepository.bulkDeleteByUserIn(users);
+        /*
+         * 8. 사용자가 신고한 편지 답장 정보 삭제
+         * (1) 본인이 신고한(Reporter) 레코드만 삭제하고, 본인이 신고당한 레코드는 삭제하지 않는다.
+         * (2) 본인이 신고당한(Replier) 레코드의 replierId값은 null로 설정해주어야 한다.
+         */
+        plazaLetterReplyReportRepository.bulkDeleteByReporterIdIn(users.stream().map(User::getId).toList());
+        plazaLetterReplyReportRepository.bulkNullifyReplierId(users.stream().map(User::getId).toList());
+        /*
+         * 9. 사용자가 답장한 편지 정보
+         * - 사용자가 답장한 편지 정보에서 Replier(답장자) 비식별화
+         * - Replier가 탈퇴하면 답장을 지우지 않고, PlazaLetterReply.replierId를 null로 만든다
+         * => replier가 null이 된 답변 객체는, 해당 편지 작성자가 회원탈퇴를 할 때 해당 사용자가 작성한 편지 정보들이 삭제되면서 같이 삭제된다.
+         */
+        plazaLetterReplyRepository.bulkNullifyReplierId(users.stream().map(User::getId).toList());
+
+        /*
+         * 10. 사용자가 작성한 편지 정보 비식별화 OR 삭제
+         * (1) 탈퇴하는 user가 보낸(Sender) 편지의 senderId를 Null로 변경
+         * (2) 탈퇴하는 user가 받은(Receiver) 편지의 receiverId를 null로 변경
+         * (3) Sender, Receiver가 모두 null이 된(양쪽 다 탈퇴한) 편지는 DB에서 삭제
+         */
+        plazaLetterRepository.bulkNullifySenderId(users.stream().map(User::getId).toList());
+        plazaLetterRepository.bulkNullifyReceiverId(users.stream().map(User::getId).toList());
+        plazaLetterRepository.bulkDeleteOrphanedLetters();
+
+        // 11. 사용자가 받은 알림 정보 삭제
+        notificationRepository.bulkDeleteByUserIn(users);
+        // 12. 사용자가 받은 오늘의 심리지식 정보들 삭제
+        userKnowledgeRepository.bulkDeleteByUserIn(users);
+        // 13. 사용자가 작성한 오늘의 질문에 대한 답변들
+        questionAnswerRepository.bulkDeleteByUserIn(users);
+        // 14. 사용자의 능력치 정보 삭제 (Cascade로 처리됨)
+        // 15. 사용자의 Ink 획득 기록 삭제
+        inkLogRepository.bulkDeleteByUserIn(users);
+        // 16. 최종 사용자 정보 삭제
+        userRepository.deleteAll(users);
+    }
+
 }

--- a/src/main/java/com/example/egobook_be/global/scheduler/DailySchedular.java
+++ b/src/main/java/com/example/egobook_be/global/scheduler/DailySchedular.java
@@ -84,7 +84,7 @@ public class DailySchedular {
      * 사용자들 중 purgeAt이 지난 사용자 데이터들을 모두 삭제하는 스케줄러
      * - 매일 자정(00:00:00)에 실행
      */
-    @Scheduled(cron = "10 17 17 * * *")
+    @Scheduled(cron = "0 0 0 * * *")
     @Transactional
     public void purgeUsers() {
         log.info("🕛 [DailySchedular] 탈퇴한 사용자들의 정보들 일괄 삭제 작업 시작");

--- a/src/main/java/com/example/egobook_be/global/security/JwtAuthFilter.java
+++ b/src/main/java/com/example/egobook_be/global/security/JwtAuthFilter.java
@@ -76,32 +76,29 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         }
 
         try {
-            // 2. 토큰 유효성 검증 (위조, 만료 등 확인)
-            if (jwtUtil.validateToken(token)) {
-                /*
-                 * 3. JwtTokenType을 가져와 Access Token인지 확인한다.
-                 * - Refresh Token으로는 API 접근이 불가하도록 설정한다.
-                 * - Access Token이 아닌 다른 토큰(Refresh, Recover)으로 요청이 왔다면 에러 로그 & 예외를 발생시킨다.
-                 */
-                JwtTokenType type = jwtUtil.getTokenType(token);
-                if (!JwtTokenType.ACCESS.equals(type)) {
-                    log.warn("Access Token이 아닌 토큰으로 접근 시도. Type: {}", type);
-                    throw new CustomException(AuthErrorCode.ACCESS_WITH_NON_ACCESS_TYPE_TOKEN);
-                }
-
-                // 4. 해당 Access Token이 Redis의 블랙리스트에 존재하는지 확인한다.
-                if(redisUtil.checkTokenInBlacklist(token)){
-                    log.warn("[Redis] BlackList에 등록된 Access Token으로 접근이 시도되었습니다. Token: {}", token);
-                    throw new CustomException(AuthErrorCode.BLACKLISTED_TOKEN);
-                }
-
-                // 5. DB 조회 없이 토큰 정보만으로 인증 객체 생성
-                Authentication authentication = createAuthentication(token);
-
-                // 6. SecurityContext에 저장
-                SecurityContextHolder.getContext().setAuthentication(authentication);
-                log.debug("Security Context에 인증 정보를 저장했습니다: {}", authentication.getName());
+            /*
+             * 3. JwtTokenType을 가져와 Access Token인지 확인한다.
+             * - Refresh Token으로는 API 접근이 불가하도록 설정한다.
+             * - Access Token이 아닌 다른 토큰(Refresh, Recover)으로 요청이 왔다면 에러 로그 & 예외를 발생시킨다.
+             */
+            JwtTokenType type = jwtUtil.getTokenType(token);
+            if (!JwtTokenType.ACCESS.equals(type)) {
+                log.warn("Access Token이 아닌 토큰으로 접근 시도. Type: {}", type);
+                throw new CustomException(AuthErrorCode.ACCESS_WITH_NON_ACCESS_TYPE_TOKEN);
             }
+
+            // 4. 해당 Access Token이 Redis의 블랙리스트에 존재하는지 확인한다.
+            if(redisUtil.checkTokenInBlacklist(token)){
+                log.warn("[Redis] BlackList에 등록된 Access Token으로 접근이 시도되었습니다. Token: {}", token);
+                throw new CustomException(AuthErrorCode.BLACKLISTED_TOKEN);
+            }
+
+            // 5. DB 조회 없이 토큰 정보만으로 인증 객체 생성
+            Authentication authentication = createAuthentication(token);
+
+            // 6. SecurityContext에 저장
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            log.debug("Security Context에 인증 정보를 저장했습니다: {}", authentication.getName());
         } catch (CustomException e) {
             log.error("인증 처리 중 비즈니스 예외 발생: {}", e.getMessage());
             request.setAttribute("exception", e); // EntryPoint에서 처리하도록 속성 저장

--- a/src/main/java/com/example/egobook_be/global/security/JwtAuthFilter.java
+++ b/src/main/java/com/example/egobook_be/global/security/JwtAuthFilter.java
@@ -6,6 +6,7 @@ import com.example.egobook_be.domain.user.enums.RoleType;
 import com.example.egobook_be.global.enums.JwtTokenType;
 import com.example.egobook_be.global.exception.CustomException;
 import com.example.egobook_be.global.util.JwtUtil;
+import com.example.egobook_be.global.util.RedisUtil;
 import com.example.egobook_be.global.util.module.UserAuthDto;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -13,6 +14,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
@@ -36,6 +38,7 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class JwtAuthFilter extends OncePerRequestFilter {
     private final JwtUtil jwtUtil;
+    private final RedisUtil redisUtil;
     private final CustomUserDetailService customUserDetailService;
     private final AuthenticationEntryPoint authenticationEntryPoint; // 예외 처리를 위한 클래스
     private static final String AUTHORIZATION_HEADER = "Authorization"; // HTTP 헤더 키
@@ -86,10 +89,16 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                     throw new CustomException(AuthErrorCode.ACCESS_WITH_NON_ACCESS_TYPE_TOKEN);
                 }
 
-                // 4. DB 조회 없이 토큰 정보만으로 인증 객체 생성
+                // 4. 해당 Access Token이 Redis의 블랙리스트에 존재하는지 확인한다.
+                if(redisUtil.checkTokenInBlacklist(token)){
+                    log.warn("[Redis] BlackList에 등록된 Access Token으로 접근이 시도되었습니다. Token: {}", token);
+                    throw new CustomException(AuthErrorCode.BLACKLISTED_TOKEN);
+                }
+
+                // 5. DB 조회 없이 토큰 정보만으로 인증 객체 생성
                 Authentication authentication = createAuthentication(token);
 
-                // 5. SecurityContext에 저장
+                // 6. SecurityContext에 저장
                 SecurityContextHolder.getContext().setAuthentication(authentication);
                 log.debug("Security Context에 인증 정보를 저장했습니다: {}", authentication.getName());
             }
@@ -97,12 +106,14 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             log.error("인증 처리 중 비즈니스 예외 발생: {}", e.getMessage());
             request.setAttribute("exception", e); // EntryPoint에서 처리하도록 속성 저장
             authenticationEntryPoint.commence(request, response, new AuthenticationException(e.getMessage(), e) {});
+            return; // 여기서 끝내야지, 아래의 doFilter가 실행되지 않음 (Double Response 방지)
         } catch (Exception e) {
             log.error("인증 필터 내부 시스템 오류: {}", e.getMessage());
             request.setAttribute("exception", e);
             authenticationEntryPoint.commence(request, response, new AuthenticationException(e.getMessage(), e) {});
+            return; // 여기서 끝내야지, 아래의 doFilter가 실행되지 않음 (Double Response 방지)
         }
-        // 8. 다음 필터로 요청 전달
+        // 7. 다음 필터로 요청 전달
         filterChain.doFilter(request, response);
     }
 

--- a/src/main/java/com/example/egobook_be/global/util/JwtUtil.java
+++ b/src/main/java/com/example/egobook_be/global/util/JwtUtil.java
@@ -311,13 +311,16 @@ public class JwtUtil {
             return true;
         } catch (SecurityException | MalformedJwtException e) {
             log.error("유효하지 않은 JWT 서명입니다: {}", e.getMessage());
+            return false;
         } catch (ExpiredJwtException e) {
             log.error("만료된 JWT 토큰입니다: {}", e.getMessage());
+            return false;
         } catch (UnsupportedJwtException e) {
             log.error("지원되지 않는 JWT 토큰입니다: {}", e.getMessage());
+            return false;
         } catch (IllegalArgumentException e) {
             log.error("JWT 토큰이 잘못되었습니다: {}", e.getMessage());
+            return false;
         }
-        return false;
     }
 }

--- a/src/main/java/com/example/egobook_be/global/util/JwtUtil.java
+++ b/src/main/java/com/example/egobook_be/global/util/JwtUtil.java
@@ -262,6 +262,15 @@ public class JwtUtil {
     }
 
     /**
+     * 해당 토큰의 만료 MS 시간을 반환하는 함수
+     */
+    public long getExpirationInMs(String token) {
+        // 1. Claims 객체의 내장 메서드 getExpiration(), JWT의 exp(초) 값을 Date 객체로 변환함
+        Date expirationDate = getPayload(token).getExpiration();
+        // 2. Date 객체의 getTime()은 해당 시간을 ms 단위로 반환함
+        return expirationDate.getTime();
+    }
+    /**
      * JWT Token에서 Claims를 추출하는 함수
      * @param token JWT Token
      * @return

--- a/src/main/java/com/example/egobook_be/global/util/RedisUtil.java
+++ b/src/main/java/com/example/egobook_be/global/util/RedisUtil.java
@@ -76,6 +76,7 @@ public class RedisUtil {
         String key = "RT:" + hashedRefreshToken;
         if (!redisTemplate.hasKey(key)) {return;} // 해당 RefreshToken이 Redis에 없으면 굳이 delete하지 않음
         redisTemplate.delete(key); //
+        log.info("[Redis] HashedRefreshToken이 Redis에서 삭제되었습니다. {}", hashedRefreshToken);
     }
 
     /**

--- a/src/main/java/com/example/egobook_be/global/util/RedisUtil.java
+++ b/src/main/java/com/example/egobook_be/global/util/RedisUtil.java
@@ -4,12 +4,15 @@ import com.example.egobook_be.global.util.module.RedisValue;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Component;
 
+import java.security.SignatureException;
 import java.time.Duration;
 
 /**
@@ -93,27 +96,35 @@ public class RedisUtil {
      * - TTL: 해당 토큰의 만료까지 남은 시간
      */
     public void setTokenInBlacklist(String token) {
-        // 1. Redis에 등록할 Key, Value, Ttl 선언
-        String key = "BL:" + jwtUtil.getJtiFromToken(token);
-        String value = jwtUtil.getTokenType(token).name();
-        long ttl = jwtUtil.getExpirationInMs(token) - System.currentTimeMillis();
+        try{
+            // 1. Redis에 등록할 Key, Value, Ttl 선언
+            String key = "BL:" + jwtUtil.getJtiFromToken(token);
+            String value = jwtUtil.getTokenType(token).name();
+            long ttl = jwtUtil.getExpirationInMs(token) - System.currentTimeMillis();
 
-        // 2. 이미 만료된 토큰인지 확인
-        if(ttl <= 0) {
-            log.warn("[Redis] 이미 만료된 Token이 블랙리스트 요청됨 - jti: {}", key);
-            return;
+            // 2. 이미 만료된 토큰인지 확인
+            if(ttl <= 0) {
+                log.warn("[Redis] 이미 만료된 Token이 블랙리스트 요청됨 - jti: {}", key);
+                return;
+            }
+
+            // 3. 해당 Key가 이미 Redis에 존재하는지 확인
+            boolean hasKey = redisTemplate.hasKey(key);
+            if(hasKey) { return; }
+            /*
+             * 4. 해당 Key:Value Redis에 등록
+             * - opsForValue(): Redis String(단일 값, Key:Value) 구조의 자료구조를 반환하는 함수
+             */
+            redisTemplate.opsForValue()
+                    .set(key, value, Duration.ofMillis(ttl));
+            log.info("[Redis] Token Redis BlackList에 등록 완료: {}, TTL - {}ms", key, ttl);
+        } catch (MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
+            // [보안] 위조되거나 손상된 토큰은 JTI를 추출할 수 없으므로 등록 불가 -> 로그 남기고 무시
+            log.warn("[Redis] 잘못된 형식의 토큰 블랙리스트 등록 시도됨: {}", e.getMessage());
+        } catch (Exception e) {
+            // 그 외 알 수 없는 에러
+            log.error("[Redis] 블랙리스트 등록 중 시스템 에러 발생: {}", e.getMessage());
         }
-
-        // 3. 해당 Key가 이미 Redis에 존재하는지 확인
-        boolean hasKey = redisTemplate.hasKey(key);
-        if(hasKey) { return; }
-        /*
-         * 4. 해당 Key:Value Redis에 등록
-         * - opsForValue(): Redis String(단일 값, Key:Value) 구조의 자료구조를 반환하는 함수
-         */
-        redisTemplate.opsForValue()
-                .set(key, value, Duration.ofMillis(ttl));
-        log.info("[Redis] Token Redis BlackList에 등록 완료: {}, TTL - {}ms", key, ttl);
     }
 
     /**

--- a/src/main/java/com/example/egobook_be/global/util/RedisUtil.java
+++ b/src/main/java/com/example/egobook_be/global/util/RedisUtil.java
@@ -21,14 +21,18 @@ import java.time.Duration;
 public class RedisUtil {
     private final StringRedisTemplate redisTemplate; // Redis의 Key, Value가 모두 문자열일 때 사용하는 템플릿
     private final ObjectMapper objectMapper;
+    private final JwtUtil jwtUtil;
 
+    // ==========================================================
+    // [ Refresh Token ]
+    // ==========================================================
     /**
      * 1. Refresh Token 정보 저장 (Set)
      * - Key: "RT:{hashedRefreshToken}" (Prefix를 붙여 관리 용이성 확보)
      * - Value: Value로 들어갈 Json 형태의 데이터들
      * - TTL: 만료 시간까지 남은 시간만큼 설정
      */
-    public void setRefreshTokenValue(String hashedRefreshToken, RedisValue value, long durationInMillis) {
+    public void setHashedRefreshTokenValue(String hashedRefreshToken, RedisValue value, long durationInMillis) {
         String key = "RT:" + hashedRefreshToken;
         try {
             String jsonValue = objectMapper.writeValueAsString(value);  // json 값을 String으로 변환한다.
@@ -44,7 +48,7 @@ public class RedisUtil {
      * 2. Refresh Token 정보 조회 (Get)
      * 해당 hashedRefreshToken으로 Redis에서 정보를 찾지 못하면 null을 반환한다.
      */
-    public RedisValue getRefreshTokenValue(String hashedRefreshToken) {
+    public RedisValue getHashedRefreshTokenValue(String hashedRefreshToken) {
         String key = "RT:" + hashedRefreshToken;
         ValueOperations<String, String> values = redisTemplate.opsForValue();
         String jsonValue = values.get(key); // key를 이용하여 해당 key의 String 형태의 value를 가져온다.
@@ -65,15 +69,58 @@ public class RedisUtil {
      * 3. Refresh Token 삭제 (Delete)
      * - 로그아웃, 재발급 시 사용
      */
-    public void deleteRefreshToken(String hashedRefreshToken) {
+    public void deleteHashedRefreshToken(String hashedRefreshToken) {
         String key = "RT:" + hashedRefreshToken;
+        if (!redisTemplate.hasKey(key)) {return;} // 해당 RefreshToken이 Redis에 없으면 굳이 delete하지 않음
         redisTemplate.delete(key); //
     }
 
     /**
      * 4. 해당 RefreshToken 존재 여부 확인
      */
-    public boolean hasKey(String hashedRefreshToken) {
+    public boolean hasHashedRefreshToken(String hashedRefreshToken) {
         return redisTemplate.hasKey("RT:" + hashedRefreshToken);
     }
+
+    // ==========================================================
+    // [ BlackList ]
+    // ==========================================================
+
+    /**
+     * 1. 해당 토큰의 Jti를 Redis의 블랙리스트에 등록하는 함수
+     * - Key: BL: + JTI
+     * - Value: TokenType
+     * - TTL: 해당 토큰의 만료까지 남은 시간
+     */
+    public void setTokenInBlacklist(String token) {
+        // 1. Redis에 등록할 Key, Value, Ttl 선언
+        String key = "BL:" + jwtUtil.getJtiFromToken(token);
+        String value = jwtUtil.getTokenType(token).name();
+        long ttl = jwtUtil.getExpirationInMs(token) - System.currentTimeMillis();
+
+        // 2. 이미 만료된 토큰인지 확인
+        if(ttl <= 0) {
+            log.warn("[Redis] 이미 만료된 Token이 블랙리스트 요청됨 - jti: {}", key);
+            return;
+        }
+
+        // 3. 해당 Key가 이미 Redis에 존재하는지 확인
+        boolean hasKey = redisTemplate.hasKey(key);
+        if(hasKey) { return; }
+        /*
+         * 4. 해당 Key:Value Redis에 등록
+         * - opsForValue(): Redis String(단일 값, Key:Value) 구조의 자료구조를 반환하는 함수
+         */
+        redisTemplate.opsForValue()
+                .set(key, value, Duration.ofMillis(ttl));
+        log.info("[Redis] Token Redis BlackList에 등록 완료: {}, TTL - {}ms", key, ttl);
+    }
+
+    /**
+     * 2. 해당 Token이 Redis의 블랙리스트에 존재하는지 확인하는 함수
+     */
+    public Boolean checkTokenInBlacklist(String token) {
+        return redisTemplate.hasKey("BL:" + jwtUtil.getJtiFromToken(token));
+    }
+
 }

--- a/src/test/java/com/example/egobook_be/global/schedular/DailySchedularTest.java
+++ b/src/test/java/com/example/egobook_be/global/schedular/DailySchedularTest.java
@@ -1,0 +1,148 @@
+package com.example.egobook_be.global.schedular;
+
+import com.example.egobook_be.domain.auth.entity.AuthAccount;
+import com.example.egobook_be.domain.auth.enums.Provider;
+import com.example.egobook_be.domain.auth.repository.AuthAccountRepository;
+import com.example.egobook_be.domain.shop.entity.Item;
+import com.example.egobook_be.domain.shop.entity.UserItem;
+import com.example.egobook_be.domain.shop.enums.ItemCategory;
+import com.example.egobook_be.domain.shop.repository.ItemRepository;
+import com.example.egobook_be.domain.user.entity.User;
+import com.example.egobook_be.domain.user.enums.UserStatus;
+import com.example.egobook_be.domain.user.repository.UserRepository;
+import com.example.egobook_be.global.scheduler.DailySchedular;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional // 테스트 종료 후 DB 롤백 (데이터 오염 방지)
+@ActiveProfiles("local") // application-local.yml 설정을 사용한다고 가정
+class DailySchedulerTest {
+
+    @Autowired
+    private DailySchedular dailyScheduler; // 테스트 대상 스케줄러
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private AuthAccountRepository authAccountRepository;
+
+    @Autowired
+    private ItemRepository itemRepository;
+
+    @Test
+    @DisplayName("탈퇴 대기 기간(purgeAt)이 지난 유저는 삭제되고, 아직 남은 유저는 유지된다. 연관 데이터(Cascade)도 함께 삭제되어야 한다.")
+    void purgeUsers_IntegrationTest() {
+        // =================================================================
+        // [Given] 테스트 데이터 세팅
+        // =================================================================
+
+        // 1. 삭제 대상 유저 (Target User)
+        // - 상태: WITHDRAW_PENDING
+        // - purgeAt: 어제 (현재 시간보다 과거)
+        User deleteTargetUser = User.builder()
+                .accountCode("DELETE_ME")
+                .nickname("삭제될유저")
+                .status(UserStatus.WITHDRAW_PENDING)
+                .purgeAt(LocalDateTime.now().minusDays(1)) // 어제 날짜
+                .build();
+
+        // 2. 삭제 대상의 연관 데이터 (Cascade 검증용)
+        // (1) AuthAccount 연결
+        AuthAccount authAccount = AuthAccount.builder()
+                .provider(Provider.GUEST)
+                .hashedDeviceUid("dummy_hash")
+                .user(deleteTargetUser)
+                .build();
+
+        // (2) UserItem 연결 (UserItem 생성을 위해 임시 Item 필요)
+        Item dummyItem = itemRepository.save(Item.builder()
+                .name("TestItem")
+                .price(100)
+                // [수정] Not Null 컬럼인 category와 path를 반드시 넣어줘야 함
+                .category(ItemCategory.SKIN) // 또는 다른 카테고리 Enum
+                .path("dummy_image.png")     // path도 not null임
+                .build());
+        UserItem userItem = UserItem.builder()
+                .user(deleteTargetUser)
+                .item(dummyItem)
+                .isEquipped(true)
+                .build();
+
+        // (User 엔티티에 연관관계 편의 메서드가 없으므로 리스트에 직접 추가하거나 repository로 저장)
+        // 여기서는 CascadeType.ALL이 걸려있다고 가정하고 User에 추가
+        deleteTargetUser.getUserItems().add(userItem);
+
+        // 부모(User)를 저장하면 자식(AuthAccount, UserItem)도 같이 저장됨 (Cascade Persist)
+        // *주의: AuthAccount는 User 필드에 없으면 별도로 저장 필요할 수 있음. 엔티티 구조에 따라 조정.
+        userRepository.save(deleteTargetUser);
+        authAccountRepository.save(authAccount); // 명시적 저장 (User쪽에서 mappedBy인 경우)
+
+
+        // 3. 유지 대상 유저 (Survivor User)
+        // - 상태: WITHDRAW_PENDING
+        // - purgeAt: 내일 (현재 시간보다 미래)
+        User survivorUser = User.builder()
+                .accountCode("SAVE_ME")
+                .nickname("살아남을유저")
+                .status(UserStatus.WITHDRAW_PENDING)
+                .purgeAt(LocalDateTime.now().plusDays(1)) // 내일 날짜
+                .build();
+        userRepository.save(survivorUser);
+
+        // 4. 일반 활성 유저 (Active User)
+        // - 상태: ACTIVE
+        User activeUser = User.builder()
+                .accountCode("ACTIVE")
+                .nickname("활동중유저")
+                .status(UserStatus.ACTIVE)
+                .build();
+        userRepository.save(activeUser);
+
+
+        // =================================================================
+        // [When] 스케줄러 실행
+        // =================================================================
+        dailyScheduler.purgeUsers();
+
+
+        // =================================================================
+        // [Then] 검증
+        // =================================================================
+
+        // 1. 삭제 대상 유저가 DB에서 사라졌는지 확인
+        Optional<User> deletedUserSearch = userRepository.findById(deleteTargetUser.getId());
+        assertThat(deletedUserSearch).isEmpty();
+
+        // 2. [중요] 연관된 자식 데이터(Cascade)도 실제로 삭제되었는지 확인
+        // AuthAccount 조회
+        boolean authAccountExists = authAccountRepository.existsById(authAccount.getId());
+        assertThat(authAccountExists).isFalse();
+
+        // UserItem 조회 (Item 자체는 지워지면 안 되고, UserItem 매핑만 지워져야 함)
+        // UserItem Repository가 있다면 조회, 없다면 로우 쿼리나 EntityManager로 확인 가능
+        // 여기서는 UserItemRepository가 없다고 가정하고 Item은 그대로 있는지 확인
+        assertThat(itemRepository.existsById(dummyItem.getId())).isTrue();
+
+
+        // 3. 유지 대상 유저는 살아있는지 확인 (날짜가 아직 안 됨)
+        Optional<User> survivorSearch = userRepository.findById(survivorUser.getId());
+        assertThat(survivorSearch).isPresent();
+
+        // 4. 활성 유저는 살아있는지 확인 (상태가 PENDING이 아님)
+        Optional<User> activeUserSearch = userRepository.findById(activeUser.getId());
+        assertThat(activeUserSearch).isPresent();
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
- #56 

## 📝작업 내용
### ✅ 1. 닉네임 변경 API
- 사용자의 닉네임을 입력받아 변경합니다. 닉네임은 중복이 가능합니다.

### ✅ 2. 회원 탈퇴 API
- 현재 로그인된 사용자의 **계정을 탈퇴 처리**합니다.
- **[ 회원 탈퇴 로직 ]**
  1. 비관적 락을 적용하여, 회원탈퇴를 요청한 사용자의 정보를 가져옵니다.
  2. 해당 사용자가 탈퇴 대기 중인지 확인한 뒤, 해당 사용자의 상태를 비식별화합니다.
  ```
  (1) status -> WITHDRAW_PENDING
  (2) deletedAt(삭제 요청 시각) 최신화
  (3) purgeAt(완전 삭제 예정 시각) 최신화
  (4) dailPraise (AI 칭찬서 수신 여부) false
  (5) notificationEnabled (알림 설정) false
  ```
  3. 기존에 사용하던 Access Token을 Redis의 BlackList에 등록합니다.
    - **Redis에 저장하는 데이터 양식**
    ```
    - **Key**: "BL" + Token의 JTI
    - **Value**: Token의 Type(Access, Refresh, Recover
    - **Ttl**: 해당 Token의 만료까지 남은 시간(ms)
    ```
  4. Redis에 저장되어있는 해당 사용자의 RefreshToken을 삭제하고, 해당 사용자의 인증 정보(AuthAccount)와 1대1로 연결되어있는 RefreshTokenBackup 테이블의 레코드를 삭제합니다.
  - 해당 사용자와 연관관 AuthAccount 레코드는 아직 삭제하지 않습니다,(7일 뒤 스케줄러로 삭제합니다)

- **[ Redis Util에 추가된 함수들 ]**
  1. 해당 토큰의 jti를 redis의 블랙리스트에 등록하는 함수
  2. 해당 token이 redis의 블랙리스트에 존재하는지 확인하는 함수


### ✅ 3. 기존 Recertification 로직 수정
- 기존에는 Refresh 토큰을 재발급할 때 사용자의 UserStatus(활성화, 휴면, 삭제 대기 등)를 확인하지 않았으나, 이제는 Recover, Google Token으로 Refresh 토큰을 재발급할 때 사용자의 상태를 확인합니다.
- **기존방식에서는** 사용자가 탈퇴를 하면 AuthAccount의 레코드를 바로 삭제하지 않기 때문에, **탈퇴를 하여도 Refresh 토큰을 재발급할 수 있었습니다.**
- 따라서, **Refresh 토큰을 재발급할 때 사용자의 상태를 확인하게 함으로써 회원탈퇴 시 Refresh Token을 재발급 받지 않게 합니다.**


### ✅ 4. JwtAuthFilter에 BlackList 확인 로직 설정
- 사용자가 전달한 AccessToken이 Redis의 BlackList에 등록되어있는지 여부를 확인하는 로직을 추가하였습니다.


### ✅ 5. 실제 회원 삭제 스케줄러 등록
- 매일 자정 00시에, 사용자들 중 회원탈퇴 요청 후 7일 이상이 경과한 사용자들의 정보를 일괄 삭제하는 기능을 합니다.
  - **Cron Expression**: 0 0 0 * * * (매일 자정 실행)
  - **Target**: UserStatus.WITHDRAW_PENDING 상태이며 purgeAt이 현재 시간 이전인 사용자
  - **[ 삭제 순서 ]**
  ```
  (0) Refresh Token Backup 테이블 삭제 (RefreshTokenBackup)
  (1) 사용자 인증 정보 삭제 (AuthAccount)
  (2) 사용자 약관 정보 삭제 (UserTerm)
  (3) 사용자가 보유한 아이템 삭제 (UserItem)
  (4) 사용자가 작성한 일기 삭제 (Diary)
  (5) 사용자의 친구 연결 삭제 (Friend) -> 해당 친구가 기준 사용자인 레코드도 삭제
  (6) 사용자가 보낸/받은 친구 연결 신청 삭제 (FriendRequest)
  (7) 사용자의 미션 상태 정보 삭제 (Mission)
  (8) 사용자가 신고한 편지 답장 정보 삭제 (PlazaLetterReplyReport)
  (9) 사용자가 답장한 편지 정보에서 Replier(답장자) 비식별화 (PlazaLetterReply) -> Replier가 탈퇴하면 답장을 지우지 않고, PlazaLetterReply.replierId를 null로 만든다.
  (10) 사용자가 작성한 편지 정보 삭제 (PlazaLetter) -> Thread는 삭제하지 않음.
  (11) 사용자가 받은 알림 정보 삭제 (Notification)
  (12) 사용자가 받은 오늘의 심리지식 정보들 삭제 (UserKnowledge)
  (13) 사용자가 작성한 오늘의 질문에 대한 답변들 삭제 (QuestionAnswer)
  (14) 사용자의 능력치 정보 삭제 (Ability)
  (15) 사용자의 Ink 획득 기록 삭제 (InkLog)
  (16) 최종 사용자 정보 삭제 (User)
  ```
  - User Entity에 연관관계로 매핑되어있는 테이블들은 Cascading으로 자동으로 삭제되도록 하였고, 그렇지 않은 테이블들은 수동으로 삭제되도록 구현하였습니다.
  - 영속성 컨텍스트의 Dirty Checking으로 단건 삭제를 수행하면 성능적인 면에서 좋지 않다고 생각해, Bulk 쿼리를 사용하여 다량의 삭제를 한번에 수행하였습니다. (향후 Batch로 사용자를 묶어서 삭제를 수행하는 로직 추가를 고려할 수 있을 것 같습니다.)

### ❗ 주요 변경 사항 ❗
1. **[ 편지 엔티티 연관관계 수정 ]**
- 편지의 경우, ```PlazaLetter```, ```PlazaLetterReply```, ```PlazaLetterReplyReport``` 엔티티들의 연관관계가 엔티티가 아닌 각 테이블의 PK(ID값)로 연결되어있는 부분이 존재하여, **PlazaLetter 삭제 시 나머지 2개의 연관 테이블의 레코드가 삭제되지 않는 오류가 발생하였음**
- 따라서, 3개의 엔티티의 연관관계를 수정하였고, 그에 맞게 PlazaLetterService 등의 코드를 일부 수정하였습니다.

2. **[ 사용자 데이터 삭제 시의 신고한 편지 삭제 로직 ]**
- 기본적으로, 사용자 데이터를 삭제할 때 로직은 아래와 같습니다.
  - **PlazaLetterReplyReport Entity 코드 일부**
  ```
  ...
  @ManyToOne(fetch = FetchType.LAZY)
  @JoinColumn(name = "letter_id")
  @OnDelete(action = OnDeleteAction.CASCADE) // 편지가 삭제되면 신고 내역도 자동 삭제
  private PlazaLetter letter;

  @Column(nullable = false)
  private Long reporterId;

  private Long replierId; // 신고를 받은 편지를 작성한 작성자의 User PK
  ...
  ```
  - ```reporterId```: 신고한 사람의 user pk (현재 삭제되는 사용자의 pk)
  - ```replierId```: 신고 당한 사람의 user pk(신고를 받은 편지를 작성한 사용자의 pk)
- **사용자가 회원 탈퇴를 하면, 본인이 신고한(Reporter) PlazaLetterReplyReport의 레코드만 삭제합니다.**
- **본인이 신고당한(Replier) PlazaLetterReplyReport의 레코드는 삭제하지 않고, 해당 레코드의 ```replierId```값을 null로 설정해줍니다.**
  -> 이는 **아직 탈퇴하지 않은 사용자가 본인이 신고한 내역을 유지하기 위함입니다.** 해당 신고 내역 조회에서는 상대방을 "알수없음" 사용자로 표시합니다.
  -> 향후 특정 사용자가 신고당한 횟수에 대한 통계도 내려하는 경우, 본인이 신고한 레코드 부분 로직의 수정도 다시 고려해야합니다.


3. **[ 사용자 데이터 삭제 시의 답장한 편지 정보 삭제 로직 ]**
- 이 로직도 위 2번 로직과 마찬가지로, 
  1. 사용자가 답장한 편지 정보에서 Replier(답장자) 비식별화 (null로 설정)
  2. Replier가 탈퇴하면 답장을 지우지 않고, PlazaLetterReply.replierId를 null로 만든다.
  -> replier가 null이 된 답변 객체는, 해당 편지 작성자가 회원탈퇴를 할 때 해당 사용자가 작성한 편지 정보들이 삭제되면서 같이 삭제됩니다.

4. **[ 사용자가 작성한 편지 정보 비식별화 & 삭제 ]**
- 사용자가 작성한 편지 정보의 코드 일부분은 아래와 같습니다.
```
public class PlazaLetter {

    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long letterId;

    @Column(nullable = false)
    private Long threadId;

    @Column
    private Long senderId;

    @Column
    private Long receiverId; // RANDOM 매칭 전이면 null 가능


    @Column(nullable = false)
    private OffsetDateTime createdAt;

    @Column(length = 20)
    private String backgroundColor;

    @Enumerated(EnumType.STRING)
    @Column(nullable = false, length = 20)
    private PlazaLetterStatus status;

    @Enumerated(EnumType.STRING)
    @Column(nullable = false, length = 20)
    private PlazaLetterMode mode;

    @Column(nullable = false, length = 30)
    private String fromLabel; // "익명" or 친구 닉네임

    @Column(nullable = false, length = 400)
    private String content;

    @Column(nullable = false)
    private OffsetDateTime arrivedAt;

    @Column(nullable = false)
    private OffsetDateTime replyDeadlineAt;

    private OffsetDateTime repliedAt;

    public void markReplied(OffsetDateTime repliedAt) {
        this.status = PlazaLetterStatus.REPLIED;
        this.repliedAt = repliedAt;
    }

    public void markDeferred() {
        this.status = PlazaLetterStatus.DEFERRED;
    }

    @Column
    private OffsetDateTime gaveUpAt;

...
```
여기서, 탈퇴하려는 사용자가 작성한 편지 정보를 삭제하는 로직은 아래와 같습니다.
1. 탈퇴하는 user가 보낸(Sender) 편지의 senderId를 Null로 변경
2. 탈퇴하는 user가 받은(Receiver) 편지의 receiverId를 null로 변경
3. Sender, Receiver가 모두 null이 된(양쪽 다 탈퇴한) 편지는 DB에서 삭제
4. 편지가 모두 삭제되어, 자식 객체들이 모두 사라져버린 PlazaLetterThread 객체를 삭제한다.
-> PlazaLetter의 sender, receiver가 모두 null이 된 레코드만 테이블에서 삭제합니다.

## 💬리뷰 요구사항
1. 해당 삭제 로직에 빠진 부분이 없는지 검토가 필요할 것 같습니다.
2. 현재 편지 데이터 삭제 로직 방식이 적절한지 검토가 필요할 것 같습니다. 저는 사용자 관점에서, 내가 보낸 편지에 답장을 보낸 상대방이 탈퇴하더라도 해당 내용이 계속해서 남아있는 것이 더 나을 것이라고 판단해 이렇게 로직을 구현하였습니다.
3. Letter 도메인에서 건든 api들을 테스트한 결과, 아직까지는 버그가 없는 것으로 확인되었습니다. 하지만 추가적인 테스트로 기존 로직에 오류가 생기지는 않았는지 확인이 필요할 것 같습니다.