### PR TITLE
✨ Feat: ai 답장 로직, 친구 검증 로직

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,6 +74,7 @@ jobs:
           sed -i "s|\${DEV_ANDROID_CLIENT_IDS}|${{ secrets.DEV_ANDROID_CLIENT_IDS }}|g" $FILE
           sed -i "s|\${WORD_AI_BASE_URL}|${{ secrets.WORD_AI_BASE_URL }}|g" $FILE
           sed -i "s|\${OPENAI_API_KEY}|${{ secrets.OPENAI_API_KEY }}|g" $FILE
+          sed -i "s|\${GEMINI_API_KEY}|${{ secrets.GEMINI_API_KEY }}|g" $FILE
         # 같은 값이 중복되면, 최근에 설정된 env값이 사용된다.
         shell: bash
 
@@ -92,6 +93,8 @@ jobs:
           sed -i "s|\${PROD_REDIS_PW}|${{ secrets.PROD_REDIS_PW }}|g" $FILE
           sed -i "s|\${PROD_ANDROID_CLIENT_IDS}|${{ secrets.PROD_ANDROID_CLIENT_IDS }}|g" $FILE
           sed -i "s|\${OPENAI_API_KEY}|${{ secrets.OPENAI_API_KEY }}|g" $FILE
+          sed -i "s|\${WORD_AI_BASE_URL}|${{ secrets.WORD_AI_BASE_URL }}|g" $FILE
+          sed -i "s|\${GEMINI_API_KEY}|${{ secrets.GEMINI_API_KEY }}|g" $FILE
         shell: bash
 
       # (5) gradlew 파일에 실행 권한 부여
@@ -142,6 +145,8 @@ jobs:
           EC2_USERNAME: ${{ secrets.EC2_USERNAME }}
           EC2_HOST: ${{ secrets.EC2_HOST }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          WORD_AI_BASE_URL: ${{ secrets.WORD_AI_BASE_URL }}
           # => github secrets에 설정해놓은 값들 env로 가져오기
 
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ application-local.yml
 
 ### env ###
 .env
+
+.DS_Store

--- a/build.gradle
+++ b/build.gradle
@@ -96,6 +96,9 @@ dependencies {
     implementation platform('dev.langchain4j:langchain4j-bom:0.36.2')
     implementation 'dev.langchain4j:langchain4j-spring-boot-starter'
     implementation 'dev.langchain4j:langchain4j-open-ai'
+
+    // WebClient
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/egobook_be/domain/letters/PlazaLetterDummyDataLoader.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/PlazaLetterDummyDataLoader.java
@@ -1,44 +1,45 @@
-package com.example.egobook_be.domain.letters;
-
-import com.example.egobook_be.domain.letters.entity.PlazaLetter;
-import com.example.egobook_be.domain.letters.entity.PlazaLetterMode;
-import com.example.egobook_be.domain.letters.entity.PlazaLetterStatus;
-import com.example.egobook_be.domain.letters.repository.PlazaLetterRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Profile;
-import org.springframework.boot.CommandLineRunner;
-import org.springframework.stereotype.Component;
-
-import java.time.OffsetDateTime;
-
-@Profile({"local", "dev"})
-@Component
-@RequiredArgsConstructor
-public class PlazaLetterDummyDataLoader implements CommandLineRunner {
-
-    private final PlazaLetterRepository repo;
-
-    @Override
-    public void run(String... args) {
-        // receiverId=1에 ARRIVED 편지 1개가 없으면 생성
-        boolean exists = repo.findFirstByReceiverIdAndStatusOrderByArrivedAtDesc(1L, PlazaLetterStatus.ARRIVED).isPresent();
-        if (exists) return;
-
-        OffsetDateTime now = OffsetDateTime.now();
-
-        repo.save(PlazaLetter.builder()
-                .senderId(1L)
-                .receiverId(2L)
-                .status(PlazaLetterStatus.ARRIVED)
-                .mode(PlazaLetterMode.RANDOM)
-                .fromLabel("익명")
-                .content("요즘 너무 지치는데… 어떻게 버티지?")
-                .arrivedAt(now)
-                .createdAt(now)
-                .threadId(1L)
-                .replyDeadlineAt(now.plusHours(24))
-                .backgroundColor("WHITE")
-                .build());
-    }
-}
-
+//package com.example.egobook_be.domain.letters;
+//
+//import com.example.egobook_be.domain.letters.entity.PlazaLetter;
+//import com.example.egobook_be.domain.letters.entity.PlazaLetterMode;
+//import com.example.egobook_be.domain.letters.entity.PlazaLetterStatus;
+//import com.example.egobook_be.domain.letters.enums.PlazaLetterColor;
+//import com.example.egobook_be.domain.letters.repository.PlazaLetterRepository;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.context.annotation.Profile;
+//import org.springframework.boot.CommandLineRunner;
+//import org.springframework.stereotype.Component;
+//
+//import java.time.OffsetDateTime;
+//
+//@Profile({"local", "dev"})
+//@Component
+//@RequiredArgsConstructor
+//public class PlazaLetterDummyDataLoader implements CommandLineRunner {
+//
+//    private final PlazaLetterRepository repo;
+//
+//    @Override
+//    public void run(String... args) {
+//        // receiverId=1에 ARRIVED 편지 1개가 없으면 생성
+//        boolean exists = repo.findFirstByReceiverIdAndStatusOrderByArrivedAtDesc(1L, PlazaLetterStatus.ARRIVED).isPresent();
+//        if (exists) return;
+//
+//        OffsetDateTime now = OffsetDateTime.now();
+//
+//        repo.save(PlazaLetter.builder()
+//                .senderId(1L)
+//                .receiverId(2L)
+//                .status(PlazaLetterStatus.ARRIVED)
+//                .mode(PlazaLetterMode.RANDOM)
+//                .fromLabel("익명")
+//                .content("요즘 너무 지치는데… 어떻게 버티지?")
+//                .arrivedAt(now)
+//                .createdAt(now)
+//                .threadId(1L)
+//                .replyDeadlineAt(now.plusHours(24))
+//                .backgroundColor(PlazaLetterColor.WHITE)
+//                .build());
+//    }
+//}
+//

--- a/src/main/java/com/example/egobook_be/domain/letters/controller/PlazaLetterController.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/controller/PlazaLetterController.java
@@ -24,6 +24,8 @@ import org.springframework.web.bind.annotation.*;
 import com.example.egobook_be.domain.letters.service.ReplyReportService;
 import org.springframework.web.bind.annotation.*;
 
+import com.example.egobook_be.domain.letters.service.ai.GeminiClient;
+import com.example.egobook_be.domain.letters.service.LetterService;
 
 @Tag(name = "Plaza Letter Controller", description = "광장 편지 관련 API")
 @RestController
@@ -34,6 +36,9 @@ public class PlazaLetterController {
     private final PlazaLetterService plazaLetterService;
     private final PlazaLetterQueryService plazaLetterQueryService;
     private final ReplyReportService replyReportService;
+
+    private final GeminiClient geminiClient;
+    private final LetterService letterService;
 
     @Operation(
             summary = "내가 답장해야 할 '도착 편지' 1건 가져오기",
@@ -303,5 +308,28 @@ public class PlazaLetterController {
         );
     }
 
+    // AI 답장 확인용 테스트 API
+    @Operation(
+            summary = "AI 답장 확인용 테스트 API",
+            description = """
+  단순test api입니다. 답장 조회하는 로직에서도 확인가능합니다.
+        """
+    )
+    @GetMapping("/ai/reply/{letterId}")
+    public String getAIReply(@PathVariable Long letterId) {
+        // 편지 가져오기
+        String letterContent = letterService.getLetterContentById(letterId);
 
+        // 편지 도달 시간이 48시간 이상 지났고 답장이 없을 경우에만 AI 요청
+        boolean isEligibleForReply = letterService.isEligibleForAIReply(letterId);
+
+        if (!isEligibleForReply) {
+            return "AI 답장 조건을 충족하지 않습니다.";
+        }
+
+        // AI 답장 생성
+        String aiReply = geminiClient.generateReply("AI", letterContent);
+
+        return aiReply;
+    }
 }

--- a/src/main/java/com/example/egobook_be/domain/letters/dto/ReplyItemDto.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/dto/ReplyItemDto.java
@@ -1,5 +1,6 @@
 package com.example.egobook_be.domain.letters.dto;
 
+import com.example.egobook_be.domain.letters.entity.PlazaLetterMode;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,6 +11,11 @@ import java.time.OffsetDateTime;
 public class ReplyItemDto {
     private Long replyId;
     private Long letterId;
+    private Long threadId;
+
+    private PlazaLetterMode mode;
+    private String backgroundColor;
+
     private String replyText;
     private OffsetDateTime createdAt;
 }

--- a/src/main/java/com/example/egobook_be/domain/letters/dto/request/CreateLetterRequest.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/dto/request/CreateLetterRequest.java
@@ -1,6 +1,7 @@
 package com.example.egobook_be.domain.letters.dto.request;
 
 import com.example.egobook_be.domain.letters.entity.PlazaLetterMode;
+import com.example.egobook_be.domain.letters.enums.PlazaLetterColor;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -22,6 +23,7 @@ public class CreateLetterRequest {
     @Schema(description = "편지 내용(360자 이하)", example = "요즘 자꾸 불안해져서... 누가 한마디 해주면 좋겠어.")
     private String text;
 
-    @Schema(description = "배경색(구독자 전용 가능), 기본은 하얀색", example = "WHITE", nullable = true)
-    private String backgroundColor;
+    @Schema(description = "배경 기본은 하얀색", example = "WHITE", nullable = true)
+    @NotNull
+    private PlazaLetterColor backgroundColor;
 }

--- a/src/main/java/com/example/egobook_be/domain/letters/dto/response/CreateLetterResponse.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/dto/response/CreateLetterResponse.java
@@ -12,5 +12,7 @@ public record CreateLetterResponse(
         Long threadId,
         PlazaLetterStatus status,
         PlazaLetterMode mode,
+        String fromLabel,
+        String backgroundColor,
         OffsetDateTime createdAt
 ) {}

--- a/src/main/java/com/example/egobook_be/domain/letters/dto/response/PlazaLetterDetailResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/dto/response/PlazaLetterDetailResDto.java
@@ -24,6 +24,8 @@ public class PlazaLetterDetailResDto {
     private OffsetDateTime createdAt;
     private OffsetDateTime arrivedAt;
 
+    private String fromLabel;
+
     // ===== 답장 =====
     private ReplyDto reply;   // 답장 없으면 null
 

--- a/src/main/java/com/example/egobook_be/domain/letters/dto/response/PlazaReceivedReplyResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/dto/response/PlazaReceivedReplyResDto.java
@@ -23,4 +23,5 @@ public class PlazaReceivedReplyResDto {
     // 편지 정보
     private PlazaLetterMode mode;
     private String fromLabel;
+    private String backgroundColor;
 }

--- a/src/main/java/com/example/egobook_be/domain/letters/dto/response/PlazaSentLetterResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/dto/response/PlazaSentLetterResDto.java
@@ -23,4 +23,5 @@ public class PlazaSentLetterResDto {
     private String lastMessagePreview;
 
     private OffsetDateTime createdAt;
+    private String backgroundColor;
 }

--- a/src/main/java/com/example/egobook_be/domain/letters/entity/PlazaLetter.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/entity/PlazaLetter.java
@@ -47,10 +47,10 @@ public class PlazaLetter {
     @Column(nullable = false, length = 400)
     private String content;
 
-    @Column(nullable = false)
+    @Column
     private OffsetDateTime arrivedAt;
 
-    @Column(nullable = false)
+    @Column
     private OffsetDateTime replyDeadlineAt;
 
     private OffsetDateTime repliedAt;
@@ -71,5 +71,29 @@ public class PlazaLetter {
         this.status = PlazaLetterStatus.GAVE_UP;
         this.gaveUpAt = gaveUpAt;
     }
+
+    public void markAiReplied(OffsetDateTime repliedAt) {
+        this.status = PlazaLetterStatus.AI_REPLIED;
+        this.repliedAt = repliedAt; // repliedAt 필드를 그대로 사용 (AI 답장)
+    }
+
+    public void assignToReceiver(Long receiverId, OffsetDateTime arrivedAt, OffsetDateTime replyDeadlineAt) {
+        this.receiverId = receiverId;
+        this.arrivedAt = arrivedAt;
+        this.replyDeadlineAt = replyDeadlineAt;
+        this.status = PlazaLetterStatus.ARRIVED;
+    }
+
+    public void assignReceiver(
+            Long receiverId,
+            OffsetDateTime arrivedAt,
+            OffsetDateTime replyDeadlineAt
+    ) {
+        this.receiverId = receiverId;
+        this.arrivedAt = arrivedAt;
+        this.replyDeadlineAt = replyDeadlineAt;
+        this.status = PlazaLetterStatus.ARRIVED;
+    }
+
 
 }

--- a/src/main/java/com/example/egobook_be/domain/letters/entity/PlazaLetter.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/entity/PlazaLetter.java
@@ -99,4 +99,16 @@ public class PlazaLetter {
     }
 
 
+    // status에 대한 setter 메서드 추가
+    public void setStatus(PlazaLetterStatus status) {
+        this.status = status;
+    }
+
+
+
+    // arrivedAt에 대한 setter 메서드 추가
+    public void setArrivedAt(OffsetDateTime arrivedAt) {
+        this.arrivedAt = arrivedAt;
+    }
+
 }

--- a/src/main/java/com/example/egobook_be/domain/letters/entity/PlazaLetter.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/entity/PlazaLetter.java
@@ -1,5 +1,6 @@
 package com.example.egobook_be.domain.letters.entity;
 
+import com.example.egobook_be.domain.letters.enums.PlazaLetterColor;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -30,8 +31,10 @@ public class PlazaLetter {
     @Column(nullable = false)
     private OffsetDateTime createdAt;
 
-    @Column(length = 20)
-    private String backgroundColor;
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    @Column(nullable = false, length = 20)
+    private PlazaLetterColor backgroundColor = PlazaLetterColor.WHITE;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)

--- a/src/main/java/com/example/egobook_be/domain/letters/entity/PlazaLetterReply.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/entity/PlazaLetterReply.java
@@ -44,8 +44,16 @@ public class PlazaLetterReply {
     @Column(nullable = false)
     private ReplyStatus status;
 
+    @PrePersist
+    public void prePersist() {
+        if (status == null) {
+            // 기본값을 SENT로 설정
+            status = ReplyStatus.SENT;
+        }
+    }
+
     public enum ReplyStatus {
-        AI_REPLIED, ARRIVED, DEFERRED, GAVE_UP, REPLIED, SENT, WAITING, DELETED
+        AI_REPLIED, ARRIVED, SENT, DELETED
     }
 }
 

--- a/src/main/java/com/example/egobook_be/domain/letters/entity/PlazaLetterReply.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/entity/PlazaLetterReply.java
@@ -38,5 +38,14 @@ public class PlazaLetterReply {
 
     @Column(nullable = false)
     private OffsetDateTime createdAt;
+
+    // status 필드 추가
+    @Enumerated(EnumType.STRING) // Enum 값이 문자열로 저장되도록 설정
+    @Column(nullable = false)
+    private ReplyStatus status;
+
+    public enum ReplyStatus {
+        AI_REPLIED, ARRIVED, DEFERRED, GAVE_UP, REPLIED, SENT, WAITING, DELETED
+    }
 }
 

--- a/src/main/java/com/example/egobook_be/domain/letters/entity/PlazaLetterStatus.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/entity/PlazaLetterStatus.java
@@ -1,11 +1,12 @@
 package com.example.egobook_be.domain.letters.entity;
 
 public enum PlazaLetterStatus {
-    SENT,
+    WAITING,
     ARRIVED,
     DEFERRED,
     REPLIED,
     GAVE_UP,
-    AI_REPLIED
+    AI_REPLIED,
+    SENT
 }
 

--- a/src/main/java/com/example/egobook_be/domain/letters/enums/LettersErrorCode.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/enums/LettersErrorCode.java
@@ -19,7 +19,7 @@ public enum LettersErrorCode implements BaseErrorCode {
     FRIEND_ID_REQUIRED(HttpStatus.BAD_REQUEST, "PLAZA400_FRIEND_ID_REQUIRED", "FRIEND 모드에서는 toFriendId가 필요해요"),
     INVALID_REPORT_REASON(HttpStatus.BAD_REQUEST, "PLAZA400_INVALID_REPORT_REASON", "잘못된 신고 사유입니다."),
     ALREADY_REPORTED(HttpStatus.BAD_REQUEST, "PLAZA400_ALREADY_REPORTED", "이미 신고한 답장입니다."),
-
+    NOT_FRIEND(HttpStatus.BAD_REQUEST, "PLAZA400_NOT_FRIEND", "친구 관계가 아닙니다."),
 
 
 

--- a/src/main/java/com/example/egobook_be/domain/letters/enums/PlazaLetterColor.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/enums/PlazaLetterColor.java
@@ -1,0 +1,20 @@
+package com.example.egobook_be.domain.letters.enums;
+
+public enum PlazaLetterColor {
+    WHITE(0),  // 기본 하얀색, 가격 0원
+    PINK(150),  // 핑크색, 가격 150원
+    GREEN(200),  // 초록색, 가격 200원
+    BLUE(300),  // 파란색, 가격 300원
+    PURPLE(400);  // 보라색, 가격 400원
+
+    private final int price;
+
+    PlazaLetterColor(int price) {
+        this.price = price;
+    }
+
+    public int getPrice() {
+        return price;
+    }
+}
+

--- a/src/main/java/com/example/egobook_be/domain/letters/mapper/PlazaLetterMapper.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/mapper/PlazaLetterMapper.java
@@ -101,7 +101,7 @@ public class PlazaLetterMapper {
                 .mode(letter.getMode())
 
                 .content(letter.getContent())
-                .backgroundColor(letter.getBackgroundColor())
+                .backgroundColor(letter.getBackgroundColor().name())
 
                 .createdAt(letter.getCreatedAt())
                 .arrivedAt(letter.getArrivedAt())

--- a/src/main/java/com/example/egobook_be/domain/letters/mapper/PlazaLetterMapper.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/mapper/PlazaLetterMapper.java
@@ -31,6 +31,7 @@ public class PlazaLetterMapper {
                 .aiReplaceAt(aiReplaceAt)
                 .lastMessagePreview(preview)
                 .createdAt(createdAt)
+                .backgroundColor(letter.getBackgroundColor().name())
                 .build();
     }
 
@@ -73,6 +74,8 @@ public class PlazaLetterMapper {
 
                 .mode(letter.getMode())
                 .fromLabel(letter.getFromLabel())
+                .backgroundColor(letter.getBackgroundColor().name())
+
                 .build();
     }
 
@@ -105,6 +108,8 @@ public class PlazaLetterMapper {
 
                 .createdAt(letter.getCreatedAt())
                 .arrivedAt(letter.getArrivedAt())
+
+                .fromLabel(letter.getFromLabel())
 
                 .reply(replyDto)
                 .build();

--- a/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterReplyReportRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterReplyReportRepository.java
@@ -30,4 +30,13 @@ public interface PlazaLetterReplyReportRepository extends JpaRepository<PlazaLet
     @Modifying(clearAutomatically = true)
     @Query("UPDATE PlazaLetterReplyReport r SET r.replierId = NULL WHERE r.replierId IN :replierIds")
     void bulkNullifyReplierId(@Param("replierIds") List<Long> replierIds);
+
+    // 3회 이상 신고된 답장 삭제하고 신고 DB로 이동
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE PlazaLetterReply r SET r.status = 'DELETED' WHERE r.replyId = :replyId")
+    void moveReplyToReportDbAndDelete(@Param("replyId") Long replyId);
+
+    // 신고된 답장에 대한 신고 횟수를 셈
+    @Query("SELECT COUNT(r) FROM PlazaLetterReplyReport r WHERE r.reply.replyId = :replyId")
+    long countByReply_ReplyId(@Param("replyId") Long replyId);
 }

--- a/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterReplyReportRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterReplyReportRepository.java
@@ -1,5 +1,6 @@
 package com.example.egobook_be.domain.letters.repository;
 
+import com.example.egobook_be.domain.letters.entity.PlazaLetterReply;
 import com.example.egobook_be.domain.letters.entity.PlazaLetterReplyReport;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -33,8 +34,8 @@ public interface PlazaLetterReplyReportRepository extends JpaRepository<PlazaLet
 
     // 3회 이상 신고된 답장 삭제하고 신고 DB로 이동
     @Modifying(clearAutomatically = true)
-    @Query("UPDATE PlazaLetterReply r SET r.status = 'DELETED' WHERE r.replyId = :replyId")
-    void moveReplyToReportDbAndDelete(@Param("replyId") Long replyId);
+    @Query("UPDATE PlazaLetterReply r SET r.status = :status WHERE r.replyId = :replyId")
+    void moveReplyToReportDbAndDelete(@Param("replyId") Long replyId, @Param("status") PlazaLetterReply.ReplyStatus status);
 
     // 신고된 답장에 대한 신고 횟수를 셈
     @Query("SELECT COUNT(r) FROM PlazaLetterReplyReport r WHERE r.reply.replyId = :replyId")

--- a/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterReplyRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterReplyRepository.java
@@ -45,4 +45,17 @@ public interface PlazaLetterReplyRepository extends JpaRepository<PlazaLetterRep
     @Modifying(clearAutomatically = true)
     @Query("UPDATE PlazaLetterReply r SET r.replierId = NULL, r.isAiGenerated = false WHERE r.replierId IN :replierIds")
     void bulkNullifyReplierId(@Param("replierIds") List<Long> replierIds);
+
+    @Query("""
+    select r
+    from PlazaLetterReply r
+    join fetch r.letter l
+    where r.replierId = :replierId
+    order by r.replyId desc
+""")
+    Slice<PlazaLetterReply> findMyRepliesWithLetter(
+            @Param("replierId") Long replierId,
+            Pageable pageable
+    );
+
 }

--- a/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterRepository.java
@@ -82,7 +82,7 @@ public interface PlazaLetterRepository extends JpaRepository<PlazaLetter, Long> 
           and not exists (
               select 1
               from PlazaLetterReply r
-              where r.letterId = l.letterId
+              where r.letter = l
           )
         order by l.createdAt asc
     """)
@@ -93,23 +93,21 @@ public interface PlazaLetterRepository extends JpaRepository<PlazaLetter, Long> 
             Pageable pageable
     );
 
-    @Query("""
-        select l
-        from PlazaLetter l
-        where l.replyDeadlineAt <= :now
-          and l.status in (:arrived, :deferred)
-          and not exists (
-              select 1 from PlazaLetterReply r
-              where r.letterId = l.letterId
-          )
-        order by l.replyDeadlineAt asc
-    """)
+    @Query("SELECT l FROM PlazaLetter l " +
+            "WHERE l.replyDeadlineAt <= :now " +
+            "AND l.status IN (:arrived, :deferred) " +
+            "AND NOT EXISTS (" +
+            "   SELECT 1 FROM PlazaLetterReply r " +
+            "   WHERE r.letter.letterId = l.letterId" +
+            ") " +
+            "ORDER BY l.replyDeadlineAt ASC")
     List<PlazaLetter> findGiveUpTargets(
             @Param("now") OffsetDateTime now,
             @Param("arrived") PlazaLetterStatus arrived,
             @Param("deferred") PlazaLetterStatus deferred,
             Pageable pageable
     );
+
 
 
     @Query("""

--- a/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterRepository.java
@@ -58,5 +58,68 @@ public interface PlazaLetterRepository extends JpaRepository<PlazaLetter, Long> 
             Pageable pageable
     );
 
+
+    @Query("""
+        select l
+        from PlazaLetter l
+        where l.createdAt <= :cutoff
+          and l.status not in (:replied, :aiReplied)
+          and not exists (
+              select 1
+              from PlazaLetterReply r
+              where r.letterId = l.letterId
+          )
+        order by l.createdAt asc
+    """)
+    List<PlazaLetter> findAiReplyTargets(
+            @Param("cutoff") OffsetDateTime cutoff,
+            @Param("replied") PlazaLetterStatus replied,
+            @Param("aiReplied") PlazaLetterStatus aiReplied,
+            Pageable pageable
+    );
+
+    @Query("""
+        select l
+        from PlazaLetter l
+        where l.replyDeadlineAt <= :now
+          and l.status in (:arrived, :deferred)
+          and not exists (
+              select 1 from PlazaLetterReply r
+              where r.letterId = l.letterId
+          )
+        order by l.replyDeadlineAt asc
+    """)
+    List<PlazaLetter> findGiveUpTargets(
+            @Param("now") OffsetDateTime now,
+            @Param("arrived") PlazaLetterStatus arrived,
+            @Param("deferred") PlazaLetterStatus deferred,
+            Pageable pageable
+    );
+
+
+    @Query("""
+    select l
+    from PlazaLetter l
+    where l.status = :waiting
+      and l.receiverId is null
+      and l.senderId <> :receiverId
+    order by l.createdAt asc
+""")
+    List<PlazaLetter> findWaitingLettersForReceiver(
+            @Param("receiverId") Long receiverId,
+            @Param("waiting") PlazaLetterStatus waiting,
+            Pageable pageable
+    );
+
+
+    @Query("""
+        select l
+        from PlazaLetter l
+        where l.status = com.example.egobook_be.domain.letters.entity.PlazaLetterStatus.WAITING
+        order by l.createdAt asc
+    """)
+    List<PlazaLetter> findWaitingLetters(Pageable pageable);
+
+
 }
 

--- a/src/main/java/com/example/egobook_be/domain/letters/scheduler/PlazaLetterAiReplyScheduler.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/scheduler/PlazaLetterAiReplyScheduler.java
@@ -1,0 +1,28 @@
+package com.example.egobook_be.domain.letters.scheduler;
+
+import com.example.egobook_be.domain.letters.service.ai.PlazaLetterAiReplyService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PlazaLetterAiReplyScheduler {
+
+    private final PlazaLetterAiReplyService aiReplyService;
+
+    @Scheduled(fixedDelay = 10 * 60 * 1000L) // 10분마다
+    public void run() {
+        try {
+            int count = aiReplyService.generateAiReplies(50);
+            if (count > 0) {
+                log.info("AI replies generated: {}", count);
+            }
+        } catch (Exception e) {
+            log.error("AI reply scheduler failed", e);
+        }
+    }
+}
+

--- a/src/main/java/com/example/egobook_be/domain/letters/scheduler/PlazaLetterGiveUpScheduler.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/scheduler/PlazaLetterGiveUpScheduler.java
@@ -1,0 +1,28 @@
+package com.example.egobook_be.domain.letters.scheduler;
+
+import com.example.egobook_be.domain.letters.service.scheduler.PlazaLetterGiveUpService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PlazaLetterGiveUpScheduler {
+
+    private final PlazaLetterGiveUpService giveUpService;
+
+    @Scheduled(fixedDelay = 5 * 60 * 1000L) // 5분마다
+    public void run() {
+        try {
+            int count = giveUpService.autoGiveUpExpiredLetters();
+            if (count > 0) {
+                log.info("Auto give-up processed: {}", count);
+            }
+        } catch (Exception e) {
+            log.error("Auto give-up scheduler failed", e);
+        }
+    }
+}
+

--- a/src/main/java/com/example/egobook_be/domain/letters/scheduler/PlazaLetterScheduler.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/scheduler/PlazaLetterScheduler.java
@@ -1,0 +1,19 @@
+package com.example.egobook_be.domain.letters.scheduler;
+
+import com.example.egobook_be.domain.letters.service.PlazaLetterDispatchService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PlazaLetterScheduler {
+
+    private final PlazaLetterDispatchService dispatchService;
+
+    // 5분마다 실행 (조절 가능)
+    @Scheduled(fixedDelay = 5 * 60 * 1000)
+    public void dispatchWaitingLetters() {
+        dispatchService.dispatchWaitingLetters();
+    }
+}

--- a/src/main/java/com/example/egobook_be/domain/letters/scheduler/PlazaLetterWaitingDispatchScheduler.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/scheduler/PlazaLetterWaitingDispatchScheduler.java
@@ -1,0 +1,19 @@
+package com.example.egobook_be.domain.letters.scheduler;
+
+import com.example.egobook_be.domain.letters.service.scheduler.PlazaLetterWaitingDispatchService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PlazaLetterWaitingDispatchScheduler {
+
+    private final PlazaLetterWaitingDispatchService dispatchService;
+
+    @Scheduled(fixedDelay = 5 * 60 * 1000L) // 5분마다
+    public void run() {
+        // 메서드 호출을 dispatchWaitingLetters로 수정
+        dispatchService.dispatchWaitingLetters();
+    }
+}

--- a/src/main/java/com/example/egobook_be/domain/letters/service/LetterService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/LetterService.java
@@ -1,0 +1,37 @@
+package com.example.egobook_be.domain.letters.service;
+
+import com.example.egobook_be.domain.letters.entity.PlazaLetter;
+import com.example.egobook_be.domain.letters.repository.PlazaLetterRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
+
+@Service
+@RequiredArgsConstructor
+public class LetterService {
+
+    private final PlazaLetterRepository plazaLetterRepository;
+
+    // 특정 편지 내용 가져오기
+    public String getLetterContentById(Long letterId) {
+        PlazaLetter letter = plazaLetterRepository.findById(letterId)
+                .orElseThrow(() -> new IllegalArgumentException("편지를 찾을 수 없습니다."));
+        return letter.getContent();
+    }
+
+    // AI 답장이 필요한지 여부를 확인
+    public boolean isEligibleForAIReply(Long letterId) {
+        PlazaLetter letter = plazaLetterRepository.findById(letterId)
+                .orElseThrow(() -> new IllegalArgumentException("편지를 찾을 수 없습니다."));
+
+        OffsetDateTime arrivedAt = letter.getArrivedAt();
+        if (arrivedAt == null) {
+            return false; // 편지가 도착하지 않았으면 AI 답장이 불필요
+        }
+
+        // 48시간이 경과했는지 확인
+        return arrivedAt.plus(48, ChronoUnit.HOURS).isBefore(OffsetDateTime.now());
+    }
+}

--- a/src/main/java/com/example/egobook_be/domain/letters/service/PlazaLetterDispatchService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/PlazaLetterDispatchService.java
@@ -1,0 +1,59 @@
+package com.example.egobook_be.domain.letters.service;
+
+import com.example.egobook_be.domain.letters.entity.PlazaLetter;
+import com.example.egobook_be.domain.letters.entity.PlazaLetterStatus;
+import com.example.egobook_be.domain.letters.repository.PlazaLetterRepository;
+import com.example.egobook_be.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+@Service
+@RequiredArgsConstructor
+public class PlazaLetterDispatchService {
+
+    private final PlazaLetterRepository plazaLetterRepository;
+    private final UserRepository userRepository;
+
+    private static final int BATCH_SIZE = 20;
+
+    /**
+     * WAITING 편지를 수신 가능한 유저에게 분배
+     */
+    @Transactional
+    public void dispatchWaitingLetters() {
+        OffsetDateTime now = OffsetDateTime.now();
+
+        List<PlazaLetter> waitingLetters =
+                plazaLetterRepository.findWaitingLetters(PageRequest.of(0, BATCH_SIZE));
+
+        for (PlazaLetter letter : waitingLetters) {
+
+            Long senderId = letter.getSenderId();
+
+            // sender 제외 + 쿨다운 해제된 유저 후보
+            List<Long> candidates =
+                    userRepository.findHighReplyRateCandidates(senderId, 30);
+
+            if (candidates.isEmpty()) {
+                // 👉 받을 사람 없으면 그대로 WAITING 유지
+                continue;
+            }
+
+            Long receiverId =
+                    candidates.get(ThreadLocalRandom.current().nextInt(candidates.size()));
+
+            // ===== 편지 도착 처리 =====
+            letter.assignReceiver(
+                    receiverId,
+                    now,
+                    now.plusHours(24)
+            );
+        }
+    }
+}

--- a/src/main/java/com/example/egobook_be/domain/letters/service/PlazaLetterService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/PlazaLetterService.java
@@ -194,6 +194,8 @@ public class PlazaLetterService {
                 .threadId(saved.getThreadId())
                 .status(saved.getStatus())
                 .mode(saved.getMode())
+                .fromLabel(saved.getFromLabel())
+                .backgroundColor(saved.getBackgroundColor().name())
                 .createdAt(saved.getCreatedAt())
                 .build();
     }
@@ -483,15 +485,20 @@ public class PlazaLetterService {
         );
 
         return SliceResponse.of(
-                plazaLetterReplyRepository.findByReplierIdOrderByReplyIdDesc(userId, pageable),
+                plazaLetterReplyRepository.findMyRepliesWithLetter(userId, pageable),
                 this::toReplyItemDto
         );
     }
 
     private ReplyItemDto toReplyItemDto(PlazaLetterReply reply) {
+        PlazaLetter letter = reply.getLetter();
+
         return ReplyItemDto.builder()
                 .replyId(reply.getReplyId())
-                .letterId(reply.getLetter().getLetterId())
+                .letterId(letter.getLetterId())
+                .threadId(reply.getThreadId())
+                .mode(letter.getMode())
+                .backgroundColor(letter.getBackgroundColor().name())
                 .replyText(reply.getText())
                 .createdAt(reply.getCreatedAt())
                 .build();

--- a/src/main/java/com/example/egobook_be/domain/letters/service/PlazaLetterService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/PlazaLetterService.java
@@ -2,6 +2,7 @@ package com.example.egobook_be.domain.letters.service;
 
 import com.example.egobook_be.domain.diary.dto.DiaryCreateResDto;
 import com.example.egobook_be.domain.diary.enums.RewardType;
+import com.example.egobook_be.domain.friend.repository.FriendRepository;
 import com.example.egobook_be.domain.home.entity.Mission;
 import com.example.egobook_be.domain.home.repository.MissionRepository;
 import com.example.egobook_be.domain.letters.entity.*;
@@ -48,6 +49,7 @@ public class PlazaLetterService {
     private final PlazaLetterRepository plazaLetterRepository;
     private final PlazaLetterReplyRepository plazaLetterReplyRepository;
     private final PlazaLetterThreadRepository plazaLetterThreadRepository;
+    private final FriendRepository friendRepository;
     private final InkLogRepository inkLogRepository;
     private final UserRepository userRepository;
     private final MissionRepository missionRepository;
@@ -82,6 +84,7 @@ public class PlazaLetterService {
         }
     }
 
+
     @Transactional
     public CreateLetterResponse createLetter(Long userId, CreateLetterRequest request) {
         // 1. User, Mission 객체 가져오기
@@ -96,6 +99,18 @@ public class PlazaLetterService {
         enforceDailyLimit(userId, now);
 
         enforceWordAiOrThrow(request.getText());
+
+        // 친구 관계 검증 추가
+        if (request.getMode() == PlazaLetterMode.FRIEND) {
+            // 친구 관계가 없으면 예외 처리
+            User receiver = userRepository.findById(request.getToFriendId())
+                    .orElseThrow(() -> new CustomException(LettersErrorCode.USER_NOT_FOUND));
+
+            // 친구 관계가 아닌 경우 예외 발생
+            if (!friendRepository.existsByUserAndFriend(user, receiver)) {
+                throw new CustomException(LettersErrorCode.NOT_FRIEND);
+            }
+        }
 
         PlazaLetterThread thread = plazaLetterThreadRepository.save(PlazaLetterThread.createNow());
         String bg = request.getBackgroundColor() == null ? "WHITE" : request.getBackgroundColor().name();
@@ -115,7 +130,7 @@ public class PlazaLetterService {
         OffsetDateTime replyDeadlineAt = null;
 
         if (request.getMode() == PlazaLetterMode.FRIEND) {
-            // TODO: friend 관계 검증 추가
+            // FRIEND 모드일 때 친구 관계 검증 후 진행
             receiverId = request.getToFriendId();
             status = PlazaLetterStatus.ARRIVED;
             arrivedAt = now;
@@ -182,6 +197,7 @@ public class PlazaLetterService {
                 .createdAt(saved.getCreatedAt())
                 .build();
     }
+
 
     private void enforceDailyLimit(Long userId, OffsetDateTime now) {
         ZoneId zoneId = ZoneId.of("Asia/Seoul");

--- a/src/main/java/com/example/egobook_be/domain/letters/service/PlazaLetterService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/PlazaLetterService.java
@@ -10,6 +10,7 @@ import com.example.egobook_be.domain.letters.dto.request.CreateLetterRequest;
 import com.example.egobook_be.domain.letters.dto.response.WordDetectResponse;
 import com.example.egobook_be.domain.letters.dto.response.*;
 import com.example.egobook_be.domain.letters.enums.LettersErrorCode;
+import com.example.egobook_be.domain.letters.enums.PlazaLetterColor;
 import com.example.egobook_be.domain.letters.repository.PlazaLetterReplyRepository;
 import com.example.egobook_be.domain.letters.repository.PlazaLetterRepository;
 import com.example.egobook_be.domain.letters.repository.PlazaLetterThreadRepository;
@@ -97,7 +98,7 @@ public class PlazaLetterService {
         enforceWordAiOrThrow(request.getText());
 
         PlazaLetterThread thread = plazaLetterThreadRepository.save(PlazaLetterThread.createNow());
-        String bg = resolveBackgroundColor(request.getBackgroundColor());
+        String bg = request.getBackgroundColor() == null ? "WHITE" : request.getBackgroundColor().name();
 
         String fromLabel = "익명";
         if (request.getMode() == PlazaLetterMode.FRIEND) {
@@ -140,7 +141,7 @@ public class PlazaLetterService {
                 .mode(request.getMode())
                 .fromLabel(fromLabel)
                 .content(request.getText())
-                .backgroundColor(bg)
+                .backgroundColor(PlazaLetterColor.valueOf(bg))
                 .status(status)                    // ARRIVED or WAITING
                 .createdAt(now)
                 .arrivedAt(arrivedAt)              // WAITING이면 null
@@ -211,11 +212,15 @@ public class PlazaLetterService {
     }
 
 
-    private String resolveBackgroundColor(String requested) {
+    private PlazaLetterColor resolveBackgroundColor(String requested) {
         if (requested == null || requested.isBlank()) {
-            return "WHITE";
+            return PlazaLetterColor.WHITE; // 기본 값: WHITE
         }
-        return requested.trim().toUpperCase();
+        try {
+            return PlazaLetterColor.valueOf(requested.trim().toUpperCase()); // Enum으로 변환
+        } catch (IllegalArgumentException e) {
+            return PlazaLetterColor.WHITE; // 잘못된 값은 기본 WHITE로 처리
+        }
     }
 
 

--- a/src/main/java/com/example/egobook_be/domain/letters/service/PlazaLetterService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/PlazaLetterService.java
@@ -97,7 +97,6 @@ public class PlazaLetterService {
         enforceWordAiOrThrow(request.getText());
 
         PlazaLetterThread thread = plazaLetterThreadRepository.save(PlazaLetterThread.createNow());
-        Long receiverId = resolveReceiverId(userId, request);
         String bg = resolveBackgroundColor(request.getBackgroundColor());
 
         String fromLabel = "익명";
@@ -108,18 +107,44 @@ public class PlazaLetterService {
             fromLabel = (nickname == null || nickname.isBlank()) ? "친구" : nickname;
         }
 
+        // ===== 핵심: receiverId/status/도착시간은 모드에 따라 다르게 =====
+        Long receiverId = null;
+        PlazaLetterStatus status;
+        OffsetDateTime arrivedAt = null;
+        OffsetDateTime replyDeadlineAt = null;
+
+        if (request.getMode() == PlazaLetterMode.FRIEND) {
+            // TODO: friend 관계 검증 추가
+            receiverId = request.getToFriendId();
+            status = PlazaLetterStatus.ARRIVED;
+            arrivedAt = now;
+            replyDeadlineAt = now.plusHours(24);
+        } else {
+            // RANDOM 모드: 후보가 없으면 WAITING으로 적재
+            List<Long> candidates = userRepository.findHighReplyRateCandidates(userId, 50);
+            if (candidates.isEmpty()) {
+                status = PlazaLetterStatus.WAITING;
+                // receiverId/arrivedAt/replyDeadlineAt = null 유지
+            } else {
+                receiverId = candidates.get(ThreadLocalRandom.current().nextInt(candidates.size()));
+                status = PlazaLetterStatus.ARRIVED;
+                arrivedAt = now;
+                replyDeadlineAt = now.plusHours(24);
+            }
+        }
+
         PlazaLetter letter = PlazaLetter.builder()
                 .threadId(thread.getThreadId())
                 .senderId(userId)
-                .receiverId(receiverId)
+                .receiverId(receiverId)            // WAITING이면 null
                 .mode(request.getMode())
                 .fromLabel(fromLabel)
                 .content(request.getText())
                 .backgroundColor(bg)
-                .status(PlazaLetterStatus.ARRIVED)
+                .status(status)                    // ARRIVED or WAITING
                 .createdAt(now)
-                .arrivedAt(now)
-                .replyDeadlineAt(now.plusHours(24))
+                .arrivedAt(arrivedAt)              // WAITING이면 null
+                .replyDeadlineAt(replyDeadlineAt)  // WAITING이면 null
                 .build();
 
         // =================================================
@@ -353,7 +378,15 @@ public class PlazaLetterService {
         OffsetDateTime now = OffsetDateTime.now();
         validateGiveUpable(letter, now);
 
+        // 유저 가져오기
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+
+        // 포기 처리
         letter.markGaveUp(now);
+
+        // 4시간 수신 제한
+        user.blockLetterReceiveUntil(now.plusHours(4));
 
         return GiveUpResponse.builder()
                 .letterId(letter.getLetterId())

--- a/src/main/java/com/example/egobook_be/domain/letters/service/ReplyReportService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/ReplyReportService.java
@@ -70,10 +70,12 @@ public class ReplyReportService {
     // 신고 횟수 3회 누적 시 답장 삭제 및 신고 DB로 이동
     private void moveReplyToReportDbAndDelete(Long replyId) {
         // 신고 DB로 이동하고 답장 삭제 처리
-        replyReportRepository.moveReplyToReportDbAndDelete(replyId);
+        replyReportRepository.moveReplyToReportDbAndDelete(replyId, PlazaLetterReply.ReplyStatus.DELETED);
 
         // 해당 답장 삭제
         plazaLetterReplyRepository.deleteById(replyId);
     }
+
+
 }
 

--- a/src/main/java/com/example/egobook_be/domain/letters/service/ReplyReportService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/ReplyReportService.java
@@ -56,6 +56,24 @@ public class ReplyReportService {
                 .build();
 
         replyReportRepository.save(report);
+
+        // 신고된 답장의 신고 횟수 확인
+        long reportCount = replyReportRepository.countByReply_ReplyId(replyId);
+
+        // 3회 신고가 누적되었으면 해당 답장 삭제 및 신고 DB로 이동
+        if (reportCount >= 3) {
+            // 3회 누적 신고된 답장 삭제 및 신고 DB로 이동
+            moveReplyToReportDbAndDelete(replyId);
+        }
+    }
+
+    // 신고 횟수 3회 누적 시 답장 삭제 및 신고 DB로 이동
+    private void moveReplyToReportDbAndDelete(Long replyId) {
+        // 신고 DB로 이동하고 답장 삭제 처리
+        replyReportRepository.moveReplyToReportDbAndDelete(replyId);
+
+        // 해당 답장 삭제
+        plazaLetterReplyRepository.deleteById(replyId);
     }
 }
 

--- a/src/main/java/com/example/egobook_be/domain/letters/service/ai/GeminiClient.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/ai/GeminiClient.java
@@ -1,0 +1,96 @@
+package com.example.egobook_be.domain.letters.service.ai;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class GeminiClient {
+
+    private final WebClient webClient;
+    private final String apiKey;
+    private final String model;
+    private final String baseUrl;
+
+    public GeminiClient(WebClient.Builder webClientBuilder,
+                        @Value("${gemini.base-url}") String baseUrl,
+                        @Value("${gemini.api-key}") String apiKey,
+                        @Value("${gemini.model}") String model) {
+        this.webClient = webClientBuilder.baseUrl(baseUrl).build(); // WebClient 설정
+        this.apiKey = apiKey;
+        this.model = model;
+        this.baseUrl = baseUrl;
+    }
+
+    public String generateReply(String nickname, String letterContent) {
+        String prompt = buildPrompt(nickname, letterContent);
+
+        String url = baseUrl + "/v1beta/models/" + model + ":generateContent";
+
+        Map<String, Object> body = Map.of(
+                "contents", List.of(
+                        Map.of("role", "user", "parts", List.of(
+                                Map.of("text", prompt)
+                        ))
+                ),
+                "generationConfig", Map.of(
+                        "temperature", 0.6,
+                        "maxOutputTokens", 256
+                )
+        );
+
+        // WebClient로 요청 보내기
+        Mono<GeminiResponse> response = webClient.post()
+                .uri(url)
+                .header("X-goog-api-key", apiKey) // API 키를 헤더에 추가
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(body)
+                .retrieve()
+                .bodyToMono(GeminiResponse.class);
+
+        // 응답이 비어 있지 않다면 텍스트를 반환
+        GeminiResponse geminiResponse = response.block(); // block()을 통해 비동기 요청을 동기적으로 처리
+        if (geminiResponse == null || geminiResponse.getText() == null || geminiResponse.getText().isBlank()) {
+            throw new IllegalStateException("Gemini response is empty");
+        }
+
+        return geminiResponse.getText().trim();
+    }
+
+    private String buildPrompt(String nickname, String letterContent) {
+        String safeNickname = (nickname == null) ? "" : nickname.trim();
+        String safeLetter = (letterContent == null) ? "" : letterContent.trim();
+
+        return """
+                너는 "에고북" 앱에서 48시간 동안 답장이 없을 때 대신 답장을 작성하는 AI야.
+                아래 규칙을 엄격하게 지키고, 답장 본문만 출력해.
+
+                [규칙]
+                1) 3~5줄로 작성
+                2) 전체 360자 이내
+                3) 해요체 사용
+                4) 공감/이해/인정 중심으로 작성
+                5) 이모지 금지, 특수문자 감정표현 금지
+                6) 2인칭 대명사 사용 금지: 당신, 너, 그대, 님, 여러분 등
+                7) 사용자는 닉네임으로만 지칭 가능 (예: "%s")
+                8) 머리말/서명/제목/번호/따옴표/안내문 출력 금지
+                9) 조언은 강요하지 말고, 부드럽고 현실적인 한두 문장만
+
+                [닉네임]
+                %s
+
+                [원문 편지]
+                %s
+                """.formatted(
+                safeNickname.isEmpty() ? "사용자" : safeNickname,
+                safeNickname,
+                safeLetter
+        );
+    }
+}

--- a/src/main/java/com/example/egobook_be/domain/letters/service/ai/GeminiClient.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/ai/GeminiClient.java
@@ -48,7 +48,7 @@ public class GeminiClient {
         // WebClient로 요청 보내기
         Mono<GeminiResponse> response = webClient.post()
                 .uri(url)
-                .header("X-goog-api-key", apiKey) // API 키를 헤더에 추가
+                .header("X-goog-api-key", apiKey)
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(body)
                 .retrieve()

--- a/src/main/java/com/example/egobook_be/domain/letters/service/ai/GeminiResponse.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/ai/GeminiResponse.java
@@ -1,0 +1,39 @@
+package com.example.egobook_be.domain.letters.service.ai;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GeminiResponse {
+
+    private List<Candidate> candidates;
+
+    public String getText() {
+        if (candidates == null || candidates.isEmpty()) return null;
+        Candidate c = candidates.get(0);
+        if (c.content == null || c.content.parts == null || c.content.parts.isEmpty()) return null;
+        Part p = c.content.parts.get(0);
+        return p.text;
+    }
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Candidate {
+        private Content content;
+    }
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Content {
+        private List<Part> parts;
+    }
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Part {
+        private String text;
+    }
+}

--- a/src/main/java/com/example/egobook_be/domain/letters/service/ai/PlazaLetterAiReplyService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/ai/PlazaLetterAiReplyService.java
@@ -28,8 +28,7 @@ public class PlazaLetterAiReplyService {
 
     @Transactional
     public int generateAiReplies(int batchSize) {
-        //OffsetDateTime cutoff = OffsetDateTime.now().minusHours(48);
-        OffsetDateTime cutoff = OffsetDateTime.now().plusMinutes(1);  // 1분 뒤로 설정
+        OffsetDateTime cutoff = OffsetDateTime.now().minusHours(48);
 
 
         List<PlazaLetter> targets = plazaLetterRepository.findAiReplyTargets(
@@ -65,8 +64,7 @@ public class PlazaLetterAiReplyService {
 
         // 48시간 지났는지 최종 확인 (스케줄러 지연/수동 호출 대비)
         OffsetDateTime createdAt = letter.getCreatedAt();
-        //if (createdAt == null || OffsetDateTime.now().isBefore(createdAt.plusHours(48))) {
-        if (createdAt == null || OffsetDateTime.now().isBefore(createdAt.plusMinutes(1))) {
+        if (createdAt == null || OffsetDateTime.now().isBefore(createdAt.plusHours(48))) {
             return false;
         }
 

--- a/src/main/java/com/example/egobook_be/domain/letters/service/ai/PlazaLetterAiReplyService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/ai/PlazaLetterAiReplyService.java
@@ -52,10 +52,11 @@ public class PlazaLetterAiReplyService {
         PlazaLetter letter = plazaLetterRepository.findById(letterId).orElse(null);
         if (letter == null) return false;
 
-
+        // 상태가 이미 REPLIED 또는 AI_REPLIED인 경우 건너뛰기
         if (letter.getStatus() == PlazaLetterStatus.REPLIED || letter.getStatus() == PlazaLetterStatus.AI_REPLIED) {
             return false;
         }
+
 
         // reply 존재하면 스킵
         if (plazaLetterReplyRepository.existsByLetter(letter)) { // 수정된 부분
@@ -92,6 +93,10 @@ public class PlazaLetterAiReplyService {
             return false;
         }
 
+        // 편지 상태 업데이트: AI가 답변한 경우 상태를 AI_REPLIED로 설정
+        letter.setStatus(PlazaLetterStatus.AI_REPLIED);
+        letter.setArrivedAt(now);
+        plazaLetterRepository.save(letter);
 
         letter.markAiReplied(now);
 

--- a/src/main/java/com/example/egobook_be/domain/letters/service/ai/PlazaLetterAiReplyService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/ai/PlazaLetterAiReplyService.java
@@ -1,0 +1,176 @@
+package com.example.egobook_be.domain.letters.service.ai;
+
+import com.example.egobook_be.domain.letters.entity.*;
+import com.example.egobook_be.domain.letters.repository.PlazaLetterReplyRepository;
+import com.example.egobook_be.domain.letters.repository.PlazaLetterRepository;
+import com.example.egobook_be.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PlazaLetterAiReplyService {
+
+    private static final int AI_REPLY_CHAR_LIMIT = 360;
+
+    private final PlazaLetterRepository plazaLetterRepository;
+    private final PlazaLetterReplyRepository plazaLetterReplyRepository;
+    private final UserRepository userRepository;
+    private final GeminiClient geminiClient;
+
+    @Transactional
+    public int generateAiReplies(int batchSize) {
+        //OffsetDateTime cutoff = OffsetDateTime.now().minusHours(48);
+        OffsetDateTime cutoff = OffsetDateTime.now().plusMinutes(1);  // 1분 뒤로 설정
+
+
+        List<PlazaLetter> targets = plazaLetterRepository.findAiReplyTargets(
+                cutoff,
+                PlazaLetterStatus.REPLIED,
+                PlazaLetterStatus.AI_REPLIED,
+                PageRequest.of(0, batchSize)
+        );
+
+        int processed = 0;
+        for (PlazaLetter letter : targets) {
+            if (generateAiReplyIfEligible(letter.getLetterId())) {
+                processed++;
+            }
+        }
+        return processed;
+    }
+
+    @Transactional
+    public boolean generateAiReplyIfEligible(Long letterId) {
+        PlazaLetter letter = plazaLetterRepository.findById(letterId).orElse(null);
+        if (letter == null) return false;
+
+
+        if (letter.getStatus() == PlazaLetterStatus.REPLIED || letter.getStatus() == PlazaLetterStatus.AI_REPLIED) {
+            return false;
+        }
+
+        // reply 존재하면 스킵
+        if (plazaLetterReplyRepository.existsByLetterId(letterId)) {
+            return false;
+        }
+
+        // 48시간 지났는지 최종 확인 (스케줄러 지연/수동 호출 대비)
+        OffsetDateTime createdAt = letter.getCreatedAt();
+        //if (createdAt == null || OffsetDateTime.now().isBefore(createdAt.plusHours(48))) {
+        if (createdAt == null || OffsetDateTime.now().isBefore(createdAt.plusMinutes(1))) {
+            return false;
+        }
+
+        String nickname = userRepository.findById(letter.getSenderId())
+                .map(u -> u.getNickname())
+                .orElse("");
+
+        String raw = geminiClient.generateReply(nickname, letter.getContent());
+        String normalized = normalizeAiReply(raw);
+
+        OffsetDateTime now = OffsetDateTime.now();
+
+        PlazaLetterReply aiReply = PlazaLetterReply.builder()
+                .threadId(letter.getThreadId())
+                .letterId(letter.getLetterId())
+                .replierId(letter.getSenderId())
+                .text(normalized)
+                .isAiGenerated(true)
+                .createdAt(now)
+                .build();
+
+        try {
+            plazaLetterReplyRepository.save(aiReply);
+        } catch (DataIntegrityViolationException e) {
+            return false;
+        }
+
+
+        letter.markAiReplied(now);
+
+        return true;
+    }
+
+    private String normalizeAiReply(String text) {
+        if (text == null) return fallbackText();
+
+        String t = text.trim();
+
+        // 360자 컷
+        if (t.length() > AI_REPLY_CHAR_LIMIT) {
+            t = t.substring(0, AI_REPLY_CHAR_LIMIT).trim();
+        }
+
+        // 5줄 초과 컷
+        String[] lines = t.split("\\r?\\n");
+        if (lines.length > 5) {
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < 5; i++) {
+                if (i > 0) sb.append("\n");
+                sb.append(lines[i].trim());
+            }
+            t = sb.toString().trim();
+        }
+
+        // 3줄 미만이면 줄바꿈 보정
+        lines = t.split("\\r?\\n");
+        if (lines.length < 3) {
+            t = forceLineBreaks(t);
+        }
+
+        if (t.isBlank()) return fallbackText();
+
+        // 혹시라도 "당신/너" 등 금칙어가 들어가면 아주 간단하게 치환(강제)
+        t = t.replace("당신", "")
+                .replace("너", "")
+                .replace("그대", "")
+                .replace("여러분", "")
+                .trim();
+
+        if (t.isBlank()) return fallbackText();
+        return t;
+    }
+
+    private String forceLineBreaks(String t) {
+
+        String x = t.replaceAll("([.!?。])\\s+", "$1\n").trim();
+        String[] lines = x.split("\\r?\\n");
+        if (lines.length >= 3) return x;
+
+
+        if (!x.contains("\n") && x.length() > 80) {
+            int cut1 = Math.min(50, x.length());
+            int cut2 = Math.min(100, x.length());
+            String a = x.substring(0, cut1).trim();
+            String b = x.substring(cut1, cut2).trim();
+            String c = x.substring(cut2).trim();
+            String merged = (a + "\n" + b + (c.isBlank() ? "" : "\n" + c)).trim();
+
+            // 5줄 넘어가면 컷
+            String[] mLines = merged.split("\\r?\\n");
+            if (mLines.length > 5) {
+                StringBuilder sb = new StringBuilder();
+                for (int i = 0; i < 5; i++) {
+                    if (i > 0) sb.append("\n");
+                    sb.append(mLines[i].trim());
+                }
+                return sb.toString().trim();
+            }
+            return merged;
+        }
+
+        return x;
+    }
+
+    private String fallbackText() {
+        return "마음이 많이 무거운 시간을 지나고 있었겠어요.\n지금까지 버텨온 것만으로도 충분히 애쓰고 있어요.\n오늘은 마음이 조금이라도 가벼워졌으면 좋겠어요.";
+    }
+}
+

--- a/src/main/java/com/example/egobook_be/domain/letters/service/scheduler/PlazaLetterBatchScheduler.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/scheduler/PlazaLetterBatchScheduler.java
@@ -1,0 +1,44 @@
+package com.example.egobook_be.domain.letters.service.scheduler;
+
+import com.example.egobook_be.domain.letters.service.ai.PlazaLetterAiReplyService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PlazaLetterBatchScheduler {
+
+    private final com.example.egobook_be.domain.letters.service.scheduler.PlazaLetterGiveUpService giveUpService;
+    private final PlazaLetterWaitingDispatchService waitingDispatchService;
+    private final PlazaLetterAiReplyService aiReplyService;
+
+    // 1) 24시간 초과 자동 포기 처리: 1분마다
+    @Scheduled(fixedDelay = 60_000)
+    public void autoGiveUpExpiredLetters() {
+        int processed = giveUpService.autoGiveUpExpiredLetters();
+        if (processed > 0) {
+            log.info("[PlazaLetter] autoGiveUp processed={}", processed);
+        }
+    }
+
+    // 2) 수신 가능(포기 후 4시간 경과) 유저에게 WAITING 편지 배정: 1분마다
+    @Scheduled(fixedDelay = 60_000)
+    public void dispatchWaitingLetters() {
+        int dispatched = waitingDispatchService.dispatchWaitingLetters();
+        if (dispatched > 0) {
+            log.info("[PlazaLetter] waiting dispatch dispatched={}", dispatched);
+        }
+    }
+
+    // 3) 48시간 무응답 AI 답장 대체: 5분마다
+    @Scheduled(fixedDelay = 300_000)
+    public void generateAiReplies() {
+        int replaced = aiReplyService.generateAiReplies(200);  // 원하는 배치 사이즈를 넣어주기
+        if (replaced > 0) {
+            log.info("[PlazaLetter] aiReply generated={}", replaced);
+        }
+    }
+}

--- a/src/main/java/com/example/egobook_be/domain/letters/service/scheduler/PlazaLetterGiveUpService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/scheduler/PlazaLetterGiveUpService.java
@@ -1,0 +1,51 @@
+package com.example.egobook_be.domain.letters.service.scheduler;
+
+import com.example.egobook_be.domain.letters.entity.PlazaLetter;
+import com.example.egobook_be.domain.letters.entity.PlazaLetterStatus;
+import com.example.egobook_be.domain.letters.repository.PlazaLetterRepository;
+import com.example.egobook_be.domain.user.entity.User;
+import com.example.egobook_be.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PlazaLetterGiveUpService {
+
+    private final PlazaLetterRepository plazaLetterRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public int autoGiveUpExpiredLetters() {
+        OffsetDateTime now = OffsetDateTime.now();
+
+        PlazaLetterStatus arrived = PlazaLetterStatus.ARRIVED;
+        PlazaLetterStatus deferred = PlazaLetterStatus.DEFERRED;
+        Pageable pageable = PageRequest.of(0, 200);
+
+
+        List<PlazaLetter> targets = plazaLetterRepository.findGiveUpTargets(now, arrived, deferred, pageable);
+
+        if (targets.isEmpty()) return 0;
+
+        for (PlazaLetter letter : targets) {
+
+            letter.markGaveUp(now);
+
+            Long receiverId = letter.getReceiverId();
+            if (receiverId != null) {
+                User receiver = userRepository.findById(receiverId).orElse(null);
+                if (receiver != null) {
+                    receiver.blockLetterReceiveUntil(now.plusHours(4));
+                }
+            }
+        }
+        return targets.size();
+    }
+}

--- a/src/main/java/com/example/egobook_be/domain/letters/service/scheduler/PlazaLetterWaitingDispatchService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/scheduler/PlazaLetterWaitingDispatchService.java
@@ -1,0 +1,55 @@
+package com.example.egobook_be.domain.letters.service.scheduler;
+
+import com.example.egobook_be.domain.letters.entity.PlazaLetter;
+import com.example.egobook_be.domain.letters.repository.PlazaLetterRepository;
+import com.example.egobook_be.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PlazaLetterWaitingDispatchService {
+
+    private final PlazaLetterRepository plazaLetterRepository;
+    private final UserRepository userRepository;
+
+    // 유저 1명당 편지 1건씩만 배정 (원하면 batchSize 조절)
+    private static final int BATCH_SIZE = 50;
+
+    @Transactional
+    public int dispatchWaitingLetters() {
+        OffsetDateTime now = OffsetDateTime.now();
+
+        // 1) 수신 가능 유저 찾기 (포기 후 4시간 지난 유저)
+        List<Long> candidateUserIds =
+                userRepository.findReceivableUsers(now, PageRequest.of(0, BATCH_SIZE)); // 이 부분은 PageRequest를 Pageable로 사용하고 있음
+
+        if (candidateUserIds.isEmpty()) return 0;
+
+        // 2) WAITING 편지 중 아직 receiver가 없는 편지 가져오기 (포기된 편지 제외는 repo 쿼리에서 처리)
+        List<PlazaLetter> waitingLetters =
+                plazaLetterRepository.findWaitingLetters(PageRequest.of(0, candidateUserIds.size())); // 동일하게 PageRequest를 사용
+
+        if (waitingLetters.isEmpty()) return 0;
+
+        int dispatchCount = Math.min(candidateUserIds.size(), waitingLetters.size());
+
+        for (int i = 0; i < dispatchCount; i++) {
+            PlazaLetter letter = waitingLetters.get(i);
+            Long receiverId = candidateUserIds.get(i);
+
+            // 편지에 수신자 붙이고 ARRIVED로 전환 + arrivedAt/replyDeadlineAt 설정
+            letter.assignToReceiver(receiverId, now, now.plusHours(24));
+
+            // 유저는 이제 다시 차단 해제 상태(원하면 null로 지우거나 유지 가능)
+            // 이 부분은 정책 선택: "차단이 끝나면 수신 가능"만 필요하면 굳이 null로 안 지워도 됨.
+        }
+
+        return dispatchCount;
+    }
+}

--- a/src/main/java/com/example/egobook_be/domain/user/entity/User.java
+++ b/src/main/java/com/example/egobook_be/domain/user/entity/User.java
@@ -10,6 +10,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
@@ -165,4 +166,29 @@ public class User extends BaseTimeEntity {
     public void updateWeeklyAnalysisEnabled(boolean enabled) {
         this.weeklyAnalysisEnabled = enabled;
     }
+
+
+    // 편지 전송 조건 저장
+    @Column(name = "letter_receive_blocked_until")
+    private OffsetDateTime letterReceiveBlockedUntil;
+
+    public void blockLetterReceiveUntil(OffsetDateTime until) {
+        this.letterReceiveBlockedUntil = until;
+    }
+
+    public boolean canReceiveLetterAt(OffsetDateTime now) {
+        return letterReceiveBlockedUntil == null || !now.isBefore(letterReceiveBlockedUntil);
+    }
+
+
+    // 해당 시간까지 수신 차단된 상태인지 확인하는 메서드도 필요할 수 있음.
+    public boolean canReceiveLetters() {
+        return letterReceiveBlockedUntil == null || OffsetDateTime.now().isAfter(letterReceiveBlockedUntil);
+    }
+
+    // getter, setter
+    public OffsetDateTime getLetterReceiveBlockedUntil() {
+        return letterReceiveBlockedUntil;
+    }
+
 }

--- a/src/main/java/com/example/egobook_be/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/user/repository/UserRepository.java
@@ -2,6 +2,7 @@ package com.example.egobook_be.domain.user.repository;
 
 import com.example.egobook_be.domain.user.entity.User;
 import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
@@ -9,6 +10,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import org.springframework.data.domain.Pageable;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -45,6 +48,16 @@ public interface UserRepository extends JpaRepository<User, Long>,UserRepository
     Optional<User> findByIdWithLock(@Param("userId") Long userId);
 
     // 수신에 동의한 유저만 조회
-    List<User> findByDailyPraiseTrue();
     List<User> findAllByWeeklyAnalysisEnabledTrue();
+
+    List<User> findByDailyPraiseTrue();
+
+    // 편지 수신 가능으로 변한 유저 찾기
+    @Query("""
+    select u.id
+    from User u
+    where u.letterReceiveBlockedUntil is not null
+      and u.letterReceiveBlockedUntil <= :now
+""")
+    List<Long> findReceivableUsers(OffsetDateTime now, PageRequest pageable);
 }

--- a/src/main/java/com/example/egobook_be/domain/user/repository/UserRepositoryCustomImpl.java
+++ b/src/main/java/com/example/egobook_be/domain/user/repository/UserRepositoryCustomImpl.java
@@ -44,6 +44,7 @@ public class UserRepositoryCustomImpl implements UserRepositoryCustom {
                 GROUP BY replier_id
             ) p ON p.uid = u.id
             WHERE u.id <> :excludeUserId
+                AND (u.letter_receive_blocked_until IS NULL OR u.letter_receive_blocked_until <= NOW())
         """ + statusWhere + """
             ORDER BY (COALESCE(p.reply_cnt,0) / NULLIF(COALESCE(r.received_cnt,0),0)) DESC,
                      COALESCE(p.reply_cnt,0) DESC,

--- a/src/main/java/com/example/egobook_be/global/config/WebClientConfig.java
+++ b/src/main/java/com/example/egobook_be/global/config/WebClientConfig.java
@@ -1,0 +1,18 @@
+package com.example.egobook_be.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Value("${gemini.base-url}")
+    private String baseUrl;
+
+    @Bean
+    public WebClient.Builder webClientBuilder() {
+        return WebClient.builder().baseUrl(baseUrl);  // baseUrl 설정
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -65,3 +65,8 @@ app:
 word:
   ai:
     base-url: ${WORD_AI_BASE_URL}
+
+gemini:
+  base-url: "https://generativelanguage.googleapis.com"
+  api-key: "${GEMINI_API_KEY}"
+  model: "gemini-2.0-flash"

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -69,3 +69,8 @@ app:
 word:
   ai:
     base-url: ${WORD_AI_BASE_URL}
+
+gemini:
+  base-url: "https://generativelanguage.googleapis.com"
+  api-key: "${GEMINI_API_KEY}"
+  model: "gemini-2.0-flash"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -67,3 +67,8 @@ management:
 word:
   ai:
     base-url: ${WORD_AI_BASE_URL}
+
+gemini:
+  base-url: "https://generativelanguage.googleapis.com"
+  api-key: "${GEMINI_API_KEY}"
+  model: "gemini-2.0-flash"


### PR DESCRIPTION
## #️⃣연관된 이슈
- #42 

## 📝작업 내용
- ai 답장 로직, 친구 검증 로직

### AI 답장 생성 로직 흐름
생성 가능한 편지 확인

1. 대상 편지 목록 가져오기:plazaLetterRepository.findAiReplyTargets 메소드를 통해 AI 답장이 가능한 편지들을 조회합니다. 이때 48시간 이내에 답장이 없는 REPLIED 상태의 편지들을 대상으로 합니다.
2. 답장 가능 여부 확인:해당 편지가 이미 답장된 상태(AI나 일반 답장)라면 AI 답장을 생성하지 않습니다. 답장을 작성할 수 있는 상태인지 확인합니다(예: 답장이 없는 편지)

AI 답장 생성

1. Gemini API를 통해 답장 내용 생성:geminiClient.generateReply 메소드를 호출하여 AI 답장을 생성합니다. 이때, 편지의 발신자 닉네임과 내용을 바탕으로 답장 텍스트를 생성합니다.
2. AI 답장 텍스트 정규화:normalizeAiReply 메소드를 사용하여 AI가 생성한 답장 텍스트를 정리하고 길이를 제한합니다.길이 제한: 360자 이내로 자르고, 불필요한 단어(예: "당신", "너")를 제거하여 보다 자연스러운 문장을 생성합니다.

AI 답장 저장

1. PlazaLetterReply 엔티티에 저장:PlazaLetterReply 엔티티를 생성하여 AI 답장을 데이터베이스에 저장합니다. 이때, isAiGenerated 플래그는 true로 설정됩니다.
2. AI 답장 상태 업데이트:AI 답장이 저장되면, markAiReplied 메소드를 호출하여 해당 편지의 상태를 AI_REPLIED로 변경하고 답장한 시간을 기록합니다.
3. 예외 처리:만약 AI 답장을 생성할 수 없는 상황(예: 48시간이 지나지 않은 편지)이면 해당 편지는 건너뛰고, 유효한 편지만 AI 답장이 생성됩니다.

### 스크린샷 (선택)
<img width="2490" height="1234" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/82c390bc-711d-4ed4-a0f2-36ccb43e674f" />
<img width="1471" height="772" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/84a7c516-d322-4c57-a7a8-115de788e7af" />


## 💬리뷰 요구사항(선택)
- `답장을 하지 않은 상태로 도착 24시간이 지나면 자동으로 ‘포기하기’ 상태. 포기하기 이후 4시간이 지난 상태일 경우 남의 편지를 받을 수 있는 상태가 됨 `: 이 기능을 구현하는 과정에서 user 파일에 코드 추가했으므로 확인 필요
- 제미나이 키값 추가로 deploy.yml 수정함
- 로컬에서 모든 테스트를 마쳐 더미데이터 주석 처리함
- 편지지 색상이 하얀색빼고는 유료인데 구매하지않았는데 api 요청에 넣을경우를 막아두어야할지 고민임
- 중간에 풀받고 충돌이 있어서 해결함
