### PR TITLE
:recycle: Refactor: 구글 Recertification 로직 -> Access Token은 선택으로 넣어 요청…

### DIFF
--- a/src/main/java/com/example/egobook_be/domain/auth/dto/req/GoogleRecertificationReqDto.java
+++ b/src/main/java/com/example/egobook_be/domain/auth/dto/req/GoogleRecertificationReqDto.java
@@ -11,7 +11,6 @@ public record GoogleRecertificationReqDto(
         String idToken, // 안드로이드가 구글에서 받아온 ID Token
 
         @Schema(description = "만료되었거나 만료되지 않은, 기존에 사용하던 Access Token (Bearer 제외)", example = "eyJhbGciOiJIUzI1NiJ9...")
-        @NotBlank(message = "Access Token은 필수입니다.")
         String accessToken
 ) {
 }

--- a/src/main/java/com/example/egobook_be/domain/auth/sevice/AuthService.java
+++ b/src/main/java/com/example/egobook_be/domain/auth/sevice/AuthService.java
@@ -404,10 +404,12 @@ public class AuthService {
 
         /*
          * 4. Redis 상태 업데이트
-         * (1) 기존에 사용되던 AccessToken 블랙리스트에 등록
+         * (1) 기존에 사용되던 AccessToken 블랙리스트에 등록 (Access Token이 Request Dto에 있는 경우에만)
          * (2) 기존에 Refresh Token Backup 테이블에 있던 Refresh Token Redis에서 삭제 (아직 만료되지 않은 상태에서 복구 로직이 실행될 수도 있으므로)
          */
-        addAccessTokenInRedisBlackList(reqDto.accessToken());
+        if (reqDto.accessToken() != null && !reqDto.accessToken().isBlank()) {
+            addAccessTokenInRedisBlackList(reqDto.accessToken());
+        }
         deleteOldRefreshTokenFromRedis(authAccount);
 
         // 5. 토큰 재발급 (Access + Refresh)


### PR DESCRIPTION
## #️⃣연관된 이슈
- #13 

## 📝작업 내용
- Google Recertification 시, 기존에는 반드시 기존에 사용하던 Access Token도 서버에게 보내주어야 했음
- 하지만, 클라이언트가 앱 삭제 or 앱 데이터 삭제 후 구글 계정으로 재로그인 시도 시, 기존에 사용하던 Access Token이 이미 없어진 상태이므로 서버에게 Access Token 값을 보내줄 수 없게 되었음
- 따라서, Access Token은 선택적으로 보낼 수 있게 하되, 프론트에게 기존에 사용하던 Access Token이 있으면 반드시 보내도록 전달하였음