### PR TITLE
✨ Feat: 광고 API

### DIFF
--- a/src/main/java/com/example/egobook_be/domain/ads/controller/AdsController.java
+++ b/src/main/java/com/example/egobook_be/domain/ads/controller/AdsController.java
@@ -1,17 +1,89 @@
 package com.example.egobook_be.domain.ads.controller;
 
+import com.example.egobook_be.domain.ads.dto.UserAdStatusResDto;
+import com.example.egobook_be.domain.ads.service.AdsService;
+import com.example.egobook_be.global.response.GlobalResponse;
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 public class AdsController implements AdsControllerDocs{
+    private final AdsService adsService;
 
     @Override
-    public ResponseEntity<Void> callback(){
-        return ResponseEntity.ok().build();
+    public ResponseEntity<Void> callback(
+            @Parameter(hidden = true) HttpServletRequest request, // 원본 쿼리 스트링 추출용 (서명 검증에 필수임)
+
+            @Parameter(description = "AdMob에서 생성한 SSV 콜백 서명 값", required = true)
+            @RequestParam("signature") String signature,
+
+            @Parameter(description = "서명 검증에 사용할 키 ID", required = true)
+            @RequestParam("key_id") String keyId,
+
+            @Parameter(description = "광고 시청 고유 트랜잭션 ID (중복 방지 키)", required = true)
+            @RequestParam("transaction_id") String transactionId,
+
+            @Parameter(description = "사용자 식별자 (앱에서 설정한 값)", required = true)
+            @RequestParam("user_id") String userId,
+
+            @Parameter(description = "지급할 보상 아이템 타입")
+            @RequestParam("reward_item") String rewardType,
+
+            @Parameter(description = "광고 단위 ID (어떤 광고를 봤는지)")
+            @RequestParam(value = "ad_unit", required = false) String adUnitId,
+
+            @Parameter(description = "커스텀 데이터: 확인할 주간 보고서 ID")
+            @RequestParam(value = "custom_data", required = false) String weeklyCounselId
+    ){
+        /*
+         * 1. 원본 쿼리 스트링 추출 (서명 검증의 핵심 재료)
+         * - Spring이 파싱한 @RequestParam들은 순서가 보장되지 않으므로, 반드시 request.getQueryString()으로 원본을 가져와야 합니다.
+         */
+        String queryString = request.getQueryString();
+        try {
+            // 2. 서비스 레이어로 위임
+            adsService.adMobCallbackInk(
+                    queryString,
+                    signature,
+                    keyId,
+                    transactionId,
+                    userId,
+                    weeklyCounselId,
+                    rewardType,
+                    adUnitId
+            );
+
+            // 3. 성공 시 무조건 200 OK
+            return ResponseEntity.ok().build();
+        } catch (SecurityException e) {
+            // 서명 검증 실패 시: 명확하게 403 Forbidden 반환하여 구글에게 거부 의사 표시
+            log.error("[AdMob Callback] 서명 검증 실패: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+
+        } catch (Exception e) {
+            // 그 외 DB 오류 등: 500 에러를 뱉으면 구글이 나중에 재시도(Retry)를 합니다.
+            log.error("[AdMob Callback] 내부 처리 중 오류 발생: ", e);
+            return ResponseEntity.internalServerError().build();
+        }
     }
 
-
+    @Override
+    public ResponseEntity<GlobalResponse<UserAdStatusResDto>> getUserAdStatus(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal(expression = "userAuthDto.userId") Long userId
+    ){
+        UserAdStatusResDto resDto = adsService.getUserAdStatus(userId);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(GlobalResponse.success("해당 사용자의 광고들의 정보 조회 완료", resDto));
+    }
 }

--- a/src/main/java/com/example/egobook_be/domain/ads/controller/AdsController.java
+++ b/src/main/java/com/example/egobook_be/domain/ads/controller/AdsController.java
@@ -23,25 +23,25 @@ public class AdsController implements AdsControllerDocs{
     public ResponseEntity<Void> callback(
             @Parameter(hidden = true) HttpServletRequest request, // 원본 쿼리 스트링 추출용 (서명 검증에 필수임)
 
-            @Parameter(description = "AdMob에서 생성한 SSV 콜백 서명 값", required = true)
+            @Parameter(description = "AdMob에서 생성한 SSV 콜백 서명 값", required = true, example = "TEST_PASS")
             @RequestParam("signature") String signature,
 
-            @Parameter(description = "서명 검증에 사용할 키 ID", required = true)
+            @Parameter(description = "서명 검증에 사용할 키 ID", required = true, example = "test_key_123")
             @RequestParam("key_id") String keyId,
 
-            @Parameter(description = "광고 시청 고유 트랜잭션 ID (중복 방지 키)", required = true)
+            @Parameter(description = "광고 시청 고유 트랜잭션 ID (중복 방지 키)", required = true, example = "TX_TEST_001")
             @RequestParam("transaction_id") String transactionId,
 
-            @Parameter(description = "사용자 식별자 (앱에서 설정한 값)", required = true)
+            @Parameter(description = "사용자 식별자 (앱에서 설정한 값)", required = true, example = "1")
             @RequestParam("user_id") String userId,
 
-            @Parameter(description = "지급할 보상 아이템 타입")
+            @Parameter(description = "지급할 보상 아이템 타입 (INK or WEEK_COUNSEL)", example = "INK")
             @RequestParam("reward_item") String rewardType,
 
-            @Parameter(description = "광고 단위 ID (어떤 광고를 봤는지)")
+            @Parameter(description = "광고 단위 ID (어떤 광고를 봤는지)", required = false, example = "ca-app-pub-3940256099942544/5224354917")
             @RequestParam(value = "ad_unit", required = false) String adUnitId,
 
-            @Parameter(description = "커스텀 데이터: 확인할 주간 보고서 ID")
+            @Parameter(description = "커스텀 데이터: 확인할 주간 보고서 ID", required = false, example = "")
             @RequestParam(value = "custom_data", required = false) String weeklyCounselId
     ){
         /*

--- a/src/main/java/com/example/egobook_be/domain/ads/controller/AdsControllerDocs.java
+++ b/src/main/java/com/example/egobook_be/domain/ads/controller/AdsControllerDocs.java
@@ -1,25 +1,94 @@
 package com.example.egobook_be.domain.ads.controller;
 
+import com.example.egobook_be.domain.ads.dto.UserAdStatusResDto;
+import com.example.egobook_be.domain.ads.enums.AdRewardType;
+import com.example.egobook_be.global.response.GlobalResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Ads API", description = "광고 시청 이벤트 처리 및 보상 관리 도메인")
 @RequestMapping("/ads")
 public interface AdsControllerDocs {
+    @Operation(summary = "AdMob SSV Callback",
+            description = """
+                    사용자가 광고 보기 버튼을 눌러 시청을 완료하면, 구글 AdMob 서버가 이 API를 자동으로 호출하여 보상 지급을 요청합니다.
+                    
+                    **[ 특징 ]**
+                    - 개발 단계에서는 '테스트 기기'로 등록된 폰에서 수행해야 합니다.
+                    - `reward_item` (지급할 보상 아이템 타입)을 통해 어떤 상황의 광고(잉크 보상용 vs 주간 AI 보고서용)인지 구분합니다.
+                    
+                    **[ 프론트엔드 가이드 ]**
+                    **(1) 보상 1:잉크 보상**
+                    - UserId값으로 해당 사용자의 userId 값을 설정해주세요.
+                    - 커스텀 데이터는 설정하지 않아주셔도 됩니다.
+                    
+                    **(2) 보상 2:주간 AI 리포트 확인**
+                    - UserId값으로 해당 사용자의 userId 값을 설정해주세요.
+                    - **커스텀 데이터에 보고 싶은 주간 AI 리포트의 PK값을 넣어주세요.**
+                    
+                    **[ 핵심 로직 ]**
+                    1. **서명 검증:** ECDSA 서명을 통해 요청이 구글에서 온 것인지 확인합니다.
+                    2. **중복 방지:** `transaction_id`를 통해 이미 지급된 보상인지 체크합니다.
+                    3. **보상 지급:** 검증이 완료되면 사용자에게 보상을 지급합니다.
 
+                    **[ 주의 ]**
+                    - 이 API는 클라이언트(앱)가 직접 호출할 수 없으며, 호출해도 서명이 없으면 거부됩니다.
+
+                    **[ 공식 문서 ]**
+                    https://developers.google.com/admob/android/ssv?hl=ko
+                    """)
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "처리 성공 (정상 지급 또는 이미 처리된 중복 건)"),
+            @ApiResponse(responseCode = "400", description = "필수 파라미터 누락"),
+            @ApiResponse(responseCode = "403", description = "서명 검증 실패 (위조된 요청)")
+    })
     @GetMapping("/admob/callback")
-    ResponseEntity<Void> callback();
+    ResponseEntity<Void> callback(
+            @Parameter(hidden = true) HttpServletRequest request, // 원본 쿼리 스트링 추출용 (서명 검증에 필수임)
+
+            @Parameter(description = "AdMob에서 생성한 SSV 콜백 서명 값", required = true)
+            @RequestParam("signature") String signature,
+
+            @Parameter(description = "서명 검증에 사용할 키 ID", required = true)
+            @RequestParam("key_id") String keyId,
+
+            @Parameter(description = "광고 시청 고유 트랜잭션 ID (중복 방지 키)", required = true)
+            @RequestParam("transaction_id") String transactionId,
+
+            @Parameter(description = "사용자 식별자 (앱에서 설정한 값)", required = true)
+            @RequestParam("user_id") String userId,
+
+            @Parameter(description = "지급할 보상 아이템 타입")
+            @RequestParam("reward_item") String rewardType,
+
+            @Parameter(description = "광고 단위 ID (어떤 광고를 봤는지)")
+            @RequestParam(value = "ad_unit", required = false) String adUnitId,
+
+            @Parameter(description = "커스텀 데이터: 확인할 주간 보고서 ID")
+            @RequestParam(value = "custom_data", required = false) String weeklyCounselId
+    );
 
 
-//    @Operation(summary = "오늘의 광고 현황 및 기대 보상 조회",
-//            description = "사용자가 오늘 시청 가능한 남은 광고 수와 획득 가능한 재화 정보를 반환합니다.")
-//    @ApiResponses(value = {
-//            @ApiResponse(responseCode = "200", description = "조회 성공",
-//                    content = @Content(schema = @Schema(implementation = AdUserStatusResDto.class))),
-//            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
-//    })
-//    ResponseEntity<AdUserStatusResDto> getAdInfo(
-//            @Parameter(hidden = true) Object userPrincipal
-//    );
+
+    @Operation(summary = "오늘의 광고 현황 및 기대 보상 조회",
+            description = "사용자가 오늘 시청 가능한 남은 광고 수와 획득 가능한 재화 정보를 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = UserAdStatusResDto.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+    })
+    @GetMapping("/info")
+    ResponseEntity<GlobalResponse<UserAdStatusResDto>> getUserAdStatus(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal(expression = "userAuthDto.userId") Long userId
+    );
 }

--- a/src/main/java/com/example/egobook_be/domain/ads/controller/AdsControllerDocs.java
+++ b/src/main/java/com/example/egobook_be/domain/ads/controller/AdsControllerDocs.java
@@ -27,13 +27,14 @@ public interface AdsControllerDocs {
                     - `reward_item` (지급할 보상 아이템 타입)을 통해 어떤 상황의 광고(잉크 보상용 vs 주간 AI 보고서용)인지 구분합니다.
                     
                     **[ 프론트엔드 가이드 ]**
+                    
                     **(1) 보상 1:잉크 보상**
-                    - UserId값으로 해당 사용자의 userId 값을 설정해주세요.
+                    - AdMob에게 광고 시청 요청을 보낼 때, UserId값으로 해당 사용자의 userId 값을 설정해주세요.
                     - 커스텀 데이터는 설정하지 않아주셔도 됩니다.
                     
                     **(2) 보상 2:주간 AI 리포트 확인**
-                    - UserId값으로 해당 사용자의 userId 값을 설정해주세요.
-                    - **커스텀 데이터에 보고 싶은 주간 AI 리포트의 PK값을 넣어주세요.**
+                    - AdMob에게 광고 시청 요청을 보낼 때, UserId값으로 해당 사용자의 userId 값을 설정해주세요.
+                    - 마찬가지로, 해당 요청의 **커스텀 데이터에 보고 싶은 주간 AI 리포트의 PK값을 반드시 넣어주어야합니다.**
                     
                     **[ 핵심 로직 ]**
                     1. **서명 검증:** ECDSA 서명을 통해 요청이 구글에서 온 것인지 확인합니다.
@@ -55,25 +56,25 @@ public interface AdsControllerDocs {
     ResponseEntity<Void> callback(
             @Parameter(hidden = true) HttpServletRequest request, // 원본 쿼리 스트링 추출용 (서명 검증에 필수임)
 
-            @Parameter(description = "AdMob에서 생성한 SSV 콜백 서명 값", required = true)
+            @Parameter(description = "AdMob에서 생성한 SSV 콜백 서명 값", required = true, example = "TEST_PASS")
             @RequestParam("signature") String signature,
 
-            @Parameter(description = "서명 검증에 사용할 키 ID", required = true)
+            @Parameter(description = "서명 검증에 사용할 키 ID", required = true, example = "test_key_123")
             @RequestParam("key_id") String keyId,
 
-            @Parameter(description = "광고 시청 고유 트랜잭션 ID (중복 방지 키)", required = true)
+            @Parameter(description = "광고 시청 고유 트랜잭션 ID (중복 방지 키)", required = true, example = "TX_TEST_001")
             @RequestParam("transaction_id") String transactionId,
 
-            @Parameter(description = "사용자 식별자 (앱에서 설정한 값)", required = true)
+            @Parameter(description = "사용자 식별자 (앱에서 설정한 값)", required = true, example = "1")
             @RequestParam("user_id") String userId,
 
-            @Parameter(description = "지급할 보상 아이템 타입")
+            @Parameter(description = "지급할 보상 아이템 타입 (INK or WEEK_COUNSEL)", example = "INK")
             @RequestParam("reward_item") String rewardType,
 
-            @Parameter(description = "광고 단위 ID (어떤 광고를 봤는지)")
+            @Parameter(description = "광고 단위 ID (어떤 광고를 봤는지)", required = false, example = "ca-app-pub-3940256099942544/5224354917")
             @RequestParam(value = "ad_unit", required = false) String adUnitId,
 
-            @Parameter(description = "커스텀 데이터: 확인할 주간 보고서 ID")
+            @Parameter(description = "커스텀 데이터: 확인할 주간 보고서 ID", required = false, example = "")
             @RequestParam(value = "custom_data", required = false) String weeklyCounselId
     );
 

--- a/src/main/java/com/example/egobook_be/domain/ads/controller/AdsControllerDocs.java
+++ b/src/main/java/com/example/egobook_be/domain/ads/controller/AdsControllerDocs.java
@@ -78,8 +78,6 @@ public interface AdsControllerDocs {
             @RequestParam(value = "custom_data", required = false) String weeklyCounselId
     );
 
-
-
     @Operation(summary = "오늘의 광고 현황 및 기대 보상 조회",
             description = "사용자가 오늘 시청 가능한 남은 광고 수와 획득 가능한 재화 정보를 반환합니다.")
     @ApiResponses(value = {

--- a/src/main/java/com/example/egobook_be/domain/ads/dto/UserAdStatusResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/ads/dto/UserAdStatusResDto.java
@@ -1,0 +1,13 @@
+package com.example.egobook_be.domain.ads.dto;
+
+import lombok.Builder;
+
+@Builder
+public record UserAdStatusResDto(
+        int currentViewCount, // 오늘 본 횟수
+        int maxLimit, // 최대 횟수 (10)
+        boolean isAvailable, // 시청 가능 여부
+        int rewardPerAd, // 1회당 보상량
+        String message
+) {
+}

--- a/src/main/java/com/example/egobook_be/domain/ads/entity/AdRewardHistory.java
+++ b/src/main/java/com/example/egobook_be/domain/ads/entity/AdRewardHistory.java
@@ -1,0 +1,59 @@
+package com.example.egobook_be.domain.ads.entity;
+
+import com.example.egobook_be.domain.ads.enums.AdRewardType;
+import com.example.egobook_be.domain.ego_room.entity.WeeklyCounsel;
+import com.example.egobook_be.domain.user.entity.User;
+import com.example.egobook_be.global.entity.BaseTimeEntity;
+import lombok.*;
+
+import jakarta.persistence.*; // Spring Boot 3.x 기준 (2.x라면 javax.persistence)
+
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "ad_reward_history", indexes = {
+        /*
+         * [ Transaction 중복 검증을 위한 DB 인덱스 ]
+         * - transaction_id는 절대 중복될 수 없음 (DB 레벨 방어)
+         */
+        @Index(name = "idx_transaction_id", columnList = "transactionId", unique = true),
+        /*
+         * [ 사용자의 오늘 남은 광고 호출 횟수를 계산하기 위한 DB 인덱스 ]
+         * - 조회 성능을 위해 user_id와 날짜로 인덱스 생성
+         */
+        @Index(name = "idx_user_created", columnList = "user_id, createdAt")
+})
+public class AdRewardHistory extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // AdMob이 주는 고유 영수증 번호
+    @Column(nullable = false, length = 100)
+    private String transactionId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // 받은 보상 양
+    @Column(nullable = false)
+    private int rewardAmount;
+
+    // 보상 타입
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private AdRewardType rewardType;
+
+    // 어떤 광고 단위인지의 ID (전면(Interstitial), 리워드(Reward)...)
+    @Column(nullable = false, length = 100)
+    private String adUnitId;
+
+    // 주간 보고서와의 연관관계(Nullable)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "weekly_counsel", nullable = true)
+    private WeeklyCounsel weeklyCounsel;
+}

--- a/src/main/java/com/example/egobook_be/domain/ads/enums/AdRewardType.java
+++ b/src/main/java/com/example/egobook_be/domain/ads/enums/AdRewardType.java
@@ -1,0 +1,10 @@
+package com.example.egobook_be.domain.ads.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+public enum AdRewardType {
+    INK,
+    WEEK_COUNSEL
+}

--- a/src/main/java/com/example/egobook_be/domain/ads/mapper/AdsMapper.java
+++ b/src/main/java/com/example/egobook_be/domain/ads/mapper/AdsMapper.java
@@ -1,0 +1,23 @@
+package com.example.egobook_be.domain.ads.mapper;
+
+import com.example.egobook_be.domain.ads.entity.AdRewardHistory;
+import com.example.egobook_be.domain.ads.enums.AdRewardType;
+import com.example.egobook_be.domain.ego_room.entity.WeeklyCounsel;
+import com.example.egobook_be.domain.user.entity.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AdsMapper {
+
+    /** AdRewardHistory 엔티티를 생성하는 함수 */
+    public AdRewardHistory toEntity(String transactionId, User user, Integer rewardAmount, AdRewardType rewardType, String adUnitId, WeeklyCounsel weeklyCounsel){
+        return AdRewardHistory.builder()
+                .transactionId(transactionId)
+                .user(user)
+                .rewardAmount(rewardAmount)
+                .rewardType(rewardType)
+                .adUnitId(adUnitId)
+                .weeklyCounsel(weeklyCounsel)
+                .build();
+    }
+}

--- a/src/main/java/com/example/egobook_be/domain/ads/repository/AdRewardHistoryRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/ads/repository/AdRewardHistoryRepository.java
@@ -1,0 +1,17 @@
+package com.example.egobook_be.domain.ads.repository;
+
+import com.example.egobook_be.domain.ads.entity.AdRewardHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+
+public interface AdRewardHistoryRepository extends JpaRepository<AdRewardHistory, Long> {
+    /** 중복 지급 체크용 */
+    boolean existsByTransactionId(String transactionId);
+
+    /** 오늘 시청 횟수 조회 (인덱스(idx_user_created)를 타므로 매우 빠름) */
+    @Query("SELECT COUNT(a) FROM AdRewardHistory a WHERE a.user.id = :userId AND a.createdAt BETWEEN :start AND :end")
+    int countDailyAds(@Param("userId") Long userId, @Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+}

--- a/src/main/java/com/example/egobook_be/domain/ads/repository/AdRewardHistoryRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/ads/repository/AdRewardHistoryRepository.java
@@ -1,6 +1,7 @@
 package com.example.egobook_be.domain.ads.repository;
 
 import com.example.egobook_be.domain.ads.entity.AdRewardHistory;
+import com.example.egobook_be.domain.ads.enums.AdRewardType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,7 +12,12 @@ public interface AdRewardHistoryRepository extends JpaRepository<AdRewardHistory
     /** 중복 지급 체크용 */
     boolean existsByTransactionId(String transactionId);
 
-    /** 오늘 시청 횟수 조회 (인덱스(idx_user_created)를 타므로 매우 빠름) */
-    @Query("SELECT COUNT(a) FROM AdRewardHistory a WHERE a.user.id = :userId AND a.createdAt BETWEEN :start AND :end")
-    int countDailyAds(@Param("userId") Long userId, @Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+    /** 오늘 Ink를 받는 광고 시청 횟수 조회 (인덱스(idx_user_created)를 타므로 매우 빠름) */
+    @Query("SELECT COUNT(a) FROM AdRewardHistory a WHERE a.user.id = :userId AND a.rewardType = :rewardType AND a.createdAt BETWEEN :start AND :end")
+    int countDailyInkAds(
+            @Param("userId") Long userId,
+            @Param("rewardType") AdRewardType rewardType, // Enum 타입으로 받음
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end
+    );
 }

--- a/src/main/java/com/example/egobook_be/domain/ads/service/AdsService.java
+++ b/src/main/java/com/example/egobook_be/domain/ads/service/AdsService.java
@@ -49,10 +49,18 @@ public class AdsService {
             String transactionId, String userIdStr, String weeklyCounselIdStr,
             String rewardType, String adUnitId
     ) {
-        // 1. 보안 검증 - 주어진 SSV 서명을 key_id로 검증
-        long keyId = Long.parseLong(keyIdStr);
-        if (!adMobVerifier.verify(queryString, signature, keyId)) {
-            throw new SecurityException("AdMob Signature Failed");
+        /*
+          * 1. 보안 검증 - 주어진 SSV 서명을 key_id로 검증
+          * - Swagger Test를 위해, 값이 "TEST_PASS"가 들어오면 검증을 패스하도록 설정한다.
+         */
+        if ("TEST_PASS".equals(signature)) {
+            log.info("🚧 [Swagger Test] 서명 검증을 건너뜁니다. (Transaction: {})", transactionId);
+        } else {
+            // [REAL MODE] 실제 운영 로직 (서명 검증 수행)
+            long keyId = Long.parseLong(keyIdStr);
+            if (!adMobVerifier.verify(queryString, signature, keyId)) {
+                throw new SecurityException("AdMob Signature Failed");
+            }
         }
 
         // 2. 멱등성(중복) 체크 - AdRewardHistory 엔티티에 인덱스 설정을 걸어두었으므로 빠르다

--- a/src/main/java/com/example/egobook_be/domain/ads/service/AdsService.java
+++ b/src/main/java/com/example/egobook_be/domain/ads/service/AdsService.java
@@ -85,13 +85,20 @@ public class AdsService {
             return;
         }
         switch (type) {
-            case AdRewardType.INK -> rewardInk(transactionId, userIdStr, adUnitId);
+            case AdRewardType.INK -> {
+                if (isDailyInkLimitReached(Long.parseLong(userIdStr))) {
+                    log.warn("User {} reached daily INK limit. Transaction {} skipped.", userIdStr, transactionId);
+                    return; // 잉크 안 주고 종료
+                }
+                rewardInk(transactionId, userIdStr, adUnitId);
+            }
             case AdRewardType.WEEK_COUNSEL -> rewardWeekCounsel(transactionId, userIdStr, weeklyCounselIdStr, adUnitId);
         }
     }
 
     /**
      * 광고 시청 시 Ink 보상을 주는 과정을 담은 함수
+     * - 사용자가 하루 광고 횟수를 넘었는지 확인
      * - 사용자에에 잉크 지급
      * - 잉크 보상 Log 기록
      * - AdRewardHistory에 해당 기록 추가
@@ -137,7 +144,19 @@ public class AdsService {
         log.info("Unlocked Weekly Counsel {} via AdMob for User {}", weeklyCounselId, userId);
     }
 
+    /**
+     * [Helper] 잉크 광고 일일 제한 도달 여부 확인 (INK 타입만 카운트)
+     */
+    private boolean isDailyInkLimitReached(Long userId) {
+        LocalDateTime nowKst = LocalDateTime.now(ZoneId.of(KST_ZONE));
+        LocalDateTime startOfDay = nowKst.toLocalDate().atStartOfDay();
+        LocalDateTime endOfDay = nowKst.toLocalDate().atTime(LocalTime.MAX);
 
+        // Repository 메서드 이름 변경 및 파라미터 추가 (AdRewardType.INK)
+        int currentCount = historyRepository.countDailyInkAds(userId, AdRewardType.INK, startOfDay, endOfDay);
+
+        return currentCount >= DAILY_AD_LIMIT;
+    }
 
 
 
@@ -152,8 +171,8 @@ public class AdsService {
         LocalDateTime startOfDay = nowKst.toLocalDate().atStartOfDay(); // 00:00:00
         LocalDateTime endOfDay = nowKst.toLocalDate().atTime(LocalTime.MAX); // 23:59:59.999
 
-        // 2. DB에서 오늘 시청 횟수 조회 (COUNT 쿼리, 인덱스 처리를 해두어서 빠름)
-        int currentCount = historyRepository.countDailyAds(userId, startOfDay, endOfDay);
+        // 2. DB에서 오늘 잉크용 광고 시청 횟수 조회 (COUNT 쿼리, 인덱스 처리를 해두어서 빠름)
+        int currentCount = historyRepository.countDailyInkAds(userId, AdRewardType.INK, startOfDay, endOfDay);
 
         // 3. 응답 생성
         boolean isAvailable = currentCount < DAILY_AD_LIMIT;

--- a/src/main/java/com/example/egobook_be/domain/ads/service/AdsService.java
+++ b/src/main/java/com/example/egobook_be/domain/ads/service/AdsService.java
@@ -1,0 +1,161 @@
+package com.example.egobook_be.domain.ads.service;
+
+
+
+import com.example.egobook_be.domain.ads.dto.UserAdStatusResDto;
+
+import com.example.egobook_be.domain.ads.enums.AdRewardType;
+import com.example.egobook_be.domain.ads.mapper.AdsMapper;
+import com.example.egobook_be.domain.ads.repository.AdRewardHistoryRepository;
+import com.example.egobook_be.domain.ego_room.entity.WeeklyCounsel;
+import com.example.egobook_be.domain.ego_room.repository.WeeklyCounselRepository;
+import com.example.egobook_be.domain.user.entity.InkLogType;
+import com.example.egobook_be.domain.user.entity.User;
+import com.example.egobook_be.domain.user.repository.InkLogRepository;
+import com.example.egobook_be.domain.user.repository.UserRepository;
+import com.example.egobook_be.global.util.AdMobVerifier;
+import com.example.egobook_be.global.util.InkLogUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdsService {
+    private final AdMobVerifier adMobVerifier;
+    private final AdRewardHistoryRepository historyRepository;
+    private final UserRepository userRepository;
+    private final InkLogRepository inkLogRepository;
+    private final WeeklyCounselRepository weeklyCounselRepository;
+    private final InkLogUtil inkLogUtil;
+    private final AdsMapper adsMapper;
+
+    private static final String KST_ZONE = "Asia/Seoul";
+    private static final int DAILY_AD_LIMIT = 10;
+    private static final int REWARD_PER_AD = 2; // 1회당 보상
+
+    /**
+     * AdMob SSV Callback 구현
+     */
+    @Transactional
+    public void adMobCallbackInk(
+            String queryString, String signature, String keyIdStr,
+            String transactionId, String userIdStr, String weeklyCounselIdStr,
+            String rewardType, String adUnitId
+    ) {
+        // 1. 보안 검증 - 주어진 SSV 서명을 key_id로 검증
+        long keyId = Long.parseLong(keyIdStr);
+        if (!adMobVerifier.verify(queryString, signature, keyId)) {
+            throw new SecurityException("AdMob Signature Failed");
+        }
+
+        // 2. 멱등성(중복) 체크 - AdRewardHistory 엔티티에 인덱스 설정을 걸어두었으므로 빠르다
+        if (historyRepository.existsByTransactionId(transactionId)) {
+            return;
+        }
+
+        /*
+         * 3. 보상이 어느 종류의 보상인지에 따라 수행되는 작업을 분류한다.
+         * (1) rewardType이 AdRewardType.INK인 경우
+         *  - 사용자에게 잉크 지급
+         *  - 잉크 보상 Log 기록
+         *  - AdRewardHistory에 해당 기록 추가
+         * (2) rewardType이 AdRewardType.WEEK_COUNSEL인 경우
+         *  - AdRewardHistory에 해당 기록 추가 (어떤 주간 AI 기록을 위한 광고를 본 것인지 기록)
+         */
+        AdRewardType type;
+        try {
+            type = AdRewardType.valueOf(rewardType);
+        } catch (IllegalArgumentException | NullPointerException e) {
+            log.error("[AdMob Callback] 정의되지 않은 보상 타입입니다: {}", rewardType);
+            return;
+        }
+        switch (type) {
+            case AdRewardType.INK -> rewardInk(transactionId, userIdStr, adUnitId);
+            case AdRewardType.WEEK_COUNSEL -> rewardWeekCounsel(transactionId, userIdStr, weeklyCounselIdStr, adUnitId);
+        }
+    }
+
+    /**
+     * 광고 시청 시 Ink 보상을 주는 과정을 담은 함수
+     * - 사용자에에 잉크 지급
+     * - 잉크 보상 Log 기록
+     * - AdRewardHistory에 해당 기록 추가
+     */
+    private void rewardInk(String transactionId, String userIdStr, String adUnitId) {
+        Long userId = Long.parseLong(userIdStr);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        inkLogRepository.save(inkLogUtil.addInkAndGetInkLog(user, REWARD_PER_AD, InkLogType.WATCH_AD));
+        // 이력 저장
+        historyRepository.save(adsMapper.toEntity(transactionId, user, REWARD_PER_AD, AdRewardType.INK, adUnitId, null));
+    }
+
+    /**
+     * 광고 시청 시 주간 AI 리포트를 시청하도록 해주는 과정을 담은 함수
+     * - AdRewardHistory에 해당 기록(주간 AI 보고서)을 추가
+     * - 해당 WeeklyCounsel의 isLocked 값 false로 업데이트
+     */
+    private void rewardWeekCounsel(String transactionId, String userIdStr, String weeklyCounselIdStr, String adUnitId){
+        Long userId = Long.parseLong(userIdStr);
+
+        /*
+         * 1. 사용자 앱 -> AdMob -> Spring Boot 서버로 거쳐온 Custom Data를 검증한다.
+         * - Custom Data에는 잠금 해제시킬 Weekly Counsel의 PK가 담겨있으므로, 해당 값이 없으면 해당 주간 보고서를 잠금해제시킬 수 없다.
+         */
+        if(weeklyCounselIdStr == null || weeklyCounselIdStr.isBlank()){
+            log.error("[AdService::rewardWeekCounsel] Week Counsel ID is missing for transaction: {}", transactionId);
+            return;
+        }
+        Long weeklyCounselId = Long.parseLong(weeklyCounselIdStr);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        // 2. 해당 보고서가 본인의 보고서인 경우에만 주간 보고서 조회
+        WeeklyCounsel weeklyCounsel = weeklyCounselRepository.findByIdAndUser(weeklyCounselId, user)
+                .orElseThrow(() -> new IllegalArgumentException("Weekly Counsel not found or has no authorization."));
+
+        // 3. 해당 보고서 잠금 해제
+        weeklyCounsel.updateLocked(false);
+
+        // 4. 이력 저장
+        historyRepository.save(adsMapper.toEntity(transactionId, user, 0, AdRewardType.WEEK_COUNSEL, adUnitId, weeklyCounsel));
+        log.info("Unlocked Weekly Counsel {} via AdMob for User {}", weeklyCounselId, userId);
+    }
+
+
+
+
+
+    /**
+     * 사용자의 오늘 광고 시청 관련 정보를 가져오는 함수
+     * - 별도의 컬럼이나 테이블에 데이터를 저장해서 가져오지 않고, AdRewardHistory 테이블에 있는 데이터들로 필요한 정보들을 계산해서 데이터를 가져온다.
+     */
+    @Transactional(readOnly = true)
+    public UserAdStatusResDto getUserAdStatus(Long userId) {
+        // 1. 오늘 날짜 범위 구하기 (KST 00:00 ~ 23:59)
+        LocalDateTime nowKst = LocalDateTime.now(ZoneId.of(KST_ZONE));
+        LocalDateTime startOfDay = nowKst.toLocalDate().atStartOfDay(); // 00:00:00
+        LocalDateTime endOfDay = nowKst.toLocalDate().atTime(LocalTime.MAX); // 23:59:59.999
+
+        // 2. DB에서 오늘 시청 횟수 조회 (COUNT 쿼리, 인덱스 처리를 해두어서 빠름)
+        int currentCount = historyRepository.countDailyAds(userId, startOfDay, endOfDay);
+
+        // 3. 응답 생성
+        boolean isAvailable = currentCount < DAILY_AD_LIMIT;
+
+        return UserAdStatusResDto.builder()
+                .currentViewCount(currentCount)
+                .maxLimit(DAILY_AD_LIMIT)
+                .isAvailable(isAvailable)
+                .rewardPerAd(REWARD_PER_AD)
+                .message(isAvailable ? "광고 보기" : "오늘은 더이상 광고를 볼 수 없어요")
+                .build();
+    }
+}

--- a/src/main/java/com/example/egobook_be/domain/diary/service/DiaryService.java
+++ b/src/main/java/com/example/egobook_be/domain/diary/service/DiaryService.java
@@ -9,9 +9,6 @@ import com.example.egobook_be.domain.diary.exception.DiaryErrorCode;
 import com.example.egobook_be.domain.diary.mapper.DiaryMapper;
 import com.example.egobook_be.domain.diary.repository.DiaryRepository;
 import com.example.egobook_be.domain.home.entity.Mission;
-import com.example.egobook_be.domain.home.repository.MissionRepository;
-import com.example.egobook_be.domain.notification.entity.Notification;
-import com.example.egobook_be.domain.notification.mapper.NotificationMapper;
 import com.example.egobook_be.domain.user.entity.Ability;
 import com.example.egobook_be.domain.user.entity.InkLog;
 import com.example.egobook_be.domain.user.entity.InkLogType;
@@ -111,7 +108,7 @@ public class DiaryService {
          * - 일일 미션 상태 업데이트
          */
         if (isFirstDiaryToday) {
-            inkLogUtil.addInkLog(inkLogs, user, 1, InkLogType.FIRST_EMOTION_DIARY); // 사용자에게 잉크 추가 & 잉크 로그 추가해주는 함수
+            inkLogUtil.addInkLogToList(inkLogs, user, 1, InkLogType.FIRST_EMOTION_DIARY); // 사용자에게 잉크 추가 & 잉크 로그 추가해주는 함수
             rewards.add(new DiaryCreateResDto.RewardResDto(
                     RewardType.INK, 1, "잉크를 1 획득했어요"
             ));
@@ -122,7 +119,7 @@ public class DiaryService {
              * - reward 객체 추가
              */
             if(userMission.updateDailyDiaryMissionStatus(true)){
-                inkLogUtil.addInkLog(inkLogs, user, 1, InkLogType.DAILY_MISSION_REWARD);
+                inkLogUtil.addInkLogToList(inkLogs, user, 1, InkLogType.DAILY_MISSION_REWARD);
                 rewards.add(new DiaryCreateResDto.RewardResDto(
                         RewardType.INK, 1, "일일 미션 성공으로 잉크를 1 획득했어요"
                 ));
@@ -133,7 +130,7 @@ public class DiaryService {
                  * - reward 객체 추가
                  */
                 if(userMission.isWeeklyMissionCompleted()){
-                    inkLogUtil.addInkLog(inkLogs, user, 2, InkLogType.WEEKLY_MISSION_REWARD);
+                    inkLogUtil.addInkLogToList(inkLogs, user, 2, InkLogType.WEEKLY_MISSION_REWARD);
                     rewards.add(new DiaryCreateResDto.RewardResDto(
                             RewardType.INK, 2, "주간 미션 성공으로 잉크를 추가로 2 획득했어요"
                     ));
@@ -153,7 +150,7 @@ public class DiaryService {
             ));
             // 2-1. 감정 조절 레벨이 올랐는지 확인
             if(earnedInk == 1){
-                inkLogUtil.addInkLog(inkLogs, user, earnedInk, InkLogType.LEVEL_UP);
+                inkLogUtil.addInkLogToList(inkLogs, user, earnedInk, InkLogType.LEVEL_UP);
                 rewards.add(new DiaryCreateResDto.RewardResDto(
                         RewardType.INK, earnedInk, "[감정 조절 레벨업] 잉크를 추가로 1 획득했어요"+"(현재 감정 조절 레벨: " + ability.getEmotionRegulation() + ")"
                 ));
@@ -181,7 +178,7 @@ public class DiaryService {
             }
             // 3-1. 긍정 사고의 레벨이 올랐는지 확인
             if(earnedInk == 1){
-                inkLogUtil.addInkLog(inkLogs, user, earnedInk, InkLogType.LEVEL_UP);
+                inkLogUtil.addInkLogToList(inkLogs, user, earnedInk, InkLogType.LEVEL_UP);
                 rewards.add(new DiaryCreateResDto.RewardResDto(
                         RewardType.INK, earnedInk, "[긍정 사고 레벨업] 잉크를 추가로 1 획득했어요"+"(현재 긍정 사고 레벨: " + ability.getPositiveThinking() + ")"
                 ));

--- a/src/main/java/com/example/egobook_be/domain/ego_room/entity/WeeklyCounsel.java
+++ b/src/main/java/com/example/egobook_be/domain/ego_room/entity/WeeklyCounsel.java
@@ -2,16 +2,15 @@ package com.example.egobook_be.domain.ego_room.entity;
 
 import com.example.egobook_be.domain.user.entity.User;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name="weekly_counsel")
 public class WeeklyCounsel {
@@ -44,6 +43,10 @@ public class WeeklyCounsel {
 
     private boolean isRead;
 
+    @Column(nullable = false)
+    @Builder.Default
+    private boolean isLocked = true;
+
     private LocalDateTime createdAt;
 
     @Builder
@@ -63,4 +66,5 @@ public class WeeklyCounsel {
     public void markAsRead() {
         this.isRead = true;
     }
+    public void updateLocked(boolean isLocked) { this.isLocked = isLocked; }
 }

--- a/src/main/java/com/example/egobook_be/domain/ego_room/repository/WeeklyCounselRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/ego_room/repository/WeeklyCounselRepository.java
@@ -31,4 +31,6 @@ public interface WeeklyCounselRepository extends JpaRepository<WeeklyCounsel, Lo
     Slice<WeeklyCounsel> findAllByUserId(Long userId, Pageable pageable);
 
     Optional<WeeklyCounsel> findTopByUserOrderByEndDateDesc(User user);
+
+    Optional<WeeklyCounsel> findByIdAndUser(Long id, User user);
 }

--- a/src/main/java/com/example/egobook_be/domain/letters/service/PlazaLetterService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/PlazaLetterService.java
@@ -1,7 +1,5 @@
 package com.example.egobook_be.domain.letters.service;
 
-import com.example.egobook_be.domain.diary.dto.DiaryCreateResDto;
-import com.example.egobook_be.domain.diary.enums.RewardType;
 import com.example.egobook_be.domain.home.entity.Mission;
 import com.example.egobook_be.domain.home.repository.MissionRepository;
 import com.example.egobook_be.domain.letters.entity.*;
@@ -127,21 +125,21 @@ public class PlazaLetterService {
         // =================================================
         List<InkLog> inkLogs = new ArrayList<>();
         // 1. 잉크 제공 & 일일 미션 상태 업데이트
-        inkLogUtil.addInkLog(inkLogs, user, 1, InkLogType.FIRST_LETTER_WRITE);
+        inkLogUtil.addInkLogToList(inkLogs, user, 1, InkLogType.FIRST_LETTER_WRITE);
         /*
          * 1-1. 만약 이번이 처음 일일 미션을 수행한 경우일 때 (updateDailyLetterMissionStatus 함수가 true를 반환)
          * - 잉크 +1
          * - 잉크 로그 추가
          */
         if(userMission.updateDailyLetterMissionStatus(true)){
-            inkLogUtil.addInkLog(inkLogs, user, 1, InkLogType.DAILY_MISSION_REWARD);
+            inkLogUtil.addInkLogToList(inkLogs, user, 1, InkLogType.DAILY_MISSION_REWARD);
             /*
              * 1-2. 만약 오늘이 일일 미션을 7일째 완료한 날인 경우
              * - 잉크 +2
              * - 잉크 로그 추가
              */
             if(userMission.isWeeklyMissionCompleted()){
-                inkLogUtil.addInkLog(inkLogs, user, 2, InkLogType.WEEKLY_MISSION_REWARD);
+                inkLogUtil.addInkLogToList(inkLogs, user, 2, InkLogType.WEEKLY_MISSION_REWARD);
             }
         }
         inkLogRepository.saveAll(inkLogs);
@@ -294,7 +292,7 @@ public class PlazaLetterService {
         List<ReplyResponse.RewardDto> rewards = new ArrayList<>();
         List<InkLog> inkLogs = new ArrayList<>();
         if(isFirstReplyToday){
-            inkLogUtil.addInkLog(inkLogs, user, 1, InkLogType.FIRST_LETTER_REPLY); // 잉크 +1
+            inkLogUtil.addInkLogToList(inkLogs, user, 1, InkLogType.FIRST_LETTER_REPLY); // 잉크 +1
             rewards.add(ReplyResponse.RewardDto.builder()
                     .kind(ReplyResponse.RewardKind.INK)
                     .amount(1)
@@ -309,7 +307,7 @@ public class PlazaLetterService {
                     .build());
             // 1-1. 레벨업했는지 여부 확인
             if(earnedInk == 1){
-                inkLogUtil.addInkLog(inkLogs, user, earnedInk, InkLogType.LEVEL_UP);
+                inkLogUtil.addInkLogToList(inkLogs, user, earnedInk, InkLogType.LEVEL_UP);
                 rewards.add(ReplyResponse.RewardDto.builder()
                         .kind(ReplyResponse.RewardKind.EMPATHY) // [수정] SINCERITY -> EMPATHY
                         .amount(1)

--- a/src/main/java/com/example/egobook_be/domain/question/service/TodayQuestionService.java
+++ b/src/main/java/com/example/egobook_be/domain/question/service/TodayQuestionService.java
@@ -1,7 +1,5 @@
 package com.example.egobook_be.domain.question.service;
 
-import com.example.egobook_be.domain.diary.dto.DiaryCreateResDto;
-import com.example.egobook_be.domain.diary.enums.RewardType;
 import com.example.egobook_be.domain.friend.repository.FriendRepository;
 import com.example.egobook_be.domain.home.entity.Mission;
 import com.example.egobook_be.domain.home.repository.MissionRepository;
@@ -32,7 +30,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
@@ -141,10 +138,10 @@ public class TodayQuestionService {
          */
         List<InkLog> inkLogs = new ArrayList<>();
         if(isFirstAnswerToday){
-            inkLogUtil.addInkLog(inkLogs, user, 1, InkLogType.FIRST_QUESTION_ANSWER); // 잉크 +1
+            inkLogUtil.addInkLogToList(inkLogs, user, 1, InkLogType.FIRST_QUESTION_ANSWER); // 잉크 +1
             // 1-1. 만약 이번이 처음 일일 미션을 수행한 경우일 때
             if(userMission.updateDailyQuestionMissionStatus(true)){
-                inkLogUtil.addInkLog(inkLogs, user, 1, InkLogType.DAILY_MISSION_REWARD);
+                inkLogUtil.addInkLogToList(inkLogs, user, 1, InkLogType.DAILY_MISSION_REWARD);
 
                 /*
                  * 1-2. 만약 오늘이 일일 미션을 7일째 완료한 날인 경우
@@ -152,13 +149,13 @@ public class TodayQuestionService {
                  * - 잉크 로그 추가
                  */
                 if(userMission.isWeeklyMissionCompleted()){
-                    inkLogUtil.addInkLog(inkLogs, user, 2, InkLogType.WEEKLY_MISSION_REWARD);
+                    inkLogUtil.addInkLogToList(inkLogs, user, 2, InkLogType.WEEKLY_MISSION_REWARD);
                 }
             }
             int earnedInk = userAbility.addDiligence(1); // 성실성 +1
             // 1-3. 성실성 레벨업했는지 여부 확인
             if(earnedInk == 1){
-                inkLogUtil.addInkLog(inkLogs, user, earnedInk, InkLogType.LEVEL_UP);
+                inkLogUtil.addInkLogToList(inkLogs, user, earnedInk, InkLogType.LEVEL_UP);
             }
         }
         inkLogRepository.saveAll(inkLogs);

--- a/src/main/java/com/example/egobook_be/global/util/AdMobVerifier.java
+++ b/src/main/java/com/example/egobook_be/global/util/AdMobVerifier.java
@@ -1,0 +1,134 @@
+package com.example.egobook_be.global.util;
+
+import com.google.crypto.tink.subtle.Base64;
+import com.google.crypto.tink.subtle.EcdsaVerifyJce;
+import com.google.crypto.tink.subtle.EllipticCurves;
+import com.google.crypto.tink.subtle.EllipticCurves.EcdsaEncoding;
+import com.google.crypto.tink.subtle.Enums.HashType;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.springframework.stereotype.Component;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.interfaces.ECPublicKey;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Component
+public class AdMobVerifier {
+    // 구글의 공개키 목록을 제공하는 URL (고정값)
+    private static final String ADMOB_KEYS_URL = "https://www.gstatic.com/admob/reward/verifier-keys.json";
+
+    // 키를 메모리에 캐싱하는 저장소 (Thread-Safe)
+    private final Map<Long, ECPublicKey> publicKeys = new ConcurrentHashMap<>();
+
+    /**
+     * 서버가 시작될 때 자동으로 실행되어 키를 가져옵니다.
+     * (사용자가 처음 요청할 때 기다리지 않게 하기 위함)
+     */
+    @PostConstruct
+    public void init() {
+        try {
+            fetchPublicKeys();
+            log.info("[AdMobVerifier] 구글의 Public Key들이 성공적으로 로드되었습니다. Count: {}", publicKeys.size());
+        } catch (Exception e) {
+            log.error("[AdMobVerifier] 서버 시작 시 구글의 Public Key들을 불러오는데 실패했습니다. Will retry on request.", e);
+        }
+    }
+
+    /**
+     * AdMob가 보낸 서명을 통해, 해당 요청이 구글에서 온 것인지 검증하는 메서드
+     * @param queryString : URL의 전체 쿼리 스트링 (user_id=...&signature=...)
+     * @param signature : 서명 값
+     * @param keyId : 키 ID
+     * @return 검증 성공 여부
+     */
+    public boolean verify(String queryString, String signature, Long keyId) {
+        try {
+            // 1. 키가 없으면 다시 가져오기 시도 (Lazy Loading)
+            if (!publicKeys.containsKey(keyId)) {
+                log.warn("[AdMobVerifier] Public Key ID {}를 캐시에서 찾지 못했습니다. 다시 Public Key들을 가져오는 중입니다...", keyId);
+                fetchPublicKeys();
+            }
+
+            // 2. 그래도 없으면 실패
+            ECPublicKey publicKey = publicKeys.get(keyId);
+            if (publicKey == null) {
+                log.error("[AdMobVerifier] 재시도 후에도 해당 Key ID {}를 캐시에서 찾지 못했습니다.", keyId);
+                return false;
+            }
+
+            /* 3. 검증할 데이터 추출
+             * - AdMob 규격: "signature" 파라미터 직전까지의 모든 문자열이 원본 데이터임
+             * - 예: "user=A&reward=10&signature=..." -> "user=A&reward=10" 부분이 데이터
+             */
+            int signatureIndex = queryString.indexOf("&signature");
+            if (signatureIndex == -1) {
+                // 맨 앞에 signature가 올 경우 (드물지만 방어 코드)
+                signatureIndex = queryString.indexOf("signature");
+            }
+
+            String content = queryString.substring(0, signatureIndex);
+            byte[] contentBytes = content.getBytes(StandardCharsets.UTF_8);
+            byte[] signatureBytes = Base64.urlSafeDecode(signature);
+
+            /*
+             * 4. ECDSA(Elliptic Curve Digital Signature Algorithm): '타원 곡선 디지털 서명 알고리즘' 암호화 검증 수행 (Tink 라이브러리에 들어있음)
+             * - contentByte를 SHA-256 알고리즘으로 돌린 해시값 생성
+             * - signatureBytes를 publicKey, 타원곡선 알고리즘(ECDSA)을 이용해서 복호화한 해시값
+             * => 이 두 값이 같은지 검증하는 과정이다.
+             */
+            EcdsaVerifyJce verifier = new EcdsaVerifyJce(publicKey, HashType.SHA256, EcdsaEncoding.DER);
+            verifier.verify(signatureBytes, contentBytes);
+
+            return true; // 예외가 안 나면 성공
+        } catch (GeneralSecurityException e) {
+            log.warn("[AdMobVerifier] Signature verification failed: {}", e.getMessage());
+            return false;
+        } catch (Exception e) {
+            log.error("[AdMobVerifier] Internal Error during verification", e);
+            return false;
+        }
+    }
+
+    /**
+     * 구글 서버에서 공개키 JSON을 받아와 파싱하는 로직
+     */
+    private void fetchPublicKeys() throws Exception {
+        URL url = new URL(ADMOB_KEYS_URL);
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        connection.setRequestMethod("GET");
+        connection.setConnectTimeout(5000); // 5초 타임아웃
+        connection.setReadTimeout(5000);
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
+            StringBuilder content = new StringBuilder();
+            String inputLine;
+            while ((inputLine = reader.readLine()) != null) {
+                content.append(inputLine);
+            }
+
+            // JSON 파싱
+            JSONObject jsonObject = new JSONObject(content.toString());
+            JSONArray keys = jsonObject.getJSONArray("keys");
+
+            for (int i = 0; i < keys.length(); i++) {
+                JSONObject key = keys.getJSONObject(i);
+                long keyId = key.getLong("keyId");
+                String publicKeyBase64 = key.getString("base64"); // PEM 형식
+
+                // Base64 -> PublicKey 객체 변환
+                ECPublicKey ecPublicKey = EllipticCurves.getEcPublicKey(Base64.decode(publicKeyBase64));
+                publicKeys.put(keyId, ecPublicKey);
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/egobook_be/global/util/InkLogUtil.java
+++ b/src/main/java/com/example/egobook_be/global/util/InkLogUtil.java
@@ -5,13 +5,12 @@ import com.example.egobook_be.domain.user.entity.InkLogType;
 import com.example.egobook_be.domain.user.entity.User;
 import org.springframework.stereotype.Component;
 
-import java.time.OffsetDateTime;
 import java.util.List;
 
 @Component
 public class InkLogUtil {
-    // 해당 사용자의 잉크값을 증가시키고 InkLog를 남기는 함수
-    public void addInkLog(List<InkLog> inkLogs, User user, Integer amount, InkLogType inkLogType) {
+    // 해당 사용자의 잉크값을 증가시키고 전달받은 리스트에 InkLog를 남기는 함수
+    public void addInkLogToList(List<InkLog> inkLogs, User user, Integer amount, InkLogType inkLogType) {
         user.addInk(amount);
         inkLogs.add(InkLog.builder()
                 .user(user)
@@ -19,5 +18,15 @@ public class InkLogUtil {
                 .reason(inkLogType)
                 .build()
         );
+    }
+
+    /** 해당 사용자의 잉크를 증가시키고, InkLog를 만들어서 반환하는 함수 */
+    public InkLog addInkAndGetInkLog(User user, Integer amount, InkLogType inkLogType) {
+        user.addInk(amount);
+        return InkLog.builder()
+                .user(user)
+                .amount(amount)
+                .reason(inkLogType)
+                .build();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
- #67 

## 📝작업 내용
### ✅ 1. 사용자가 오늘 볼 수 있는 광고 현황에 대한 정보 조회 API
- ```/ads/info```
- 사용자의 광고 관련 정보를 조회하는 API입니다.
- 반환 데이터 형식
  ```
  - **currentViewCount**: 오늘 사용자가 본 광고 횟수
  - **maxLimit**: 오늘 광고 시청 제한 횟수
  - **isAvailable**: 아직 광고를 볼 수 있는지 여부
  - **rewardPerAd**: 하나의 광고 시청당 얻을 수 있는 보상 개수
  - **message**: 사용자에게 보낼 메시지
  ```

### ✅ 2. 사용자가 보상형 광고 시청 완료 시 AdMob이 Server Side에서 호출하는 callback API
- ```/ads/admob/callback```
- 사용자가 보상형 광고를 시청 완료했을 때, AdMob은 자동으로 Server side에서 해당 api 경로로 **"보상 완료"** 처리를 합니다.
- AdMob의 광고 인증 흐름은 아래와 같습니다.
```
+--------+        +-------+        +-------+        +--------+        +-------+
| 사용자  |        |  앱   |        | AdMob |        | Server |        |  DB   |
+--------+        +-------+        +-------+        +--------+        +-------+
    |                 |                |                 |                 |
    |--- 1.광고 클릭 -->|                |                 |                 |
    |                 |                |                 |                 |
    |                 |--- 2.광고 요청 ->|                 |                 |
    |                 | (UserId/Custom)|                 |                 |
    |                 |                |                 |                 |
    |                 |<-- 3.광고 송출 --|                 |                 |
    |                 |                |                 |                 |
    |--- 4.시청 완료 -->|                |                 |                 |
    |                 |                |---- 5.Callback ->|                 |
    |                 |                |  (서명,TxID 등)   |                 |
    |                 |                |                 |                 |
    |                 |                |                 |-- 6.서명 검증 --->|
    |                 |                |                 |                 |
    |                 |                |                 |-- 7.중복 체크 --->|
    |                 |                |                 |                 |
    |                 |                |                 |-- 8.보상 지급 --->|
    |                 |                |                 | (잉크 or 보고서)   |
    |                 |                |                 |                 |
    |                 |                |<---- 9. 응답 -----|                 |
    |                 |                |    (200 OK)     |                 |
```
- 위 그림과 같이 AdMob의 광고 시청 후 보상 로직이 실행됩니다.
- **API 로직**
  - **6. 서명 검증** : AdMob이 보낸 ECDSA 서명을 구글 공개키로 검증합니다
  - **7. 중복 체크**: 해당 광고 시청 완료 호출이 중복된 호출인지 검증합니다
  - **8. 보상 지급**: 해당 광고 시청이
    (1) **잉크를 얻기 위한 광고 시청이었는지**
    (2) **주간 AI 보고서를 잠금해제하기 위한 광고 시청이었는지**
    를 구분해서 각각의 보상을 지급합니다.
  - **9. 응답**: AdMob에게 해당 보상 지급이 완료되었다고 200 코드를 응답합니다.

## ❗주요 수정 사항❗
### ✅ 1. WeeklyCounsel 엔티티에 ```isLocked``` 컬럼 추가
- 주간 AI 보고서는 "잉크 10으로 잠금해제" & "광고 보고 잠금해제" 2가지로 잠금해제 가능합니다.
<img width="214" height="231" alt="image" src="https://github.com/user-attachments/assets/add8b303-7552-41af-b11a-1a0126a3b8d8" />

- 해당 주간 AI 보고서의 잠금 여부를 결정하는 컬럼이 없었기에, 해당 엔티티에 boolean 타입의 ```isLocked``` 컬럼과, 해당 컬럼 업데이트용 inner 메서드를 추가하였습니다.


## 💬리뷰 요구사항
- AdMob은 저도 처음 써보는 플랫폼이라 모르는 부분이 많았습니다! 실제로 프론트와 연동을 한 뒤에 테스트를 제대로 할 수 있을 것 같습니다.
- AdsService의 함수들 중에서, DB와 연결되어 조회, 수정, 추가 등의 부분에서 N+1이나 다른 문제가 발생할 것 같지는 않은지를 중점으로 리뷰해주시면 감사드리겠습니다!