### PR TITLE
🐛 Fix: 워드클라우드 구현 방식 변경 (코모란->openai)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,8 +98,6 @@ dependencies {
     implementation 'dev.langchain4j:langchain4j-spring-boot-starter'
     implementation 'dev.langchain4j:langchain4j-open-ai'
 
-    // KOMORAN 형태소 분석기
-    implementation 'com.github.shin285:KOMORAN:3.3.4'
 
     // firebase
     implementation 'com.google.firebase:firebase-admin:9.7.1'

--- a/src/main/java/com/example/egobook_be/domain/ego_room/dto/WordCloudResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/ego_room/dto/WordCloudResDto.java
@@ -1,0 +1,12 @@
+package com.example.egobook_be.domain.ego_room.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import java.util.List;
+
+@Getter @Setter
+@NoArgsConstructor
+public class WordCloudResDto {
+    private List<WordCloudDto> keywords;
+}

--- a/src/main/java/com/example/egobook_be/domain/ego_room/service/WordCloudAiService.java
+++ b/src/main/java/com/example/egobook_be/domain/ego_room/service/WordCloudAiService.java
@@ -1,0 +1,29 @@
+package com.example.egobook_be.domain.ego_room.service;
+
+import com.example.egobook_be.domain.ego_room.dto.WordCloudDto;
+import com.example.egobook_be.domain.ego_room.dto.WordCloudResDto;
+import dev.langchain4j.service.SystemMessage;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.spring.AiService;
+import java.util.List;
+import static dev.langchain4j.service.spring.AiServiceWiringMode.EXPLICIT;
+
+@AiService(wiringMode = EXPLICIT, chatModel = "gptModel")
+public interface WordCloudAiService {
+
+    @SystemMessage("""
+        You are an expert in Korean Natural Language Processing (NLP). 
+        Analyze the provided diary entries and extract the top 20 most meaningful NOUNS.
+        
+        [Strict Rules]
+        1. Extract only high-value NOUNS that represent the user's activities, emotions, or key events.
+        2. EXCLUDE meaningless adverbs, pronouns, or common fillers (e.g., '정말', '매우', '오늘', '내일', '생각', '진심으로', '것입니다', '합니다').
+        3. IGNORE repetitive template phrases like "내일은 오늘보다 더 성장한 내가 되기를...".
+        4. Assign a 'weight' (1-100) to each noun based on its frequency and emotional significance.
+        5. Your response MUST be a pure JSON array of objects, with no extra text or markdown formatting.
+        
+        [Format Example]
+        [{"word": "여행", "weight": 95}, {"word": "행복", "weight": 80}]
+        """)
+    WordCloudResDto extractKeywords(@UserMessage String diaryContent);
+}

--- a/src/main/java/com/example/egobook_be/domain/ego_room/service/WordCloudService.java
+++ b/src/main/java/com/example/egobook_be/domain/ego_room/service/WordCloudService.java
@@ -2,50 +2,47 @@ package com.example.egobook_be.domain.ego_room.service;
 
 import com.example.egobook_be.domain.diary.entity.Diary;
 import com.example.egobook_be.domain.ego_room.dto.WordCloudDto;
-import kr.co.shineware.nlp.komoran.constant.DEFAULT_MODEL;
-import kr.co.shineware.nlp.komoran.core.Komoran;
-import kr.co.shineware.nlp.komoran.model.KomoranResult;
+import com.example.egobook_be.domain.ego_room.dto.WordCloudResDto;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class WordCloudService {
-    private final Komoran komoran;
 
-    public WordCloudService() {
-        this.komoran = new Komoran(DEFAULT_MODEL.FULL);
-    }
-
+    private final WordCloudAiService wordCloudAiService;
 
     public List<WordCloudDto> calculateWordCloud(List<Diary> diaries) {
+        if (diaries == null || diaries.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        // 일기 내용 하나로 합치기
         String allContent = diaries.stream()
                 .map(Diary::getContent)
                 .filter(Objects::nonNull)
-                .collect(Collectors.joining(" "));
+                .collect(Collectors.joining("\n"));
 
-        // 코모란 형태소 분석
-        KomoranResult analyzeResult = komoran.analyze(allContent);
-        List<String> nouns = analyzeResult.getNouns();
+        // AI가 키워드 추출
+        try {
+            WordCloudResDto response = wordCloudAiService.extractKeywords(allContent);
 
-        // 빈도수 계산 (2글자 이상 명사만)
-        Map<String, Long> wordCounts = nouns.stream()
-                .filter(word -> word.length() >= 2)
-                .collect(Collectors.groupingBy(word -> word, Collectors.counting()));
+            // 결과가 null이거나 리스트가 없으면 빈 리스트 반환
+            if (response == null || response.getKeywords() == null) {
+                return Collections.emptyList();
+            }
 
-        // 상위 30개 추출
-        List<WordCloudDto> result = wordCounts.entrySet().stream()
-                .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
-                .limit(30)
-                .map(entry -> new WordCloudDto(entry.getKey(), entry.getValue().intValue()))
-                .toList();
-
-        return result;
+            return response.getKeywords();
+        } catch (Exception e) {
+            log.error("AI 워드클라우드 생성 중 오류 발생: {}", e.getMessage());
+            return Collections.emptyList();
+        }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
- #72

## 📝작업 내용

- 기존 형태소 분석기(KOMORAN)를 제거하고 OpenAI API를 활용한 키워드 추출 로직으로 교체했습니다.
- 초기에 속도와 비용효율성을 생각해 외부 api 호출이 불필요한 코모란 라이브러리를 선택했으나, 로컬 기반이기에 배포에서 과대한 메모리 사용으로 502 에러가 발생하는 문제가 있었습니다. 
- 변경결과 문맥을 고려하여 추출함으로써 분석 정확도가 상승했고, API 호출로 인한 지연 시간이 발생했습니다.(1초~5초 내외)
- WordCloudResDto 생성 : LangChain이 List 형태의 직접 반환을 할 시 매핑 에러가 발생하기 때문에, JSON 배열을 자바 객체로 안전하게 변환하기 위해 리스트를 감싸는 Wrapper 클래스를 추가했습니다.


<br>
<br>


## 💬리뷰 요구사항
- 변경한 워드 클라우드 호출 로직과, 응답 wrapper 방식이 적절한지 검토 부탁드립니다.