### PR TITLE
:recycle: Refactor: 상점 사용자 장착 아이템 이미지 원본으로 수정

### DIFF
--- a/src/main/java/com/example/egobook_be/domain/shop/controller/ShopController.java
+++ b/src/main/java/com/example/egobook_be/domain/shop/controller/ShopController.java
@@ -38,13 +38,13 @@ public class ShopController implements ShopControllerDocs{
             @Parameter(description = "아이템 카테고리", required = true)
             @RequestParam("category") ItemCategory category,
 
-            @Parameter(description = "Slice 번호 (1 ~ N)")
-            @RequestParam(value = "slice", defaultValue = "1") Integer slice,
+            @Parameter(description = "Page 번호 (1 ~ N)")
+            @RequestParam(value = "page", defaultValue = "1") Integer page,
 
-            @Parameter(description = "Slice 크기")
+            @Parameter(description = "Page 크기")
             @RequestParam(value = "size", defaultValue = "6") Integer size
     ){
-        SliceResponse<ItemInfoResDto> sliceResponse = shopService.getItemSlice(userId, category, slice, size);
+        SliceResponse<ItemInfoResDto> sliceResponse = shopService.getItemSlice(userId, category, page, size);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(GlobalResponse.success(sliceResponse));

--- a/src/main/java/com/example/egobook_be/domain/shop/controller/ShopControllerDocs.java
+++ b/src/main/java/com/example/egobook_be/domain/shop/controller/ShopControllerDocs.java
@@ -26,16 +26,17 @@ import java.util.List;
 public interface ShopControllerDocs {
     @Operation(summary = "상점 아이템 조회", description = """
             특정 카테고리의 아이템들을 조회하는 API입니다.
+            **상점용 아이템 이미지들의 url을 반환합니다**
             
             [**Query Parameter**]
             - category: **BACK** | **SKIN** | **DECOR_ONE** | **DECOR_TWO** | **BACKGROUND**
-            - slice: 1 ~ n (slice값은 1부터 시작합니다.)
+            - slice: 1 ~ n (page값은 1부터 시작합니다.)
             
             [**기능**:]
             - 각 카테고리의 n slice의 데이터를 반환합니다.
             
             [**주의**]
-             1. Slice 값을 0을 넣지 않도록 주의하세요.
+             1. Page 값을 0을 넣지 않도록 주의하세요.
              2. category 값은 필수입니다.
             """)
     @ApiResponses(value = {
@@ -56,16 +57,17 @@ public interface ShopControllerDocs {
             @Parameter(description = "아이템 카테고리", required = true)
             @RequestParam("category") ItemCategory category,
 
-            @Parameter(description = "Slice 번호 (1 ~ N)")
-            @RequestParam(value = "slice", defaultValue = "1") Integer slice,
+            @Parameter(description = "Page 번호 (1 ~ N)")
+            @RequestParam(value = "page", defaultValue = "1") Integer page,
 
-            @Parameter(description = "Slice 크기")
+            @Parameter(description = "Page 크기")
             @RequestParam(value = "size", defaultValue = "6") Integer size
     );
 
 
     @Operation(summary = "아이템 구매 API", description = """
             특정 아이템을 구매하는 API입니다.
+            **상점용 아이템 이미지들의 url을 반환합니다**
             
             [**Request Body**]
             - itemId : Item의 PK
@@ -93,6 +95,7 @@ public interface ShopControllerDocs {
 
     @Operation(summary = "아이템 착용/해제 API", description = """
             보유 중인 아이템을 착용하는 API입니다.
+            **사용자용 아이템 이미지들의 url을 반환합니다**
             
             [**Request Body**]
             - itemId : 착용할 Item의 PK
@@ -121,6 +124,7 @@ public interface ShopControllerDocs {
 
     @Operation(summary = "착용 중인 아이템 목록 조회", description = """
             현재 사용자가 착용(Equipped)하고 있는 모든 아이템 정보를 조회하는 API입니다.
+            **사용자용 아이템 이미지들의 url을 반환합니다**
             
             [**기능**]
             - 사용자의 인벤토리에서 `isEquipped` 상태가 `true`인 아이템들을 카테고리에 상관없이 모두 반환합니다.

--- a/src/main/java/com/example/egobook_be/domain/shop/sevice/ShopService.java
+++ b/src/main/java/com/example/egobook_be/domain/shop/sevice/ShopService.java
@@ -48,14 +48,15 @@ public class ShopService {
     
     /**
      * 특정 카테고리의 아이템을 무한 스크롤이 가능하도록 Slice로 가져와서 반환하는 api
+     * [ 아이템의 s3 url은 shop용 url을 반환한다 ]
      * @param userId 요청을 한 user의 PK
      * @param category 가져올 아이템의 카테고리
-     * @param slice 반환할 Slice 번호
+     * @param page 반환할 Slice 번호
      * @param size 한개의 Slice에 들어있는 요소의 개수
      * @return
      */
     @Transactional(readOnly = true)
-    public SliceResponse<ItemInfoResDto> getItemSlice(Long userId, ItemCategory category, Integer slice, Integer size){
+    public SliceResponse<ItemInfoResDto> getItemSlice(Long userId, ItemCategory category, Integer page, Integer size){
         /*
          * 1. Slicing을 위한 Pageable 객체 생성 (아이템 가격 기준으로 오름차순 정렬)
          * - 프론트로부터는 Slice값이 1 ~ N으로 오기 때문에, 해당 값을 -1
@@ -63,9 +64,9 @@ public class ShopService {
          * (1) 입력된 Slice값이 0보다 작은 경우나 null인 경우
          * (2) Size값이 너무 큰 경우, 최대 크기 100으로 제한 두기
          */
-        if(slice == null || slice < 0) throw new CustomException(GlobalErrorCode.INVALID_SLICE_VALUE);
+        if(page == null || page < 0) throw new CustomException(GlobalErrorCode.INVALID_SLICE_VALUE);
         int validSize = (size == null || size < 1) ? 6 : Math.min(size, 100);
-        int pageIndex = (slice >= 1) ? slice - 1 : 0;
+        int pageIndex = (page >= 1) ? page - 1 : 0;
         Pageable pageable = PageRequest.of(pageIndex, validSize, Sort.by(Sort.Direction.ASC, "price"));
 
         // 2. 해당 카테고리에 해당하는 Item들 slice로 조회
@@ -91,12 +92,13 @@ public class ShopService {
          */
         return SliceResponse.of(sliceEntity, item -> {
             Boolean isPurchased = userItemMap.containsKey(item.getId());
-            return itemMapper.toItemInfoResDto(item, cloudfrontDomain, isPurchased, userItemMap.getOrDefault(item.getId(), false));
+            return itemMapper.toItemInfoResDto(item, getShopCloudFrontDomain(), isPurchased, userItemMap.getOrDefault(item.getId(), false));
         });
     }
 
     /**
      * 특정 아이템을 구매(UserItem 테이블에 추가)하고, 해당 아이템의 정보를 반환해주는 함수
+     * [ 상점용 아이템 이미지 url을 반환한다 ]
      * @param userId User PK
      * @param reqDto PurchaseItemReqDto
      * @return ItemInfoResDto
@@ -128,11 +130,12 @@ public class ShopService {
         user.purchaseItem(item.getPrice());
 
         // 4. 아이템 구매 후, 해당 아이템에 대한 정보를 반환한다.
-        return userItemMapper.toItemInfoResDto(userItem, item, cloudfrontDomain);
+        return userItemMapper.toItemInfoResDto(userItem, item, getShopCloudFrontDomain());
     }
 
     /**
      * 아이템 착용/해제 상태를 변경하는 함수 (멱등성 보장)
+     * [ 사용자용 아이템 이미지 url을 반환한다 ]
      * @param userId User PK
      * @param reqDto EquipItemReqDto (itemId, isEquipped)
      * @return ItemInfoResDto
@@ -181,18 +184,27 @@ public class ShopService {
         }
 
         // 4. 변경된 정보 반환
-        return userItemMapper.toItemInfoResDto(targetUserItem, targetUserItem.getItem(), cloudfrontDomain);
+        return userItemMapper.toItemInfoResDto(targetUserItem, targetUserItem.getItem(), getMyCloudFrontDomain());
     }
 
-    /** 사용자가 장착하고 있는 아이템들의 정보 리스트를 반환하는 함수 */
+    /**
+     * 사용자가 장착하고 있는 아이템들의 정보 리스트를 반환하는 함수
+     * [ 사용자용 아이템 이미지 url을 반환한다 ]
+     */
     @Transactional(readOnly = true)
     public List<ItemInfoResDto> getEquippedItems(Long userId){
         // 1. 해당 사용자가 보유하고 있는 아이템들 조회
         List<UserItem> equippedItems = userItemRepository.findEquippedItems(userId);
         // 2. 조회해온 각 아이템을 dto로 변환 (Fetch Join 썼으므로 N+1 발생 안함)
         return equippedItems.stream()
-                .map(userItem -> userItemMapper.toItemInfoResDto(userItem, userItem.getItem(), cloudfrontDomain))
+                .map(userItem -> userItemMapper.toItemInfoResDto(userItem, userItem.getItem(), getMyCloudFrontDomain()))
                 .toList();
     }
 
+    private String getShopCloudFrontDomain(){
+        return cloudfrontDomain+"/shop";
+    }
+    private String getMyCloudFrontDomain(){
+        return cloudfrontDomain+"/my";
+    }
 }

--- a/src/main/java/com/example/egobook_be/global/loader/ItemInitializer.java
+++ b/src/main/java/com/example/egobook_be/global/loader/ItemInitializer.java
@@ -29,11 +29,11 @@ public class ItemInitializer implements ApplicationRunner {
     // ==================================================
     // 파일 생성을 위한 변수들 선언
     // ==================================================
-    String PATH_BACK = "shop/back";
-    String PATH_SKIN = "shop/skin";
-    String PATH_DECOR_ONE = "shop/decor1";
-    String PATH_DECOR_TWO = "shop/decor2";
-    String PATH_BACKGROUND = "shop/background";
+    String PATH_BACK = "back";
+    String PATH_SKIN = "skin";
+    String PATH_DECOR_ONE = "decor1";
+    String PATH_DECOR_TWO = "decor2";
+    String PATH_BACKGROUND = "background";
 
 
     @Override


### PR DESCRIPTION
## #️⃣연관된 이슈
- #32 

## 📝작업 내용
- 기존에는 상점 api들이 모두 상점용 이미지들을 반환하였는데, 아래와 같이 반환하는 이미지들이 수정되었음
(1) ```/shop/items``` 상점 아이템 조회 api : 상점용 아이템 이미지 url 반환
(2) ```/shop/purchase``` 아이템 구매 api : 상점용 아이템 이미지 url 반환
(3) ```/shop/equip``` 아이템 착용/해제 api : 사용자용 아이템 이미지 url 반환
(4) ```/shop/items/equipped``` 사용자가 착용 중인 아이템들 정보 조회: 사용자용 아이템 이미지 url 반환

- slice -> page로 변수명 수정