### PR TITLE
🐛  Fix: Diary 달력 month 필드 JSON 직렬화 형식 명시

### DIFF
--- a/src/main/java/com/example/egobook_be/domain/diary/dto/DiaryCalendarResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/diary/dto/DiaryCalendarResDto.java
@@ -1,5 +1,6 @@
 package com.example.egobook_be.domain.diary.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
 
 import java.time.LocalDate;
@@ -8,11 +9,13 @@ import java.util.List;
 
 @Builder
 public record DiaryCalendarResDto (
+        @JsonFormat(pattern = "yyyy-MM")
         YearMonth month,
         List<DailyTopEmotionResDto> days
 ) {
     @Builder
     public record DailyTopEmotionResDto (
+            @JsonFormat(pattern = "yyyy-MM-dd")
             LocalDate date,
             Integer emotionLevel
     ) {}


### PR DESCRIPTION
## #️⃣연관된 이슈
- #117 

## 📝작업 내용
- ``YearMonth` 타입이 JSON 직렬화 시 객체 형태로 변환되어 `monthValue`, `leapYear` 등 불필요한 필드 노출

> month 필드 확인
<img width="39%" alt="image" src="https://github.com/user-attachments/assets/592058f5-16e3-479f-a9dd-a9a8e7efe5ab" />
