### PR TITLE
🐛  Fix: Diary 달력 API Swagger 스키마 타입 명시

### DIFF
--- a/src/main/java/com/example/egobook_be/domain/diary/dto/DiaryCalendarResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/diary/dto/DiaryCalendarResDto.java
@@ -1,6 +1,7 @@
 package com.example.egobook_be.domain.diary.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 import java.time.LocalDate;
@@ -10,13 +11,16 @@ import java.util.List;
 @Builder
 public record DiaryCalendarResDto (
         @JsonFormat(pattern = "yyyy-MM")
+        @Schema(description = "조회 월", example = "2025-02", type = "string")
         YearMonth month,
         List<DailyTopEmotionResDto> days
 ) {
     @Builder
     public record DailyTopEmotionResDto (
             @JsonFormat(pattern = "yyyy-MM-dd")
+            @Schema(description = "날짜", example = "2025-02-12", type = "string")
             LocalDate date,
+            @Schema(description = "감정 레벨 (1-5)", example = "4")
             Integer emotionLevel
     ) {}
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
- #118 

## 📝작업 내용
- `DiaryCalendarResDto` 스키마 예시 형식 수정

> Diary 달력 API Swagger 스키마
<img width="60%" alt="image" src="https://github.com/user-attachments/assets/e36fe044-b6ad-49a0-a231-87488dcee765" />
