### PR TITLE
🐛 Fix: Diary 페이징 조회 시 데이터 누락 버그 수정

### DIFF
--- a/src/main/java/com/example/egobook_be/domain/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/diary/repository/DiaryRepository.java
@@ -43,11 +43,10 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
     List<DailyEmotionCount> findDailyEmotions(User user, LocalDate start, LocalDate end);
 
     @Query("""
-    SELECT d 
-    FROM Diary d 
-    JOIN d.type t 
-    WHERE d.user = :user 
-      AND d.date = :date 
+    SELECT DISTINCT d
+    FROM Diary d
+    WHERE d.user = :user
+      AND d.date = :date
       AND (:type IS NULL OR :type MEMBER OF d.type)
     ORDER BY d.writtenAt DESC
 """)


### PR DESCRIPTION
- 불필요한 `JOIN d.type t` 제거
- `SELECT DISTINCT d`로 중복 제거

> 일기 목록 페이징 확인 
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/c703cbcf-ec67-41d5-9c88-97b0bc76a7d5" />
