### PR TITLE
:bug: Fix: 동일한 구글 사용자 로그인 시도 시 409 예외 추가

### DIFF
--- a/src/main/java/com/example/egobook_be/domain/auth/sevice/AuthService.java
+++ b/src/main/java/com/example/egobook_be/domain/auth/sevice/AuthService.java
@@ -116,6 +116,9 @@ public class AuthService {
                 log.info("[Google Join] 탈퇴된 구글 사용자가 재 회원가입을 시도하였습니다.");
                 throw new CustomException(AuthErrorCode.GOOGLE_JOIN_FAIL_USER_WITHDRAWN);
             }
+
+            // (4) 만약 사용자가 삭제 대기중도, 삭제 상태도 아니라면 이미 존재하는 사용자이므로, 중복 회원가입을 막기 위해 "중복된 사용자입니다" 응답 반환
+            throw new CustomException(AuthErrorCode.ALREADY_REGISTERED_USER);
         }
 
         /*


### PR DESCRIPTION
## #️⃣연관된 이슈
- #13 

## 📝작업 내용
- 구글로 회원가입 시, 기존에 활성화된 사용자의 동일한 구글 계정으로 회원가입을 시도했을 때 409 에러가 아닌 500 에러를 반환하는 버그 수정 (예외 처리 추가 함)
