### PR TITLE
✅ test: 광장편지 로직 테스트 

### DIFF
--- a/src/test/java/com/example/egobook_be/domain/letter/LetterReportServiceTest.java
+++ b/src/test/java/com/example/egobook_be/domain/letter/LetterReportServiceTest.java
@@ -1,0 +1,120 @@
+package com.example.egobook_be.domain.letter;
+
+import com.example.egobook_be.domain.letters.entity.PlazaLetter;
+import com.example.egobook_be.domain.letters.entity.PlazaLetterMode;
+import com.example.egobook_be.domain.letters.entity.PlazaLetterReport;
+import com.example.egobook_be.domain.letters.entity.PlazaLetterStatus;
+import com.example.egobook_be.domain.letters.entity.ReplyReportReason;
+import com.example.egobook_be.domain.letters.enums.LettersErrorCode;
+import com.example.egobook_be.domain.letters.repository.PlazaLetterReportRepository;
+import com.example.egobook_be.domain.letters.repository.PlazaLetterRepository;
+import com.example.egobook_be.domain.letters.service.LetterReportService;
+import com.example.egobook_be.global.exception.CustomException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class LetterReportServiceTest {
+
+    @InjectMocks
+    private LetterReportService letterReportService;
+
+    @Mock
+    private PlazaLetterReportRepository letterReportRepository;
+
+    @Mock
+    private PlazaLetterRepository plazaLetterRepository;
+
+    @Test
+    @DisplayName("reportLetter_OTHER 사유인데 설명이 없으면 예외가 발생한다")
+    void reportLetter_otherReasonWithoutDescription_fail() {
+        assertThatThrownBy(() -> letterReportService.reportLetter(1L, 10L, ReplyReportReason.OTHER, " "))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(LettersErrorCode.INVALID_REPORT_REASON);
+    }
+
+    @Test
+    @DisplayName("reportLetter_이미 신고한 편지면 예외가 발생한다")
+    void reportLetter_alreadyReported_fail() {
+        given(letterReportRepository.existsByLetter_LetterIdAndReporterId(10L, 1L)).willReturn(true);
+
+        assertThatThrownBy(() -> letterReportService.reportLetter(1L, 10L, ReplyReportReason.ABUSE, "신고"))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(LettersErrorCode.ALREADY_REPORTED);
+
+        verify(plazaLetterRepository, never()).findById(any());
+    }
+
+    @Test
+    @DisplayName("reportLetter_받은 편지가 아니면 예외가 발생한다")
+    void reportLetter_notReceiver_fail() {
+        PlazaLetter letter = plazaLetter(10L, 2L, 3L);
+        given(letterReportRepository.existsByLetter_LetterIdAndReporterId(10L, 1L)).willReturn(false);
+        given(plazaLetterRepository.findById(10L)).willReturn(Optional.of(letter));
+
+        assertThatThrownBy(() -> letterReportService.reportLetter(1L, 10L, ReplyReportReason.ABUSE, "신고"))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(LettersErrorCode.FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("reportLetter_누적 신고가 3회 이상이면 편지를 삭제한다")
+    void reportLetter_reportCountThreeOrMore_deleteLetter() {
+        PlazaLetter letter = plazaLetter(10L, 2L, 1L);
+        given(letterReportRepository.existsByLetter_LetterIdAndReporterId(10L, 1L)).willReturn(false);
+        given(plazaLetterRepository.findById(10L)).willReturn(Optional.of(letter));
+        given(letterReportRepository.countByLetter_LetterId(10L)).willReturn(3L);
+
+        letterReportService.reportLetter(1L, 10L, ReplyReportReason.ABUSE, "신고 사유");
+
+        verify(letterReportRepository).save(any(PlazaLetterReport.class));
+        verify(plazaLetterRepository).deleteById(10L);
+    }
+
+    @Test
+    @DisplayName("reportLetter_정상 신고면 신고 내역을 저장한다")
+    void reportLetter_validRequest_success() {
+        PlazaLetter letter = plazaLetter(10L, 2L, 1L);
+        given(letterReportRepository.existsByLetter_LetterIdAndReporterId(10L, 1L)).willReturn(false);
+        given(plazaLetterRepository.findById(10L)).willReturn(Optional.of(letter));
+        given(letterReportRepository.countByLetter_LetterId(10L)).willReturn(1L);
+
+        letterReportService.reportLetter(1L, 10L, ReplyReportReason.SPAM, "광고 같아요");
+
+        verify(letterReportRepository).save(any(PlazaLetterReport.class));
+        verify(plazaLetterRepository, never()).deleteById(any());
+    }
+
+    private PlazaLetter plazaLetter(Long letterId, Long senderId, Long receiverId) {
+        return PlazaLetter.builder()
+                .letterId(letterId)
+                .threadId(100L)
+                .senderId(senderId)
+                .receiverId(receiverId)
+                .mode(PlazaLetterMode.RANDOM)
+                .fromLabel("익명")
+                .content("내용")
+                .status(PlazaLetterStatus.ARRIVED)
+                .createdAt(OffsetDateTime.now().minusHours(1))
+                .arrivedAt(OffsetDateTime.now().minusMinutes(30))
+                .replyDeadlineAt(OffsetDateTime.now().plusHours(23))
+                .build();
+    }
+}

--- a/src/test/java/com/example/egobook_be/domain/letter/PlazaLetterAiReplyServiceTest.java
+++ b/src/test/java/com/example/egobook_be/domain/letter/PlazaLetterAiReplyServiceTest.java
@@ -1,0 +1,121 @@
+package com.example.egobook_be.domain.letter;
+
+import com.example.egobook_be.domain.letters.entity.PlazaLetter;
+import com.example.egobook_be.domain.letters.entity.PlazaLetterMode;
+import com.example.egobook_be.domain.letters.entity.PlazaLetterReply;
+import com.example.egobook_be.domain.letters.entity.PlazaLetterStatus;
+import com.example.egobook_be.domain.letters.repository.PlazaLetterReplyRepository;
+import com.example.egobook_be.domain.letters.repository.PlazaLetterRepository;
+import com.example.egobook_be.domain.letters.service.ai.GeminiClient;
+import com.example.egobook_be.domain.letters.service.ai.PlazaLetterAiReplyService;
+import com.example.egobook_be.domain.notification.service.NotificationService;
+import com.example.egobook_be.domain.user.entity.User;
+import com.example.egobook_be.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class PlazaLetterAiReplyServiceTest {
+
+    @InjectMocks
+    private PlazaLetterAiReplyService plazaLetterAiReplyService;
+
+    @Mock
+    private PlazaLetterRepository plazaLetterRepository;
+
+    @Mock
+    private PlazaLetterReplyRepository plazaLetterReplyRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private GeminiClient geminiClient;
+
+    @Mock
+    private NotificationService notificationService;
+
+    @Test
+    @DisplayName("generateAiReplyIfEligible_이미 답장이 있으면 false를 반환한다")
+    void generateAiReplyIfEligible_replyAlreadyExists_returnFalse() {
+        PlazaLetter letter = targetLetter(10L, OffsetDateTime.now().minusHours(49), PlazaLetterStatus.ARRIVED);
+        given(plazaLetterRepository.findById(10L)).willReturn(Optional.of(letter));
+        given(plazaLetterReplyRepository.existsByLetter(letter)).willReturn(true);
+
+        boolean result = plazaLetterAiReplyService.generateAiReplyIfEligible(10L);
+
+        assertThat(result).isFalse();
+        verify(geminiClient, never()).generateReply(any(), any());
+    }
+
+    @Test
+    @DisplayName("generateAiReplyIfEligible_48시간이 지나지 않았으면 false를 반환한다")
+    void generateAiReplyIfEligible_notExpired48Hours_returnFalse() {
+        PlazaLetter letter = targetLetter(10L, OffsetDateTime.now().minusHours(47), PlazaLetterStatus.ARRIVED);
+        given(plazaLetterRepository.findById(10L)).willReturn(Optional.of(letter));
+        given(plazaLetterReplyRepository.existsByLetter(letter)).willReturn(false);
+
+        boolean result = plazaLetterAiReplyService.generateAiReplyIfEligible(10L);
+
+        assertThat(result).isFalse();
+        verify(geminiClient, never()).generateReply(any(), any());
+    }
+
+    @Test
+    @DisplayName("generateAiReplyIfEligible_조건을 만족하면 AI 답장을 저장하고 상태를 AI_REPLIED로 변경한다")
+    void generateAiReplyIfEligible_eligibleLetter_success() {
+        PlazaLetter letter = targetLetter(10L, OffsetDateTime.now().minusHours(49), PlazaLetterStatus.ARRIVED);
+        User sender = User.builder()
+                .id(1L)
+                .accountCode("USER1234")
+                .nickname("효진")
+                .ink(0)
+                .build();
+
+        given(plazaLetterRepository.findById(10L)).willReturn(Optional.of(letter));
+        given(plazaLetterReplyRepository.existsByLetter(letter)).willReturn(false);
+        given(userRepository.findById(1L)).willReturn(Optional.of(sender));
+        given(geminiClient.generateReply(eq("효진"), eq("원본 편지 내용")))
+                .willReturn("첫 줄입니다. 둘째 줄입니다. 셋째 줄입니다.");
+        given(plazaLetterReplyRepository.save(any(PlazaLetterReply.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        boolean result = plazaLetterAiReplyService.generateAiReplyIfEligible(10L);
+
+        assertThat(result).isTrue();
+        assertThat(letter.getStatus()).isEqualTo(PlazaLetterStatus.AI_REPLIED);
+        assertThat(letter.getRepliedAt()).isNotNull();
+        verify(plazaLetterReplyRepository).save(any(PlazaLetterReply.class));
+        verify(plazaLetterRepository).save(letter);
+    }
+
+    private PlazaLetter targetLetter(Long letterId, OffsetDateTime createdAt, PlazaLetterStatus status) {
+        return PlazaLetter.builder()
+                .letterId(letterId)
+                .threadId(500L)
+                .senderId(1L)
+                .receiverId(2L)
+                .mode(PlazaLetterMode.RANDOM)
+                .fromLabel("익명")
+                .content("원본 편지 내용")
+                .status(status)
+                .createdAt(createdAt)
+                .arrivedAt(createdAt.plusHours(1))
+                .replyDeadlineAt(createdAt.plusHours(25))
+                .build();
+    }
+}

--- a/src/test/java/com/example/egobook_be/domain/letter/PlazaLetterGiveUpServiceTest.java
+++ b/src/test/java/com/example/egobook_be/domain/letter/PlazaLetterGiveUpServiceTest.java
@@ -1,0 +1,91 @@
+package com.example.egobook_be.domain.letter;
+
+import com.example.egobook_be.domain.letters.entity.PlazaLetter;
+import com.example.egobook_be.domain.letters.entity.PlazaLetterMode;
+import com.example.egobook_be.domain.letters.entity.PlazaLetterStatus;
+import com.example.egobook_be.domain.letters.repository.PlazaLetterRepository;
+import com.example.egobook_be.domain.letters.service.scheduler.PlazaLetterGiveUpService;
+import com.example.egobook_be.domain.user.entity.User;
+import com.example.egobook_be.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class PlazaLetterGiveUpServiceTest {
+
+    @InjectMocks
+    private PlazaLetterGiveUpService plazaLetterGiveUpService;
+
+    @Mock
+    private PlazaLetterRepository plazaLetterRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("autoGiveUpExpiredLetters_대상이 없으면 0을 반환한다")
+    void autoGiveUpExpiredLetters_noTargets_returnZero() {
+        given(plazaLetterRepository.findGiveUpTargets(any(), any(), any(), any())).willReturn(List.of());
+
+        int result = plazaLetterGiveUpService.autoGiveUpExpiredLetters();
+
+        assertThat(result).isZero();
+        verify(userRepository, never()).findById(any());
+    }
+
+    @Test
+    @DisplayName("autoGiveUpExpiredLetters_만료 편지를 포기 처리하고 4시간 수신 차단한다")
+    void autoGiveUpExpiredLetters_expiredLetters_markGiveUpAndBlockReceiver() {
+        PlazaLetter target = plazaLetter(10L, 2L, 1L, PlazaLetterStatus.ARRIVED);
+        User receiver = user(1L);
+
+        given(plazaLetterRepository.findGiveUpTargets(any(), any(), any(), any())).willReturn(List.of(target));
+        given(userRepository.findById(1L)).willReturn(Optional.of(receiver));
+
+        int result = plazaLetterGiveUpService.autoGiveUpExpiredLetters();
+
+        assertThat(result).isEqualTo(1);
+        assertThat(target.getStatus()).isEqualTo(PlazaLetterStatus.GAVE_UP);
+        assertThat(target.getGaveUpAt()).isNotNull();
+        assertThat(receiver.getLetterReceiveBlockedUntil()).isNotNull();
+    }
+
+    private PlazaLetter plazaLetter(Long letterId, Long senderId, Long receiverId, PlazaLetterStatus status) {
+        return PlazaLetter.builder()
+                .letterId(letterId)
+                .threadId(300L)
+                .senderId(senderId)
+                .receiverId(receiverId)
+                .mode(PlazaLetterMode.RANDOM)
+                .fromLabel("익명")
+                .content("편지")
+                .status(status)
+                .createdAt(OffsetDateTime.now().minusDays(1))
+                .arrivedAt(OffsetDateTime.now().minusHours(25))
+                .replyDeadlineAt(OffsetDateTime.now().minusHours(1))
+                .build();
+    }
+
+    private User user(Long userId) {
+        return User.builder()
+                .id(userId)
+                .accountCode("USER1234")
+                .nickname("receiver")
+                .ink(0)
+                .build();
+    }
+}

--- a/src/test/java/com/example/egobook_be/domain/letter/PlazaLetterServiceTest.java
+++ b/src/test/java/com/example/egobook_be/domain/letter/PlazaLetterServiceTest.java
@@ -1,0 +1,318 @@
+package com.example.egobook_be.domain.letter;
+
+import com.example.egobook_be.domain.friend.repository.FriendRepository;
+import com.example.egobook_be.domain.home.entity.Mission;
+import com.example.egobook_be.domain.home.repository.MissionRepository;
+import com.example.egobook_be.domain.letters.dto.request.CreateLetterRequest;
+import com.example.egobook_be.domain.letters.dto.response.CreateLetterResponse;
+import com.example.egobook_be.domain.letters.entity.PlazaLetter;
+import com.example.egobook_be.domain.letters.entity.PlazaLetterMode;
+import com.example.egobook_be.domain.letters.entity.PlazaLetterStatus;
+import com.example.egobook_be.domain.letters.entity.PlazaLetterThread;
+import com.example.egobook_be.domain.letters.enums.LettersErrorCode;
+import com.example.egobook_be.domain.letters.enums.PlazaLetterColor;
+import com.example.egobook_be.domain.letters.mapper.PlazaLetterMapper;
+import com.example.egobook_be.domain.letters.repository.PlazaLetterReplyRepository;
+import com.example.egobook_be.domain.letters.repository.PlazaLetterRepository;
+import com.example.egobook_be.domain.letters.repository.PlazaLetterThreadRepository;
+import com.example.egobook_be.domain.letters.service.PlazaLetterService;
+import com.example.egobook_be.domain.letters.service.WordClientService;
+import com.example.egobook_be.domain.notification.service.NotificationService;
+import com.example.egobook_be.domain.user.entity.Ability;
+import com.example.egobook_be.domain.user.entity.User;
+import com.example.egobook_be.domain.user.repository.AbilityRepository;
+import com.example.egobook_be.domain.user.repository.InkLogRepository;
+import com.example.egobook_be.domain.user.repository.UserRepository;
+import com.example.egobook_be.global.exception.CustomException;
+import com.example.egobook_be.global.util.InkLogUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PlazaLetterServiceTest {
+
+    @Mock
+    private PlazaLetterRepository plazaLetterRepository;
+
+    @Mock
+    private PlazaLetterReplyRepository plazaLetterReplyRepository;
+
+    @Mock
+    private PlazaLetterThreadRepository plazaLetterThreadRepository;
+
+    @Mock
+    private FriendRepository friendRepository;
+
+    @Mock
+    private InkLogRepository inkLogRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private MissionRepository missionRepository;
+
+    @Mock
+    private AbilityRepository abilityRepository;
+
+    @Mock
+    private WordClientService wordClient;
+
+    @Mock
+    private InkLogUtil inkLogUtil;
+
+    @Mock
+    private PlazaLetterMapper plazaLetterMapper;
+
+    @Mock
+    private NotificationService notificationService;
+
+    @InjectMocks
+    private PlazaLetterService plazaLetterService;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(plazaLetterService, "cloudfrontDomain", "https://cdn.test.com");
+    }
+
+    @Test
+    @DisplayName("createLetter_RANDOM 후보 없음_WAITING 저장")
+    void createLetter_RANDOM후보없음_WAITING저장() {
+
+        Long userId = 1L;
+
+        User sender = User.builder()
+                .id(userId)
+                .accountCode("ACC001")
+                .nickname("효진")
+                .ink(0)
+                .build();
+
+        Mission mission = Mission.builder()
+                .user(sender)
+                .build();
+
+        CreateLetterRequest request = new CreateLetterRequest();
+        ReflectionTestUtils.setField(request, "mode", PlazaLetterMode.RANDOM);
+        ReflectionTestUtils.setField(request, "text", "익명으로 보내는 광장 편지");
+        ReflectionTestUtils.setField(request, "backgroundColor", PlazaLetterColor.WHITE);
+
+        PlazaLetterThread savedThread = PlazaLetterThread.builder()
+                .threadId(10L)
+                .createdAt(OffsetDateTime.now())
+                .build();
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(sender));
+        given(missionRepository.findByUser(sender)).willReturn(Optional.of(mission));
+        given(plazaLetterRepository.existsBySenderIdAndCreatedAtBetween(eq(userId), any(), any()))
+                .willReturn(false);
+
+        given(wordClient.detect("익명으로 보내는 광장 편지")).willReturn(null);
+        given(wordClient.shouldBlock(null)).willReturn(false);
+
+        given(userRepository.findHighReplyRateCandidates(userId, 50))
+                .willReturn(Collections.emptyList());
+
+        given(plazaLetterThreadRepository.save(any(PlazaLetterThread.class)))
+                .willReturn(savedThread);
+
+        given(plazaLetterRepository.save(any(PlazaLetter.class)))
+                .willAnswer(invocation -> {
+                    PlazaLetter letter = invocation.getArgument(0);
+                    return PlazaLetter.builder()
+                            .letterId(100L)
+                            .threadId(letter.getThreadId())
+                            .senderId(letter.getSenderId())
+                            .receiverId(letter.getReceiverId())
+                            .mode(letter.getMode())
+                            .fromLabel(letter.getFromLabel())
+                            .content(letter.getContent())
+                            .backgroundColor(letter.getBackgroundColor())
+                            .status(letter.getStatus())
+                            .createdAt(letter.getCreatedAt())
+                            .arrivedAt(letter.getArrivedAt())
+                            .replyDeadlineAt(letter.getReplyDeadlineAt())
+                            .build();
+                });
+
+
+        CreateLetterResponse response = plazaLetterService.createLetter(userId, request);
+
+
+        ArgumentCaptor<PlazaLetter> captor = ArgumentCaptor.forClass(PlazaLetter.class);
+        verify(plazaLetterRepository).save(captor.capture());
+
+        PlazaLetter savedLetter = captor.getValue();
+        assertThat(savedLetter.getStatus()).isEqualTo(PlazaLetterStatus.WAITING);
+        assertThat(savedLetter.getReceiverId()).isNull();
+        assertThat(savedLetter.getArrivedAt()).isNull();
+        assertThat(savedLetter.getReplyDeadlineAt()).isNull();
+        assertThat(savedLetter.getMode()).isEqualTo(PlazaLetterMode.RANDOM);
+        assertThat(savedLetter.getBackgroundColor()).isEqualTo(PlazaLetterColor.WHITE);
+
+        assertThat(response.letterId()).isEqualTo(100L);
+        assertThat(response.threadId()).isEqualTo(10L);
+        assertThat(response.status()).isEqualTo(PlazaLetterStatus.WAITING);
+        assertThat(response.mode()).isEqualTo(PlazaLetterMode.RANDOM);
+
+        verify(notificationService).createNotification(
+                isNull(),
+                any(),
+                eq(100L)
+        );
+    }
+
+    @Test
+    @DisplayName("createLetter_FRIEND인데 친구 아님_예외")
+    void createLetter_FRIEND인데친구아님_예외() {
+        // given
+        Long userId = 1L;
+        Long friendId = 2L;
+
+        User sender = User.builder()
+                .id(userId)
+                .accountCode("ACC001")
+                .nickname("효진")
+                .ink(0)
+                .build();
+
+        User receiver = User.builder()
+                .id(friendId)
+                .accountCode("ACC002")
+                .nickname("민지")
+                .ink(0)
+                .build();
+
+        Mission mission = Mission.builder()
+                .user(sender)
+                .build();
+
+        CreateLetterRequest request = new CreateLetterRequest();
+        ReflectionTestUtils.setField(request, "mode", PlazaLetterMode.FRIEND);
+        ReflectionTestUtils.setField(request, "toFriendId", friendId);
+        ReflectionTestUtils.setField(request, "text", "친구에게 보내는 편지");
+        ReflectionTestUtils.setField(request, "backgroundColor", PlazaLetterColor.WHITE);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(sender));
+        given(missionRepository.findByUser(sender)).willReturn(Optional.of(mission));
+        given(plazaLetterRepository.existsBySenderIdAndCreatedAtBetween(eq(userId), any(), any()))
+                .willReturn(false);
+        given(wordClient.detect("친구에게 보내는 편지")).willReturn(null);
+        given(wordClient.shouldBlock(null)).willReturn(false);
+        given(userRepository.findById(friendId)).willReturn(Optional.of(receiver));
+        given(friendRepository.existsByUserAndFriend(sender, receiver)).willReturn(false);
+
+        // when
+        Throwable thrown = catchThrowable(() -> plazaLetterService.createLetter(userId, request));
+
+        // then
+        assertThat(thrown).isInstanceOf(CustomException.class);
+        assertThat(((CustomException) thrown).getErrorCode()).isEqualTo(LettersErrorCode.NOT_FRIEND);
+
+        verify(plazaLetterThreadRepository, never()).save(any());
+        verify(plazaLetterRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("replyToLetter_이미 답장 존재_예외")
+    void replyToLetter_이미답장존재_예외() {
+        // given
+        Long userId = 2L;
+        Long letterId = 101L;
+
+        User receiver = User.builder()
+                .id(userId)
+                .accountCode("ACC002")
+                .nickname("민지")
+                .ink(0)
+                .build();
+
+        Ability ability = Ability.builder()
+                .user(receiver)
+                .build();
+
+        PlazaLetter letter = PlazaLetter.builder()
+                .letterId(letterId)
+                .threadId(10L)
+                .senderId(1L)
+                .receiverId(userId)
+                .mode(PlazaLetterMode.RANDOM)
+                .fromLabel("익명")
+                .content("원본 편지")
+                .backgroundColor(PlazaLetterColor.WHITE)
+                .status(PlazaLetterStatus.ARRIVED)
+                .createdAt(OffsetDateTime.now().minusHours(1))
+                .arrivedAt(OffsetDateTime.now().minusMinutes(30))
+                .replyDeadlineAt(OffsetDateTime.now().plusHours(23))
+                .build();
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(receiver));
+        given(abilityRepository.findByUser(receiver)).willReturn(Optional.of(ability));
+        given(plazaLetterRepository.findById(letterId)).willReturn(Optional.of(letter));
+        given(plazaLetterReplyRepository.existsByLetter(letter)).willReturn(true);
+
+        // when
+        Throwable thrown = catchThrowable(() ->
+                plazaLetterService.replyToLetter(userId, letterId, "답장 내용")
+        );
+
+        // then
+        assertThat(thrown).isInstanceOf(CustomException.class);
+        assertThat(((CustomException) thrown).getErrorCode()).isEqualTo(LettersErrorCode.ALREADY_REPLIED);
+
+        verify(plazaLetterReplyRepository, never()).save(any());
+        verify(notificationService, never()).createNotification(anyLong(), any(), anyLong(), any());
+    }
+
+    @Test
+    @DisplayName("deleteThread_내 스레드 아님_예외")
+    void deleteThread_내스레드아님_예외() {
+        // given
+        Long userId = 99L;
+        Long threadId = 300L;
+
+        PlazaLetter letter = PlazaLetter.builder()
+                .letterId(1L)
+                .threadId(threadId)
+                .senderId(1L)
+                .receiverId(2L)
+                .mode(PlazaLetterMode.RANDOM)
+                .fromLabel("익명")
+                .content("편지 내용")
+                .backgroundColor(PlazaLetterColor.WHITE)
+                .status(PlazaLetterStatus.REPLIED)
+                .createdAt(OffsetDateTime.now())
+                .build();
+
+        given(plazaLetterThreadRepository.existsById(threadId)).willReturn(true);
+        given(plazaLetterRepository.findByThreadId(threadId)).willReturn(Optional.of(letter));
+
+        // when
+        Throwable thrown = catchThrowable(() -> plazaLetterService.deleteThread(userId, threadId));
+
+        // then
+        assertThat(thrown).isInstanceOf(CustomException.class);
+        assertThat(((CustomException) thrown).getErrorCode()).isEqualTo(LettersErrorCode.FORBIDDEN);
+
+        verify(plazaLetterReplyRepository, never()).deleteByThreadId(anyLong());
+        verify(plazaLetterRepository, never()).deleteByThreadId(anyLong());
+        verify(plazaLetterThreadRepository, never()).deleteById(anyLong());
+    }
+}

--- a/src/test/java/com/example/egobook_be/domain/letter/PlazaLetterWaitingDispatchServiceTest.java
+++ b/src/test/java/com/example/egobook_be/domain/letter/PlazaLetterWaitingDispatchServiceTest.java
@@ -1,0 +1,79 @@
+package com.example.egobook_be.domain.letter;
+
+import com.example.egobook_be.domain.letters.entity.PlazaLetter;
+import com.example.egobook_be.domain.letters.entity.PlazaLetterMode;
+import com.example.egobook_be.domain.letters.entity.PlazaLetterStatus;
+import com.example.egobook_be.domain.letters.repository.PlazaLetterRepository;
+import com.example.egobook_be.domain.letters.service.scheduler.PlazaLetterWaitingDispatchService;
+import com.example.egobook_be.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class PlazaLetterWaitingDispatchServiceTest {
+
+    @InjectMocks
+    private PlazaLetterWaitingDispatchService plazaLetterWaitingDispatchService;
+
+    @Mock
+    private PlazaLetterRepository plazaLetterRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("dispatchWaitingLetters_수신 가능 유저가 없으면 0을 반환한다")
+    void dispatchWaitingLetters_noCandidateUsers_returnZero() {
+        given(userRepository.findReceivableUsers(any(), any())).willReturn(List.of());
+
+        int result = plazaLetterWaitingDispatchService.dispatchWaitingLetters();
+
+        assertThat(result).isZero();
+    }
+
+    @Test
+    @DisplayName("dispatchWaitingLetters_WAITING 편지를 수신 가능 유저에게 배정한다")
+    void dispatchWaitingLetters_waitingLettersExist_assignArrived() {
+        PlazaLetter waiting1 = waitingLetter(1L);
+        PlazaLetter waiting2 = waitingLetter(2L);
+
+        given(userRepository.findReceivableUsers(any(), any())).willReturn(List.of(101L, 102L));
+        given(plazaLetterRepository.findWaitingLetters(any())).willReturn(List.of(waiting1, waiting2));
+
+        int result = plazaLetterWaitingDispatchService.dispatchWaitingLetters();
+
+        assertThat(result).isEqualTo(2);
+        assertThat(waiting1.getReceiverId()).isEqualTo(101L);
+        assertThat(waiting1.getStatus()).isEqualTo(PlazaLetterStatus.ARRIVED);
+        assertThat(waiting1.getArrivedAt()).isNotNull();
+        assertThat(waiting1.getReplyDeadlineAt()).isNotNull();
+
+        assertThat(waiting2.getReceiverId()).isEqualTo(102L);
+        assertThat(waiting2.getStatus()).isEqualTo(PlazaLetterStatus.ARRIVED);
+    }
+
+    private PlazaLetter waitingLetter(Long letterId) {
+        return PlazaLetter.builder()
+                .letterId(letterId)
+                .threadId(400L + letterId)
+                .senderId(10L + letterId)
+                .receiverId(null)
+                .mode(PlazaLetterMode.RANDOM)
+                .fromLabel("익명")
+                .content("대기 편지")
+                .status(PlazaLetterStatus.WAITING)
+                .createdAt(OffsetDateTime.now().minusHours(2))
+                .build();
+    }
+}

--- a/src/test/java/com/example/egobook_be/domain/letter/ReplyReportServiceTest.java
+++ b/src/test/java/com/example/egobook_be/domain/letter/ReplyReportServiceTest.java
@@ -1,0 +1,145 @@
+package com.example.egobook_be.domain.letter;
+
+import com.example.egobook_be.domain.letters.entity.PlazaLetter;
+import com.example.egobook_be.domain.letters.entity.PlazaLetterMode;
+import com.example.egobook_be.domain.letters.entity.PlazaLetterReply;
+import com.example.egobook_be.domain.letters.entity.PlazaLetterReplyReport;
+import com.example.egobook_be.domain.letters.entity.PlazaLetterStatus;
+import com.example.egobook_be.domain.letters.entity.ReplyReportReason;
+import com.example.egobook_be.domain.letters.enums.LettersErrorCode;
+import com.example.egobook_be.domain.letters.repository.PlazaLetterReplyReportRepository;
+import com.example.egobook_be.domain.letters.repository.PlazaLetterReplyRepository;
+import com.example.egobook_be.domain.letters.repository.PlazaLetterRepository;
+import com.example.egobook_be.domain.letters.service.ReplyReportService;
+import com.example.egobook_be.global.exception.CustomException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ReplyReportServiceTest {
+
+    @InjectMocks
+    private ReplyReportService replyReportService;
+
+    @Mock
+    private PlazaLetterReplyReportRepository replyReportRepository;
+
+    @Mock
+    private PlazaLetterReplyRepository plazaLetterReplyRepository;
+
+    @Mock
+    private PlazaLetterRepository plazaLetterRepository;
+
+    @Test
+    @DisplayName("reportReply_OTHER 사유인데 설명이 없으면 예외가 발생한다")
+    void reportReply_otherReasonWithoutDescription_fail() {
+        assertThatThrownBy(() -> replyReportService.reportReply(1L, 10L, ReplyReportReason.OTHER, " "))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(LettersErrorCode.INVALID_REPORT_REASON);
+    }
+
+    @Test
+    @DisplayName("reportReply_이미 신고한 답장이면 예외가 발생한다")
+    void reportReply_alreadyReported_fail() {
+        given(replyReportRepository.existsByReply_ReplyIdAndReporterId(10L, 1L)).willReturn(true);
+
+        assertThatThrownBy(() -> replyReportService.reportReply(1L, 10L, ReplyReportReason.ABUSE, "신고"))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(LettersErrorCode.ALREADY_REPORTED);
+
+        verify(plazaLetterReplyRepository, never()).findByIdWithLetter(any());
+    }
+
+    @Test
+    @DisplayName("reportReply_수신자는 답장을 신고할 수 없다")
+    void reportReply_receiverReports_fail() {
+        PlazaLetter letter = plazaLetter(100L, 2L, 1L);
+        PlazaLetterReply reply = plazaReply(10L, letter, 2L);
+
+        given(replyReportRepository.existsByReply_ReplyIdAndReporterId(10L, 1L)).willReturn(false);
+        given(plazaLetterReplyRepository.findByIdWithLetter(10L)).willReturn(Optional.of(reply));
+
+        assertThatThrownBy(() -> replyReportService.reportReply(1L, 10L, ReplyReportReason.ABUSE, "신고"))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(LettersErrorCode.FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("reportReply_누적 신고가 3회 이상이면 답장을 삭제 처리한다")
+    void reportReply_reportCountThreeOrMore_deleteReply() {
+        PlazaLetter letter = plazaLetter(100L, 1L, 2L);
+        PlazaLetterReply reply = plazaReply(10L, letter, 2L);
+
+        given(replyReportRepository.existsByReply_ReplyIdAndReporterId(10L, 1L)).willReturn(false);
+        given(plazaLetterReplyRepository.findByIdWithLetter(10L)).willReturn(Optional.of(reply));
+        given(replyReportRepository.countByReply_ReplyId(10L)).willReturn(3L);
+
+        replyReportService.reportReply(1L, 10L, ReplyReportReason.ABUSE, "신고");
+
+        verify(replyReportRepository).save(any(PlazaLetterReplyReport.class));
+        verify(replyReportRepository).moveReplyToReportDbAndDelete(10L, PlazaLetterReply.ReplyStatus.DELETED);
+        verify(plazaLetterReplyRepository).deleteById(10L);
+    }
+
+    @Test
+    @DisplayName("reportReply_정상 신고면 신고 내역만 저장한다")
+    void reportReply_validRequest_success() {
+        PlazaLetter letter = plazaLetter(100L, 1L, 2L);
+        PlazaLetterReply reply = plazaReply(10L, letter, 2L);
+
+        given(replyReportRepository.existsByReply_ReplyIdAndReporterId(10L, 1L)).willReturn(false);
+        given(plazaLetterReplyRepository.findByIdWithLetter(10L)).willReturn(Optional.of(reply));
+        given(replyReportRepository.countByReply_ReplyId(10L)).willReturn(1L);
+
+        replyReportService.reportReply(1L, 10L, ReplyReportReason.SPAM, "도배 답장");
+
+        verify(replyReportRepository).save(any(PlazaLetterReplyReport.class));
+        verify(replyReportRepository, never()).moveReplyToReportDbAndDelete(any(), any());
+        verify(plazaLetterReplyRepository, never()).deleteById(any());
+    }
+
+    private PlazaLetter plazaLetter(Long letterId, Long senderId, Long receiverId) {
+        return PlazaLetter.builder()
+                .letterId(letterId)
+                .threadId(200L)
+                .senderId(senderId)
+                .receiverId(receiverId)
+                .mode(PlazaLetterMode.RANDOM)
+                .fromLabel("익명")
+                .content("편지")
+                .status(PlazaLetterStatus.ARRIVED)
+                .createdAt(OffsetDateTime.now().minusHours(10))
+                .arrivedAt(OffsetDateTime.now().minusHours(9))
+                .replyDeadlineAt(OffsetDateTime.now().plusHours(15))
+                .build();
+    }
+
+    private PlazaLetterReply plazaReply(Long replyId, PlazaLetter letter, Long replierId) {
+        return PlazaLetterReply.builder()
+                .replyId(replyId)
+                .threadId(letter.getThreadId())
+                .letter(letter)
+                .replierId(replierId)
+                .text("답장")
+                .isAiGenerated(false)
+                .createdAt(OffsetDateTime.now())
+                .status(PlazaLetterReply.ReplyStatus.SENT)
+                .build();
+    }
+}

--- a/src/test/java/com/example/egobook_be/domain/letter/WordClientServiceTest.java
+++ b/src/test/java/com/example/egobook_be/domain/letter/WordClientServiceTest.java
@@ -1,0 +1,50 @@
+package com.example.egobook_be.domain.letter;
+
+import com.example.egobook_be.domain.letters.dto.response.WordDetectResponse;
+import com.example.egobook_be.domain.letters.service.WordClientService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class WordClientServiceTest {
+
+    @InjectMocks
+    private WordClientService wordClientService;
+
+    @Mock
+    private RestClient wordRestClient;
+
+    @Test
+    @DisplayName("shouldBlock_응답이 없으면 차단한다")
+    void shouldBlock_nullResponse_true() {
+        assertThat(wordClientService.shouldBlock(null)).isTrue();
+    }
+
+    @Test
+    @DisplayName("shouldBlock_유해 문장이고 80퍼센트 이상이면 차단한다")
+    void shouldBlock_harmfulAndAboveThreshold_true() {
+        WordDetectResponse response = new WordDetectResponse();
+        ReflectionTestUtils.setField(response, "harmful", true);
+        ReflectionTestUtils.setField(response, "percentage", 80.0d);
+
+        assertThat(wordClientService.shouldBlock(response)).isTrue();
+    }
+
+    @Test
+    @DisplayName("shouldBlock_유해 문장이 아니거나 임계치 미만이면 차단하지 않는다")
+    void shouldBlock_notHarmfulOrBelowThreshold_false() {
+        WordDetectResponse response = new WordDetectResponse();
+        ReflectionTestUtils.setField(response, "harmful", true);
+        ReflectionTestUtils.setField(response, "percentage", 79.9d);
+
+        assertThat(wordClientService.shouldBlock(response)).isFalse();
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
- #140 

## 📝작업 내용
- 광장편지 도메인에 대한 테스트 코드를 추가했습니다.
이번 PR에서는 광장편지의 핵심 서비스 로직과 스케줄러 로직을 중심으로
정상/예외 케이스를 검증하는 단위 테스트를 작성했습니다.


### 1. 광장편지 서비스 테스트
- PlazaLetterServiceTest
  - [성공] RANDOM 편지 작성 시 후보가 없으면 WAITING 상태로 저장
  - [실패] FRIEND 모드인데 친구가 아니면 예외 발생
  - [실패] 이미 답장된 편지에 다시 답장하면 예외 발생
  - [실패] 내 스레드가 아니면 삭제 불가

### 2. 편지/답장 신고 테스트
- LetterReportServiceTest
- ReplyReportServiceTest

### 3. 욕설 탐지 클라이언트 테스트
- WordClientServiceTest

### 4. 광장편지 스케줄러 테스트
- PlazaLetterGiveUpServiceTest
  - 24시간 초과 편지 자동 포기 처리 검증
- PlazaLetterWaitingDispatchServiceTest
  - WAITING 편지를 수신 가능 유저에게 배정하는 로직 검증
- PlazaLetterAiReplyServiceTest
  - 48시간 무응답 편지에 AI 답장 생성 로직 검증

## 테스트 결과
- 작성한 광장편지 테스트 파일 단독 실행 기준 모두 통과 확인
- `BUILD SUCCESSFUL` 확인 완료

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?