### PR TITLE
✅ Test: Friends API 테스트 코드

### DIFF
--- a/src/test/java/com/example/egobook_be/domain/freind/FriendAcceptServiceTest.java
+++ b/src/test/java/com/example/egobook_be/domain/freind/FriendAcceptServiceTest.java
@@ -1,0 +1,176 @@
+package com.example.egobook_be.domain.freind;
+
+import com.example.egobook_be.domain.friend.entity.Friend;
+import com.example.egobook_be.domain.friend.entity.FriendRequest;
+import com.example.egobook_be.domain.friend.exception.FriendErrorCode;
+import com.example.egobook_be.domain.friend.repository.FriendRepository;
+import com.example.egobook_be.domain.friend.repository.FriendRequestRepository;
+import com.example.egobook_be.domain.friend.service.FriendService;
+import com.example.egobook_be.domain.user.entity.User;
+import com.example.egobook_be.domain.user.repository.UserRepository;
+import com.example.egobook_be.global.exception.CustomException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FriendAcceptServiceTest {
+
+    @InjectMocks
+    private FriendService friendService;
+
+    @Mock
+    private FriendRequestRepository friendRequestRepository;
+
+    @Mock
+    private FriendRepository friendRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private User sender;
+    private User receiver;
+    private FriendRequest friendRequest;
+
+    @BeforeEach
+    void setUp() {
+        sender = mock(User.class);
+        receiver = mock(User.class);
+        friendRequest = mock(FriendRequest.class);
+    }
+
+    @Test
+    @DisplayName("acceptRequest_정상수락_성공")
+    void acceptRequest_validRequest_success() {
+        // given
+        given(friendRequest.getSender()).willReturn(sender);
+        given(userRepository.findById(2L)).willReturn(Optional.of(receiver));
+        given(friendRequestRepository.findByIdAndReceiver(10L, receiver))
+                .willReturn(Optional.of(friendRequest));
+        given(friendRepository.existsByUserAndFriend(receiver, sender)).willReturn(false);
+        given(friendRepository.countByUser(receiver)).willReturn(0L);
+        given(friendRepository.countByUser(sender)).willReturn(0L);
+
+        // when
+        friendService.acceptRequest(2L, 10L);
+
+        // then
+        verify(friendRequest).accept();
+        verify(friendRepository, times(2)).save(any(Friend.class));
+    }
+
+    @Test
+    @DisplayName("acceptRequest_수신자없음_실패")
+    void acceptRequest_receiverNotFound_fail() {
+        // given
+        given(userRepository.findById(2L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> friendService.acceptRequest(2L, 10L))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(FriendErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("acceptRequest_신청내역없음_실패")
+    void acceptRequest_requestNotFound_fail() {
+        // given
+        given(userRepository.findById(2L)).willReturn(Optional.of(receiver));
+        given(friendRequestRepository.findByIdAndReceiver(10L, receiver))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> friendService.acceptRequest(2L, 10L))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(FriendErrorCode.FRIEND_REQUEST_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("acceptRequest_이미친구인경우_실패")
+    void acceptRequest_alreadyFriend_fail() {
+        // given
+        given(friendRequest.getSender()).willReturn(sender);
+        given(userRepository.findById(2L)).willReturn(Optional.of(receiver));
+        given(friendRequestRepository.findByIdAndReceiver(10L, receiver))
+                .willReturn(Optional.of(friendRequest));
+        given(friendRepository.existsByUserAndFriend(receiver, sender)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> friendService.acceptRequest(2L, 10L))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(FriendErrorCode.ALREADY_FRIEND);
+    }
+
+    @Test
+    @DisplayName("acceptRequest_수신자친구10명초과_실패")
+    void acceptRequest_receiverFriendLimitExceeded_fail() {
+        // given
+        given(friendRequest.getSender()).willReturn(sender);
+        given(userRepository.findById(2L)).willReturn(Optional.of(receiver));
+        given(friendRequestRepository.findByIdAndReceiver(10L, receiver))
+                .willReturn(Optional.of(friendRequest));
+        given(friendRepository.existsByUserAndFriend(receiver, sender)).willReturn(false);
+        given(friendRepository.countByUser(receiver)).willReturn(10L);
+
+        // when & then
+        assertThatThrownBy(() -> friendService.acceptRequest(2L, 10L))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(FriendErrorCode.FRIEND_LIMIT_EXCEEDED);
+    }
+
+    @Test
+    @DisplayName("acceptRequest_발신자친구10명초과_실패")
+    void acceptRequest_senderFriendLimitExceeded_fail() {
+        // given
+        given(friendRequest.getSender()).willReturn(sender);
+        given(userRepository.findById(2L)).willReturn(Optional.of(receiver));
+        given(friendRequestRepository.findByIdAndReceiver(10L, receiver))
+                .willReturn(Optional.of(friendRequest));
+        given(friendRepository.existsByUserAndFriend(receiver, sender)).willReturn(false);
+        given(friendRepository.countByUser(receiver)).willReturn(0L);
+        given(friendRepository.countByUser(sender)).willReturn(10L);
+
+        // when & then
+        assertThatThrownBy(() -> friendService.acceptRequest(2L, 10L))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(FriendErrorCode.FRIEND_LIMIT_EXCEEDED);
+    }
+
+    @Test
+    @DisplayName("acceptRequest_동시요청낙관적락충돌_실패")
+    void acceptRequest_optimisticLockConflict_fail() {
+        // given
+        given(friendRequest.getSender()).willReturn(sender);
+        given(userRepository.findById(2L)).willReturn(Optional.of(receiver));
+        given(friendRequestRepository.findByIdAndReceiver(10L, receiver))
+                .willReturn(Optional.of(friendRequest));
+        given(friendRepository.existsByUserAndFriend(receiver, sender)).willReturn(false);
+        given(friendRepository.countByUser(receiver)).willReturn(0L);
+        given(friendRepository.countByUser(sender)).willReturn(0L);
+        doThrow(ObjectOptimisticLockingFailureException.class).when(friendRequest).accept();
+
+        // when & then
+        assertThatThrownBy(() -> friendService.acceptRequest(2L, 10L))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(FriendErrorCode.FRIEND_REQUEST_CONFLICT);
+    }
+}
+

--- a/src/test/java/com/example/egobook_be/domain/freind/FriendRejectServiceTest.java
+++ b/src/test/java/com/example/egobook_be/domain/freind/FriendRejectServiceTest.java
@@ -1,0 +1,144 @@
+package com.example.egobook_be.domain.freind;
+import com.example.egobook_be.domain.friend.entity.FriendRequest;
+import com.example.egobook_be.domain.friend.enums.FriendRequestStatus;
+import com.example.egobook_be.domain.friend.exception.FriendErrorCode;
+import com.example.egobook_be.domain.friend.repository.FriendRepository;
+import com.example.egobook_be.domain.friend.repository.FriendRequestRepository;
+import com.example.egobook_be.domain.friend.service.FriendService;
+import com.example.egobook_be.domain.user.entity.User;
+import com.example.egobook_be.domain.user.repository.UserRepository;
+import com.example.egobook_be.global.exception.CustomException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FriendRejectServiceTest {
+
+    @InjectMocks
+    private FriendService friendService;
+
+    @Mock
+    private FriendRequestRepository friendRequestRepository;
+
+    @Mock
+    private FriendRepository friendRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private User sender;
+    private User receiver;
+    private FriendRequest friendRequest;
+
+    @BeforeEach
+    void setUp() {
+        sender = mock(User.class);
+        receiver = mock(User.class);
+        friendRequest = mock(FriendRequest.class);
+    }
+
+    @Test
+    @DisplayName("rejectRequest_정상거절_성공")
+    void rejectRequest_validRequest_success() {
+
+        given(friendRequest.getSender()).willReturn(sender);
+        given(userRepository.findById(2L)).willReturn(Optional.of(receiver));
+        given(friendRequestRepository.findByIdAndReceiver(10L, receiver))
+                .willReturn(Optional.of(friendRequest));
+        given(friendRepository.existsByUserAndFriend(receiver, sender)).willReturn(false);
+        given(friendRequest.getStatus()).willReturn(FriendRequestStatus.PENDING);
+
+        friendService.rejectRequest(2L, 10L);
+
+        verify(friendRequest).reject();
+    }
+
+    @Test
+    @DisplayName("rejectRequest_수신자없음_실패")
+    void rejectRequest_receiverNotFound_fail() {
+
+        given(userRepository.findById(2L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> friendService.rejectRequest(2L, 10L))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(FriendErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("rejectRequest_신청내역없음_실패")
+    void rejectRequest_requestNotFound_fail() {
+
+        given(userRepository.findById(2L)).willReturn(Optional.of(receiver));
+        given(friendRequestRepository.findByIdAndReceiver(10L, receiver))
+                .willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> friendService.rejectRequest(2L, 10L))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(FriendErrorCode.FRIEND_REQUEST_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("rejectRequest_이미친구인경우_실패")
+    void rejectRequest_alreadyFriend_fail() {
+
+        given(friendRequest.getSender()).willReturn(sender);
+        given(userRepository.findById(2L)).willReturn(Optional.of(receiver));
+        given(friendRequestRepository.findByIdAndReceiver(10L, receiver))
+                .willReturn(Optional.of(friendRequest));
+        given(friendRepository.existsByUserAndFriend(receiver, sender)).willReturn(true);
+
+        assertThatThrownBy(() -> friendService.rejectRequest(2L, 10L))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(FriendErrorCode.ALREADY_FRIEND);
+    }
+
+    @Test
+    @DisplayName("rejectRequest_이미처리된신청_실패")
+    void rejectRequest_alreadyProcessedRequest_fail() {
+
+        given(friendRequest.getSender()).willReturn(sender);
+        given(userRepository.findById(2L)).willReturn(Optional.of(receiver));
+        given(friendRequestRepository.findByIdAndReceiver(10L, receiver))
+                .willReturn(Optional.of(friendRequest));
+        given(friendRepository.existsByUserAndFriend(receiver, sender)).willReturn(false);
+        given(friendRequest.getStatus()).willReturn(FriendRequestStatus.REJECTED);
+
+        assertThatThrownBy(() -> friendService.rejectRequest(2L, 10L))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(FriendErrorCode.INVALID_FRIEND_REQUEST_STATE);
+    }
+
+    @Test
+    @DisplayName("rejectRequest_동시요청낙관적락충돌_실패")
+    void rejectRequest_optimisticLockConflict_fail() {
+
+        given(friendRequest.getSender()).willReturn(sender);
+        given(userRepository.findById(2L)).willReturn(Optional.of(receiver));
+        given(friendRequestRepository.findByIdAndReceiver(10L, receiver))
+                .willReturn(Optional.of(friendRequest));
+        given(friendRepository.existsByUserAndFriend(receiver, sender)).willReturn(false);
+        given(friendRequest.getStatus()).willReturn(FriendRequestStatus.PENDING);
+        doThrow(ObjectOptimisticLockingFailureException.class).when(friendRequest).reject();
+
+        assertThatThrownBy(() -> friendService.rejectRequest(2L, 10L))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(FriendErrorCode.FRIEND_REQUEST_CONFLICT);
+    }
+}

--- a/src/test/java/com/example/egobook_be/domain/freind/FriendRequestServiceTest.java
+++ b/src/test/java/com/example/egobook_be/domain/freind/FriendRequestServiceTest.java
@@ -1,0 +1,204 @@
+package com.example.egobook_be.domain.freind;
+
+import com.example.egobook_be.domain.friend.dto.FriendRequestCreateReqDto;
+import com.example.egobook_be.domain.friend.entity.FriendRequest;
+import com.example.egobook_be.domain.friend.enums.FriendRequestStatus;
+import com.example.egobook_be.domain.friend.exception.FriendErrorCode;
+import com.example.egobook_be.domain.friend.repository.FriendRepository;
+import com.example.egobook_be.domain.friend.repository.FriendRequestRepository;
+import com.example.egobook_be.domain.friend.service.FriendService;
+import com.example.egobook_be.domain.user.entity.User;
+import com.example.egobook_be.domain.user.repository.UserRepository;
+import com.example.egobook_be.global.exception.CustomException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FriendRequestServiceTest {
+
+    @InjectMocks
+    private FriendService friendService;
+
+    @Mock
+    private FriendRequestRepository friendRequestRepository;
+
+    @Mock
+    private FriendRepository friendRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private User sender;
+    private User receiver;
+    private FriendRequestCreateReqDto reqDto;
+
+    @BeforeEach
+    void setUp() {
+        sender = mock(User.class);
+        receiver = mock(User.class);
+
+        reqDto = FriendRequestCreateReqDto.builder()
+                .receiverId(2L)
+                .build();
+    }
+
+    @Test
+    @DisplayName("requestFriend_정상신청_성공")
+    void requestFriend_validRequest_success() {
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(sender));
+        given(userRepository.findById(2L)).willReturn(Optional.of(receiver));
+        given(friendRepository.existsByUserAndFriend(sender, receiver)).willReturn(false);
+        given(friendRepository.existsByUserAndFriend(receiver, sender)).willReturn(false);
+        given(friendRequestRepository.findBySenderAndReceiver(sender, receiver))
+                .willReturn(Optional.empty());
+
+        friendService.requestFriend(1L, reqDto);
+
+        ArgumentCaptor<FriendRequest> captor = ArgumentCaptor.forClass(FriendRequest.class);
+        verify(friendRequestRepository).save(captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo(FriendRequestStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("requestFriend_자기자신에게신청_실패")
+    void requestFriend_selfRequest_fail() {
+
+        FriendRequestCreateReqDto selfReqDto = FriendRequestCreateReqDto.builder()
+                .receiverId(1L)
+                .build();
+
+        assertThatThrownBy(() -> friendService.requestFriend(1L, selfReqDto))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(FriendErrorCode.SELF_REQUEST_NOT_ALLOWED);
+    }
+
+    @Test
+    @DisplayName("requestFriend_발신자없음_실패")
+    void requestFriend_senderNotFound_fail() {
+
+        given(userRepository.findById(1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> friendService.requestFriend(1L, reqDto))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(FriendErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("requestFriend_수신자없음_실패")
+    void requestFriend_receiverNotFound_fail() {
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(sender));
+        given(userRepository.findById(2L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> friendService.requestFriend(1L, reqDto))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(FriendErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("requestFriend_이미친구인경우_실패")
+    void requestFriend_alreadyFriend_fail() {
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(sender));
+        given(userRepository.findById(2L)).willReturn(Optional.of(receiver));
+        given(friendRepository.existsByUserAndFriend(sender, receiver)).willReturn(true);
+
+        assertThatThrownBy(() -> friendService.requestFriend(1L, reqDto))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(FriendErrorCode.ALREADY_FRIEND);
+    }
+
+    @Test
+    @DisplayName("requestFriend_역방향이미친구인경우_실패")
+    void requestFriend_alreadyFriendReverse_fail() {
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(sender));
+        given(userRepository.findById(2L)).willReturn(Optional.of(receiver));
+        given(friendRepository.existsByUserAndFriend(sender, receiver)).willReturn(false);
+        given(friendRepository.existsByUserAndFriend(receiver, sender)).willReturn(true);
+
+        assertThatThrownBy(() -> friendService.requestFriend(1L, reqDto))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(FriendErrorCode.ALREADY_FRIEND);
+    }
+
+    @Test
+    @DisplayName("requestFriend_이미PENDING신청존재_실패")
+    void requestFriend_alreadyPendingRequest_fail() {
+
+        FriendRequest existingRequest = mock(FriendRequest.class);
+        given(existingRequest.getStatus()).willReturn(FriendRequestStatus.PENDING);
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(sender));
+        given(userRepository.findById(2L)).willReturn(Optional.of(receiver));
+        given(friendRepository.existsByUserAndFriend(sender, receiver)).willReturn(false);
+        given(friendRepository.existsByUserAndFriend(receiver, sender)).willReturn(false);
+        given(friendRequestRepository.findBySenderAndReceiver(sender, receiver))
+                .willReturn(Optional.of(existingRequest));
+
+        assertThatThrownBy(() -> friendService.requestFriend(1L, reqDto))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(FriendErrorCode.ALREADY_REQUESTED);
+    }
+
+    @Test
+    @DisplayName("requestFriend_ACCEPTED상태신청재시도_실패")
+    void requestFriend_retryOnAcceptedRequest_fail() {
+
+        FriendRequest existingRequest = mock(FriendRequest.class);
+        given(existingRequest.getStatus()).willReturn(FriendRequestStatus.ACCEPTED);
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(sender));
+        given(userRepository.findById(2L)).willReturn(Optional.of(receiver));
+        given(friendRepository.existsByUserAndFriend(sender, receiver)).willReturn(false);
+        given(friendRepository.existsByUserAndFriend(receiver, sender)).willReturn(false);
+        given(friendRequestRepository.findBySenderAndReceiver(sender, receiver))
+                .willReturn(Optional.of(existingRequest));
+
+        assertThatThrownBy(() -> friendService.requestFriend(1L, reqDto))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(FriendErrorCode.ALREADY_FRIEND);
+    }
+
+    @Test
+    @DisplayName("requestFriend_REJECTED후재신청_성공")
+    void requestFriend_reRequestAfterRejected_success() {
+
+        FriendRequest existingRequest = mock(FriendRequest.class);
+        given(existingRequest.getStatus()).willReturn(FriendRequestStatus.REJECTED);
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(sender));
+        given(userRepository.findById(2L)).willReturn(Optional.of(receiver));
+        given(friendRepository.existsByUserAndFriend(sender, receiver)).willReturn(false);
+        given(friendRepository.existsByUserAndFriend(receiver, sender)).willReturn(false);
+        given(friendRequestRepository.findBySenderAndReceiver(sender, receiver))
+                .willReturn(Optional.of(existingRequest));
+
+        friendService.requestFriend(1L, reqDto);
+
+        verify(existingRequest).reRequest();
+        verify(friendRequestRepository, never()).save(any(FriendRequest.class));
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
- close #147 

## 📝 작업 내용

친구 기능 핵심 비즈니스 로직에 대한 단위 테스트 코드를 작성했습니다.

### 테스트 대상
- `FriendRequestServiceTest` - 친구 신청 보내기
- `FriendAcceptServiceTest` - 친구 신청 수락
- `FriendRejectServiceTest` - 친구 신청 거절

### 테스트 케이스

**1. 친구 신청 (8개)**
- 정상 신청 성공
- 자기 자신에게 신청 시 실패
- 발신자 없음 시 실패
- 수신자 없음 시 실패
- 이미 친구인 경우 실패 (정방향 / 역방향)
- 이미 PENDING 상태 신청 존재 시 실패
- ACCEPTED 상태에서 재시도 시 실패
- REJECTED 후 재신청 성공

**2. 친구 신청 수락 (7개)**
- 정상 수락 성공
- 수신자 없음 시 실패
- 신청 내역 없음 시 실패
- 이미 친구인 경우 실패
- 수신자 친구 10명 초과 시 실패
- 발신자 친구 10명 초과 시 실패
- 낙관적 락 충돌 시 실패

**3. 친구 신청 거절 (6개)**
- 정상 거절 성공
- 수신자 없음 시 실패
- 신청 내역 없음 시 실패
- 이미 친구인 경우 실패
- 이미 처리된 신청 거절 시 실패
- 낙관적 락 충돌 시 실패

## ✅ 테스트 결과
- 22개 Test 모두 성공했습니다.