### PR TITLE
✅ Test: Question API 테스트 코드

### DIFF
--- a/src/test/java/com/example/egobook_be/domain/question/TodayQuestionAnsweredStatusServiceTest.java
+++ b/src/test/java/com/example/egobook_be/domain/question/TodayQuestionAnsweredStatusServiceTest.java
@@ -52,11 +52,6 @@ class TodayQuestionAnsweredStatusServiceTest {
     @BeforeEach
     void setUp() {
         todayQuestion = mock(TodayQuestion.class);
-        given(todayQuestion.getId()).willReturn(100L);
-        given(todayQuestion.getContent()).willReturn("오늘의 질문입니다.");
-        given(todayQuestion.getQuestionDate()).willReturn(LocalDate.now());
-        given(todayQuestionRepository.findByQuestionDate(LocalDate.now()))
-                .willReturn(Optional.of(todayQuestion));
     }
 
     @Test
@@ -76,6 +71,11 @@ class TodayQuestionAnsweredStatusServiceTest {
     @DisplayName("getTodayQuestion_답변안한경우_answered가false_성공")
     void getTodayQuestion_notAnsweredYet_answeredFalse() {
 
+        given(todayQuestion.getId()).willReturn(100L);
+        given(todayQuestion.getContent()).willReturn("오늘의 질문입니다.");
+        given(todayQuestion.getQuestionDate()).willReturn(LocalDate.now());
+        given(todayQuestionRepository.findByQuestionDate(LocalDate.now()))
+                .willReturn(Optional.of(todayQuestion));
         given(questionAnswerRepository.findByUserIdAndQuestionIdWithQuestion(1L, 100L))
                 .willReturn(Optional.empty());
 
@@ -89,12 +89,17 @@ class TodayQuestionAnsweredStatusServiceTest {
     @DisplayName("getTodayQuestion_이미답변한경우_answered가true_성공")
     void getTodayQuestion_alreadyAnswered_answeredTrue() {
 
+        given(todayQuestion.getId()).willReturn(100L);
+        given(todayQuestion.getContent()).willReturn("오늘의 질문입니다.");
+        given(todayQuestion.getQuestionDate()).willReturn(LocalDate.now());
+        given(todayQuestionRepository.findByQuestionDate(LocalDate.now()))
+                .willReturn(Optional.of(todayQuestion));
+
         QuestionAnswer answer = mock(QuestionAnswer.class);
         given(answer.getId()).willReturn(10L);
         given(answer.getContent()).willReturn("내 답변");
         given(answer.getVisibility()).willReturn(AnswerVisibility.PUBLIC);
         given(answer.getCreatedAt()).willReturn(LocalDateTime.now());
-
         given(questionAnswerRepository.findByUserIdAndQuestionIdWithQuestion(1L, 100L))
                 .willReturn(Optional.of(answer));
 
@@ -109,6 +114,11 @@ class TodayQuestionAnsweredStatusServiceTest {
     @Test
     @DisplayName("getTodayQuestion_비로그인유저_answered가false_성공")
     void getTodayQuestion_anonymousUser_answeredFalse() {
+
+        given(todayQuestion.getContent()).willReturn("오늘의 질문입니다.");
+        given(todayQuestion.getQuestionDate()).willReturn(LocalDate.now());
+        given(todayQuestionRepository.findByQuestionDate(LocalDate.now()))
+                .willReturn(Optional.of(todayQuestion));
 
         TodayQuestionResDto result = todayQuestionService.getTodayQuestion(null);
 

--- a/src/test/java/com/example/egobook_be/domain/question/TodayQuestionAnsweredStatusServiceTest.java
+++ b/src/test/java/com/example/egobook_be/domain/question/TodayQuestionAnsweredStatusServiceTest.java
@@ -1,0 +1,118 @@
+package com.example.egobook_be.domain.question;
+
+import com.example.egobook_be.domain.friend.repository.FriendRepository;
+import com.example.egobook_be.domain.home.repository.MissionRepository;
+import com.example.egobook_be.domain.question.dto.TodayQuestionResDto;
+import com.example.egobook_be.domain.question.entity.QuestionAnswer;
+import com.example.egobook_be.domain.question.entity.TodayQuestion;
+import com.example.egobook_be.domain.question.enums.AnswerVisibility;
+import com.example.egobook_be.domain.question.exception.QuestionErrorCode;
+import com.example.egobook_be.domain.question.repository.QuestionAnswerRepository;
+import com.example.egobook_be.domain.question.repository.TodayQuestionRepository;
+import com.example.egobook_be.domain.question.service.TodayQuestionService;
+import com.example.egobook_be.domain.user.repository.AbilityRepository;
+import com.example.egobook_be.domain.user.repository.InkLogRepository;
+import com.example.egobook_be.domain.user.repository.UserRepository;
+import com.example.egobook_be.global.exception.CustomException;
+import com.example.egobook_be.global.util.InkLogUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class TodayQuestionAnsweredStatusServiceTest {
+
+    @InjectMocks
+    private TodayQuestionService todayQuestionService;
+
+    @Mock private TodayQuestionRepository todayQuestionRepository;
+    @Mock private QuestionAnswerRepository questionAnswerRepository;
+    @Mock private MissionRepository missionRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private InkLogRepository inkLogRepository;
+    @Mock private AbilityRepository abilityRepository;
+    @Mock private FriendRepository friendRepository;
+    @Mock private InkLogUtil inkLogUtil;
+
+    private TodayQuestion todayQuestion;
+
+    @BeforeEach
+    void setUp() {
+        todayQuestion = mock(TodayQuestion.class);
+        given(todayQuestion.getId()).willReturn(100L);
+        given(todayQuestion.getContent()).willReturn("오늘의 질문입니다.");
+        given(todayQuestion.getQuestionDate()).willReturn(LocalDate.now());
+        given(todayQuestionRepository.findByQuestionDate(LocalDate.now()))
+                .willReturn(Optional.of(todayQuestion));
+    }
+
+    @Test
+    @DisplayName("getTodayQuestion_오늘의질문없음_실패")
+    void getTodayQuestion_questionNotFound_fail() {
+
+        given(todayQuestionRepository.findByQuestionDate(LocalDate.now()))
+                .willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> todayQuestionService.getTodayQuestion(1L))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(QuestionErrorCode.TODAY_QUESTION_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("getTodayQuestion_답변안한경우_answered가false_성공")
+    void getTodayQuestion_notAnsweredYet_answeredFalse() {
+
+        given(questionAnswerRepository.findByUserIdAndQuestionIdWithQuestion(1L, 100L))
+                .willReturn(Optional.empty());
+
+        TodayQuestionResDto result = todayQuestionService.getTodayQuestion(1L);
+
+        assertThat(result.answered()).isFalse();
+        assertThat(result.myAnswer()).isNull();
+    }
+
+    @Test
+    @DisplayName("getTodayQuestion_이미답변한경우_answered가true_성공")
+    void getTodayQuestion_alreadyAnswered_answeredTrue() {
+
+        QuestionAnswer answer = mock(QuestionAnswer.class);
+        given(answer.getId()).willReturn(10L);
+        given(answer.getContent()).willReturn("내 답변");
+        given(answer.getVisibility()).willReturn(AnswerVisibility.PUBLIC);
+        given(answer.getCreatedAt()).willReturn(LocalDateTime.now());
+
+        given(questionAnswerRepository.findByUserIdAndQuestionIdWithQuestion(1L, 100L))
+                .willReturn(Optional.of(answer));
+
+        TodayQuestionResDto result = todayQuestionService.getTodayQuestion(1L);
+
+        assertThat(result.answered()).isTrue();
+        assertThat(result.myAnswer()).isNotNull();
+        assertThat(result.myAnswer().content()).isEqualTo("내 답변");
+        assertThat(result.myAnswer().visibility()).isEqualTo(AnswerVisibility.PUBLIC);
+    }
+
+    @Test
+    @DisplayName("getTodayQuestion_비로그인유저_answered가false_성공")
+    void getTodayQuestion_anonymousUser_answeredFalse() {
+
+        TodayQuestionResDto result = todayQuestionService.getTodayQuestion(null);
+
+        assertThat(result.answered()).isFalse();
+        assertThat(result.myAnswer()).isNull();
+    }
+}

--- a/src/test/java/com/example/egobook_be/domain/question/TodayQuestionCreateAnswerServiceTest.java
+++ b/src/test/java/com/example/egobook_be/domain/question/TodayQuestionCreateAnswerServiceTest.java
@@ -71,7 +71,7 @@ class TodayQuestionCreateAnswerServiceTest {
     @Test
     @DisplayName("createAnswer_정상답변저장_성공")
     void createAnswer_validRequest_success() {
-        // given
+
         given(userRepository.findById(1L)).willReturn(Optional.of(user));
         given(missionRepository.findByUser(user)).willReturn(Optional.of(mission));
         given(abilityRepository.findByUser(user)).willReturn(Optional.of(ability));
@@ -84,10 +84,8 @@ class TodayQuestionCreateAnswerServiceTest {
         given(mission.updateDailyQuestionMissionStatus(true)).willReturn(false);
         given(ability.addDiligence(1)).willReturn(0);
 
-        // when
         todayQuestionService.createAnswer(1L, reqDto);
 
-        // then
         ArgumentCaptor<QuestionAnswer> captor = ArgumentCaptor.forClass(QuestionAnswer.class);
         verify(questionAnswerRepository).save(captor.capture());
         assertThat(captor.getValue().getContent()).isEqualTo("오늘의 답변입니다.");
@@ -97,10 +95,9 @@ class TodayQuestionCreateAnswerServiceTest {
     @Test
     @DisplayName("createAnswer_사용자없음_실패")
     void createAnswer_userNotFound_fail() {
-        // given
+
         given(userRepository.findById(1L)).willReturn(Optional.empty());
 
-        // when & then
         assertThatThrownBy(() -> todayQuestionService.createAnswer(1L, reqDto))
                 .isInstanceOf(CustomException.class)
                 .extracting(e -> ((CustomException) e).getErrorCode())
@@ -110,11 +107,10 @@ class TodayQuestionCreateAnswerServiceTest {
     @Test
     @DisplayName("createAnswer_미션정보없음_실패")
     void createAnswer_missionNotFound_fail() {
-        // given
+
         given(userRepository.findById(1L)).willReturn(Optional.of(user));
         given(missionRepository.findByUser(user)).willReturn(Optional.empty());
 
-        // when & then
         assertThatThrownBy(() -> todayQuestionService.createAnswer(1L, reqDto))
                 .isInstanceOf(CustomException.class)
                 .extracting(e -> ((CustomException) e).getErrorCode())
@@ -124,12 +120,11 @@ class TodayQuestionCreateAnswerServiceTest {
     @Test
     @DisplayName("createAnswer_능력치정보없음_실패")
     void createAnswer_abilityNotFound_fail() {
-        // given
+
         given(userRepository.findById(1L)).willReturn(Optional.of(user));
         given(missionRepository.findByUser(user)).willReturn(Optional.of(mission));
         given(abilityRepository.findByUser(user)).willReturn(Optional.empty());
 
-        // when & then
         assertThatThrownBy(() -> todayQuestionService.createAnswer(1L, reqDto))
                 .isInstanceOf(CustomException.class)
                 .extracting(e -> ((CustomException) e).getErrorCode())
@@ -139,14 +134,13 @@ class TodayQuestionCreateAnswerServiceTest {
     @Test
     @DisplayName("createAnswer_오늘의질문없음_실패")
     void createAnswer_todayQuestionNotFound_fail() {
-        // given
+
         given(userRepository.findById(1L)).willReturn(Optional.of(user));
         given(missionRepository.findByUser(user)).willReturn(Optional.of(mission));
         given(abilityRepository.findByUser(user)).willReturn(Optional.of(ability));
         given(todayQuestionRepository.findByQuestionDate(LocalDate.now()))
                 .willReturn(Optional.empty());
 
-        // when & then
         assertThatThrownBy(() -> todayQuestionService.createAnswer(1L, reqDto))
                 .isInstanceOf(CustomException.class)
                 .extracting(e -> ((CustomException) e).getErrorCode())
@@ -156,7 +150,7 @@ class TodayQuestionCreateAnswerServiceTest {
     @Test
     @DisplayName("createAnswer_오늘이미답변함_실패")
     void createAnswer_alreadyAnsweredToday_fail() {
-        // given
+
         given(userRepository.findById(1L)).willReturn(Optional.of(user));
         given(missionRepository.findByUser(user)).willReturn(Optional.of(mission));
         given(abilityRepository.findByUser(user)).willReturn(Optional.of(ability));
@@ -164,7 +158,6 @@ class TodayQuestionCreateAnswerServiceTest {
                 .willReturn(Optional.of(todayQuestion));
         given(questionAnswerRepository.existsByUserAndQuestion(user, todayQuestion)).willReturn(true);
 
-        // when & then
         assertThatThrownBy(() -> todayQuestionService.createAnswer(1L, reqDto))
                 .isInstanceOf(CustomException.class)
                 .extracting(e -> ((CustomException) e).getErrorCode())
@@ -174,7 +167,7 @@ class TodayQuestionCreateAnswerServiceTest {
     @Test
     @DisplayName("createAnswer_첫답변시잉크보상지급_성공")
     void createAnswer_firstAnswerToday_inkRewardGiven() {
-        // given
+
         given(userRepository.findById(1L)).willReturn(Optional.of(user));
         given(missionRepository.findByUser(user)).willReturn(Optional.of(mission));
         given(abilityRepository.findByUser(user)).willReturn(Optional.of(ability));
@@ -187,17 +180,15 @@ class TodayQuestionCreateAnswerServiceTest {
         given(mission.updateDailyQuestionMissionStatus(true)).willReturn(false);
         given(ability.addDiligence(1)).willReturn(0);
 
-        // when
         todayQuestionService.createAnswer(1L, reqDto);
 
-        // then
         verify(inkLogUtil, atLeastOnce()).addInkLogToList(any(), eq(user), anyInt(), any());
     }
 
     @Test
     @DisplayName("createAnswer_일일미션최초달성시추가잉크지급_성공")
     void createAnswer_dailyMissionFirstComplete_bonusInkGiven() {
-        // given
+
         given(userRepository.findById(1L)).willReturn(Optional.of(user));
         given(missionRepository.findByUser(user)).willReturn(Optional.of(mission));
         given(abilityRepository.findByUser(user)).willReturn(Optional.of(ability));
@@ -211,10 +202,8 @@ class TodayQuestionCreateAnswerServiceTest {
         given(mission.isWeeklyMissionCompleted()).willReturn(false);
         given(ability.addDiligence(1)).willReturn(0);
 
-        // when
         todayQuestionService.createAnswer(1L, reqDto);
 
-        // then
         verify(inkLogUtil, atLeast(2)).addInkLogToList(any(), eq(user), anyInt(), any());
     }
 }

--- a/src/test/java/com/example/egobook_be/domain/question/TodayQuestionCreateAnswerServiceTest.java
+++ b/src/test/java/com/example/egobook_be/domain/question/TodayQuestionCreateAnswerServiceTest.java
@@ -1,0 +1,220 @@
+package com.example.egobook_be.domain.question;
+
+import com.example.egobook_be.domain.home.entity.Mission;
+import com.example.egobook_be.domain.home.repository.MissionRepository;
+import com.example.egobook_be.domain.question.dto.AnswerCreateReqDto;
+import com.example.egobook_be.domain.question.entity.QuestionAnswer;
+import com.example.egobook_be.domain.question.entity.TodayQuestion;
+import com.example.egobook_be.domain.question.enums.AnswerVisibility;
+import com.example.egobook_be.domain.question.exception.QuestionErrorCode;
+import com.example.egobook_be.domain.question.repository.QuestionAnswerRepository;
+import com.example.egobook_be.domain.question.repository.TodayQuestionRepository;
+import com.example.egobook_be.domain.question.service.TodayQuestionService;
+import com.example.egobook_be.domain.user.entity.Ability;
+import com.example.egobook_be.domain.user.entity.User;
+import com.example.egobook_be.domain.user.enums.UserErrorCode;
+import com.example.egobook_be.domain.user.repository.AbilityRepository;
+import com.example.egobook_be.domain.user.repository.InkLogRepository;
+import com.example.egobook_be.domain.user.repository.UserRepository;
+import com.example.egobook_be.global.exception.CustomException;
+import com.example.egobook_be.global.util.InkLogUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TodayQuestionCreateAnswerServiceTest {
+
+    @InjectMocks
+    private TodayQuestionService todayQuestionService;
+
+    @Mock private TodayQuestionRepository todayQuestionRepository;
+    @Mock private QuestionAnswerRepository questionAnswerRepository;
+    @Mock private MissionRepository missionRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private InkLogRepository inkLogRepository;
+    @Mock private AbilityRepository abilityRepository;
+    @Mock private InkLogUtil inkLogUtil;
+    @Mock private com.example.egobook_be.domain.friend.repository.FriendRepository friendRepository;
+
+    private User user;
+    private TodayQuestion todayQuestion;
+    private Mission mission;
+    private Ability ability;
+    private AnswerCreateReqDto reqDto;
+
+    @BeforeEach
+    void setUp() {
+        user = mock(User.class);
+        todayQuestion = mock(TodayQuestion.class);
+        mission = mock(Mission.class);
+        ability = mock(Ability.class);
+
+        reqDto = new AnswerCreateReqDto("오늘의 답변입니다.", AnswerVisibility.PUBLIC);
+    }
+
+    @Test
+    @DisplayName("createAnswer_정상답변저장_성공")
+    void createAnswer_validRequest_success() {
+        // given
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(missionRepository.findByUser(user)).willReturn(Optional.of(mission));
+        given(abilityRepository.findByUser(user)).willReturn(Optional.of(ability));
+        given(todayQuestionRepository.findByQuestionDate(LocalDate.now()))
+                .willReturn(Optional.of(todayQuestion));
+        given(questionAnswerRepository.existsByUserAndQuestion(user, todayQuestion)).willReturn(false);
+        given(questionAnswerRepository.existsByUserAndCreatedAtBetween(
+                eq(user), any(LocalDateTime.class), any(LocalDateTime.class)
+        )).willReturn(false);
+        given(mission.updateDailyQuestionMissionStatus(true)).willReturn(false);
+        given(ability.addDiligence(1)).willReturn(0);
+
+        // when
+        todayQuestionService.createAnswer(1L, reqDto);
+
+        // then
+        ArgumentCaptor<QuestionAnswer> captor = ArgumentCaptor.forClass(QuestionAnswer.class);
+        verify(questionAnswerRepository).save(captor.capture());
+        assertThat(captor.getValue().getContent()).isEqualTo("오늘의 답변입니다.");
+        assertThat(captor.getValue().getVisibility()).isEqualTo(AnswerVisibility.PUBLIC);
+    }
+
+    @Test
+    @DisplayName("createAnswer_사용자없음_실패")
+    void createAnswer_userNotFound_fail() {
+        // given
+        given(userRepository.findById(1L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> todayQuestionService.createAnswer(1L, reqDto))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(UserErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("createAnswer_미션정보없음_실패")
+    void createAnswer_missionNotFound_fail() {
+        // given
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(missionRepository.findByUser(user)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> todayQuestionService.createAnswer(1L, reqDto))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(UserErrorCode.MISSION_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("createAnswer_능력치정보없음_실패")
+    void createAnswer_abilityNotFound_fail() {
+        // given
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(missionRepository.findByUser(user)).willReturn(Optional.of(mission));
+        given(abilityRepository.findByUser(user)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> todayQuestionService.createAnswer(1L, reqDto))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(UserErrorCode.ABILITY_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("createAnswer_오늘의질문없음_실패")
+    void createAnswer_todayQuestionNotFound_fail() {
+        // given
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(missionRepository.findByUser(user)).willReturn(Optional.of(mission));
+        given(abilityRepository.findByUser(user)).willReturn(Optional.of(ability));
+        given(todayQuestionRepository.findByQuestionDate(LocalDate.now()))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> todayQuestionService.createAnswer(1L, reqDto))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(QuestionErrorCode.TODAY_QUESTION_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("createAnswer_오늘이미답변함_실패")
+    void createAnswer_alreadyAnsweredToday_fail() {
+        // given
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(missionRepository.findByUser(user)).willReturn(Optional.of(mission));
+        given(abilityRepository.findByUser(user)).willReturn(Optional.of(ability));
+        given(todayQuestionRepository.findByQuestionDate(LocalDate.now()))
+                .willReturn(Optional.of(todayQuestion));
+        given(questionAnswerRepository.existsByUserAndQuestion(user, todayQuestion)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> todayQuestionService.createAnswer(1L, reqDto))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(QuestionErrorCode.ALREADY_ANSWERED_TODAY);
+    }
+
+    @Test
+    @DisplayName("createAnswer_첫답변시잉크보상지급_성공")
+    void createAnswer_firstAnswerToday_inkRewardGiven() {
+        // given
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(missionRepository.findByUser(user)).willReturn(Optional.of(mission));
+        given(abilityRepository.findByUser(user)).willReturn(Optional.of(ability));
+        given(todayQuestionRepository.findByQuestionDate(LocalDate.now()))
+                .willReturn(Optional.of(todayQuestion));
+        given(questionAnswerRepository.existsByUserAndQuestion(user, todayQuestion)).willReturn(false);
+        given(questionAnswerRepository.existsByUserAndCreatedAtBetween(
+                eq(user), any(LocalDateTime.class), any(LocalDateTime.class)
+        )).willReturn(false);
+        given(mission.updateDailyQuestionMissionStatus(true)).willReturn(false);
+        given(ability.addDiligence(1)).willReturn(0);
+
+        // when
+        todayQuestionService.createAnswer(1L, reqDto);
+
+        // then
+        verify(inkLogUtil, atLeastOnce()).addInkLogToList(any(), eq(user), anyInt(), any());
+    }
+
+    @Test
+    @DisplayName("createAnswer_일일미션최초달성시추가잉크지급_성공")
+    void createAnswer_dailyMissionFirstComplete_bonusInkGiven() {
+        // given
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(missionRepository.findByUser(user)).willReturn(Optional.of(mission));
+        given(abilityRepository.findByUser(user)).willReturn(Optional.of(ability));
+        given(todayQuestionRepository.findByQuestionDate(LocalDate.now()))
+                .willReturn(Optional.of(todayQuestion));
+        given(questionAnswerRepository.existsByUserAndQuestion(user, todayQuestion)).willReturn(false);
+        given(questionAnswerRepository.existsByUserAndCreatedAtBetween(
+                eq(user), any(LocalDateTime.class), any(LocalDateTime.class)
+        )).willReturn(false);
+        given(mission.updateDailyQuestionMissionStatus(true)).willReturn(true);
+        given(mission.isWeeklyMissionCompleted()).willReturn(false);
+        given(ability.addDiligence(1)).willReturn(0);
+
+        // when
+        todayQuestionService.createAnswer(1L, reqDto);
+
+        // then
+        verify(inkLogUtil, atLeast(2)).addInkLogToList(any(), eq(user), anyInt(), any());
+    }
+}

--- a/src/test/java/com/example/egobook_be/domain/question/TodayQuestionDeleteAnswerServiceTest.java
+++ b/src/test/java/com/example/egobook_be/domain/question/TodayQuestionDeleteAnswerServiceTest.java
@@ -1,0 +1,78 @@
+package com.example.egobook_be.domain.question;
+
+import com.example.egobook_be.domain.friend.repository.FriendRepository;
+import com.example.egobook_be.domain.home.repository.MissionRepository;
+import com.example.egobook_be.domain.question.entity.QuestionAnswer;
+import com.example.egobook_be.domain.question.exception.QuestionErrorCode;
+import com.example.egobook_be.domain.question.repository.QuestionAnswerRepository;
+import com.example.egobook_be.domain.question.repository.TodayQuestionRepository;
+import com.example.egobook_be.domain.question.service.TodayQuestionService;
+import com.example.egobook_be.domain.user.entity.User;
+import com.example.egobook_be.domain.user.repository.AbilityRepository;
+import com.example.egobook_be.domain.user.repository.InkLogRepository;
+import com.example.egobook_be.domain.user.repository.UserRepository;
+import com.example.egobook_be.global.exception.CustomException;
+import com.example.egobook_be.global.util.InkLogUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TodayQuestionDeleteAnswerServiceTest {
+
+    @InjectMocks
+    private TodayQuestionService todayQuestionService;
+
+    @Mock private TodayQuestionRepository todayQuestionRepository;
+    @Mock private QuestionAnswerRepository questionAnswerRepository;
+    @Mock private MissionRepository missionRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private InkLogRepository inkLogRepository;
+    @Mock private AbilityRepository abilityRepository;
+    @Mock private FriendRepository friendRepository;
+    @Mock private InkLogUtil inkLogUtil;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = mock(User.class);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+    }
+
+    @Test
+    @DisplayName("deleteAnswer_정상삭제_성공")
+    void deleteAnswer_validRequest_success() {
+
+        QuestionAnswer answer = mock(QuestionAnswer.class);
+        given(questionAnswerRepository.findByIdAndUser(10L, user))
+                .willReturn(Optional.of(answer));
+
+        todayQuestionService.deleteAnswer(1L, 10L);
+
+        verify(questionAnswerRepository).delete(answer);
+    }
+
+    @Test
+    @DisplayName("deleteAnswer_답변없음_실패")
+    void deleteAnswer_answerNotFound_fail() {
+
+        given(questionAnswerRepository.findByIdAndUser(10L, user))
+                .willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> todayQuestionService.deleteAnswer(1L, 10L))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(QuestionErrorCode.ANSWER_NOT_FOUND);
+    }
+}

--- a/src/test/java/com/example/egobook_be/domain/question/TodayQuestionUpdateAnswerServiceTest.java
+++ b/src/test/java/com/example/egobook_be/domain/question/TodayQuestionUpdateAnswerServiceTest.java
@@ -1,0 +1,108 @@
+package com.example.egobook_be.domain.question;
+
+import com.example.egobook_be.domain.friend.repository.FriendRepository;
+import com.example.egobook_be.domain.home.repository.MissionRepository;
+import com.example.egobook_be.domain.question.dto.AnswerUpdateReqDto;
+import com.example.egobook_be.domain.question.entity.QuestionAnswer;
+import com.example.egobook_be.domain.question.entity.TodayQuestion;
+import com.example.egobook_be.domain.question.enums.AnswerVisibility;
+import com.example.egobook_be.domain.question.exception.QuestionErrorCode;
+import com.example.egobook_be.domain.question.repository.QuestionAnswerRepository;
+import com.example.egobook_be.domain.question.repository.TodayQuestionRepository;
+import com.example.egobook_be.domain.question.service.TodayQuestionService;
+import com.example.egobook_be.domain.user.entity.User;
+import com.example.egobook_be.domain.user.repository.AbilityRepository;
+import com.example.egobook_be.domain.user.repository.InkLogRepository;
+import com.example.egobook_be.domain.user.repository.UserRepository;
+import com.example.egobook_be.global.exception.CustomException;
+import com.example.egobook_be.global.util.InkLogUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TodayQuestionUpdateAnswerServiceTest {
+
+    @InjectMocks
+    private TodayQuestionService todayQuestionService;
+
+    @Mock private TodayQuestionRepository todayQuestionRepository;
+    @Mock private QuestionAnswerRepository questionAnswerRepository;
+    @Mock private MissionRepository missionRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private InkLogRepository inkLogRepository;
+    @Mock private AbilityRepository abilityRepository;
+    @Mock private FriendRepository friendRepository;
+    @Mock private InkLogUtil inkLogUtil;
+
+    private User user;
+    private TodayQuestion todayQuestion;
+    private AnswerUpdateReqDto reqDto;
+
+    @BeforeEach
+    void setUp() {
+        user = mock(User.class);
+        todayQuestion = mock(TodayQuestion.class);
+
+        reqDto = AnswerUpdateReqDto.builder()
+                .content("수정된 답변입니다.")
+                .visibility(AnswerVisibility.FRIEND)
+                .build();
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+    }
+
+    @Test
+    @DisplayName("updateAnswer_정상수정_성공")
+    void updateAnswer_validRequest_success() {
+
+        QuestionAnswer answer = mock(QuestionAnswer.class);
+        given(todayQuestionRepository.findByQuestionDate(LocalDate.now()))
+                .willReturn(Optional.of(todayQuestion));
+        given(questionAnswerRepository.findByUserAndQuestion(user, todayQuestion))
+                .willReturn(Optional.of(answer));
+
+        todayQuestionService.updateAnswer(1L, reqDto);
+
+        verify(answer).update("수정된 답변입니다.", AnswerVisibility.FRIEND);
+    }
+
+    @Test
+    @DisplayName("updateAnswer_오늘의질문없음_실패")
+    void updateAnswer_todayQuestionNotFound_fail() {
+
+        given(todayQuestionRepository.findByQuestionDate(LocalDate.now()))
+                .willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> todayQuestionService.updateAnswer(1L, reqDto))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(QuestionErrorCode.TODAY_QUESTION_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("updateAnswer_답변없음_실패")
+    void updateAnswer_answerNotFound_fail() {
+
+        given(todayQuestionRepository.findByQuestionDate(LocalDate.now()))
+                .willReturn(Optional.of(todayQuestion));
+        given(questionAnswerRepository.findByUserAndQuestion(user, todayQuestion))
+                .willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> todayQuestionService.updateAnswer(1L, reqDto))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(QuestionErrorCode.ANSWER_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close #149 

## 📝 작업 내용
오늘의 질문 로직에 대한 단위 테스트 코드를 작성했습니다.

### 테스트 대상
- `TodayQuestionCreateAnswerServiceTest` - 답변 작성
- `TodayQuestionAnsweredStatusServiceTest` - 답변 완료 여부 판별
- `TodayQuestionUpdateAnswerServiceTest` - 답변 수정
- `TodayQuestionDeleteAnswerServiceTest` - 답변 삭제

### 테스트 케이스

**1. 답변 작성 (8개)**
- 정상 답변 저장 성공
- 사용자 없음 실패
- 미션 정보 없음 실패
- 능력치 정보 없음 실패
- 오늘의 질문 없음 실패
- 오늘 이미 답변함 실패
- 첫 답변 시 잉크 보상 지급 성공
- 일일 미션 최초 달성 시 추가 잉크 지급 성공

**2. 답변 완료 여부 판별 (4개)**
- 오늘의 질문 없음 실패
- 답변하지 않은 경우 answered = false
- 이미 답변한 경우 answered = true
- 비로그인 유저 answered = false

**3. 답변 수정 (3개)**
- 정상 수정 성공
- 오늘의 질문 없음 실패
- 답변 없음 실패

**4. 답변 삭제 (2개)**
- 정상 삭제 성공
- 답변 없음 실패


## ✅ 테스트 결과
- 17개 모두 성공 했습니다.