### PR TITLE
✅ Test: 에고룸 API 테스트 코드

### DIFF
--- a/src/test/java/com/example/egobook_be/domain/ego_room/service/EgoRoomServiceTest.java
+++ b/src/test/java/com/example/egobook_be/domain/ego_room/service/EgoRoomServiceTest.java
@@ -1,0 +1,183 @@
+package com.example.egobook_be.domain.ego_room.service;
+
+import com.example.egobook_be.domain.diary.entity.Diary;
+import com.example.egobook_be.domain.diary.repository.DiaryRepository;
+import com.example.egobook_be.domain.ego_room.dto.WeeklyCounselResDto;
+import com.example.egobook_be.domain.ego_room.entity.DailyPraise;
+import com.example.egobook_be.domain.ego_room.entity.WeeklyCounsel;
+import com.example.egobook_be.domain.ego_room.enums.CounselTone;
+import com.example.egobook_be.domain.ego_room.repository.DailyPraiseRepository;
+import com.example.egobook_be.domain.ego_room.repository.WeeklyCounselRepository;
+import com.example.egobook_be.domain.notification.enums.NotificationType;
+import com.example.egobook_be.domain.notification.service.NotificationService;
+import com.example.egobook_be.domain.user.entity.User;
+import com.example.egobook_be.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EgoRoomServiceTest {
+
+    @Mock
+    private DailyPraiseRepository dailyPraiseRepository;
+    @Mock private WeeklyCounselRepository weeklyCounselRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private DiaryRepository diaryRepository;
+    @Mock private DailyPraiseAiService dailyPraiseAiService;
+    @Mock private WeeklyAnalysisAiService weeklyAnalysisAiService;
+    @Mock private NotificationService notificationService;
+
+    @InjectMocks
+    private EgoRoomService egoRoomService;
+
+    @Test
+    @DisplayName("createDailyPraise_유저없음_실패")
+    void createDailyPraise_userNotFound_fail() {
+        // given
+        Long userId = 999L;
+        LocalDate date = LocalDate.now();
+        when(dailyPraiseRepository.findByUserIdAndPraiseDate(userId, date)).thenReturn(Optional.empty());
+        when(userRepository.findById(userId)).thenReturn(Optional.empty()); // 유저 없음
+
+        // when & then
+        assertThrows(RuntimeException.class, () -> {
+            egoRoomService.createDailyPraise(userId, date);
+        });
+    }
+
+    @Test
+    @DisplayName("일기 데이터가 있을 때 일간 칭찬서를 생성 후 알림")
+    void createDailyPraise_diaryExists_success() {
+        // given
+        Long userId = 1L;
+        LocalDate date = LocalDate.now();
+        User user = User.builder().id(userId).nickname("테스트유저").build();
+        Diary diary = Diary.builder().content("오늘의 일기").build();
+
+        when(dailyPraiseRepository.findByUserIdAndPraiseDate(userId, date)).thenReturn(Optional.empty());
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(diaryRepository.findByUserIdAndDate(userId, date)).thenReturn(List.of(diary));
+        when(dailyPraiseAiService.getPraise(anyString())).thenReturn("AI 칭찬 내용");
+
+        // when
+        egoRoomService.createDailyPraise(userId, date);
+
+        // then
+        verify(dailyPraiseRepository, times(1)).save(any(DailyPraise.class));
+        verify(notificationService, times(1)).createNotification(eq(userId), eq(NotificationType.PRAISE), any(), any());
+    }
+
+    @Test
+    @DisplayName("이미 해당 날짜에 칭찬서가 존재하면 생성 스킵")
+    void createDailyPraise_alreadyExists_skip() {
+        // given
+        Long userId = 1L;
+        LocalDate date = LocalDate.now();
+        when(dailyPraiseRepository.findByUserIdAndPraiseDate(userId, date))
+                .thenReturn(Optional.of(mock(DailyPraise.class)));
+
+        // when
+        egoRoomService.createDailyPraise(userId, date);
+
+        // then
+        verify(dailyPraiseAiService, never()).getPraise(anyString());
+        verify(dailyPraiseRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("일기가 없을 때는 칭찬서 생성 스킵")
+    void createDailyPraise_noDiary_skip() {
+        // given
+        Long userId = 1L;
+        LocalDate date = LocalDate.now();
+        when(dailyPraiseRepository.findByUserIdAndPraiseDate(userId, date)).thenReturn(Optional.empty());
+        when(userRepository.findById(userId)).thenReturn(Optional.of(User.builder().id(userId).build()));
+
+        when(diaryRepository.findByUserIdAndDate(userId, date)).thenReturn(Collections.emptyList());
+
+        // when
+        egoRoomService.createDailyPraise(userId, date);
+
+        // then
+        verify(dailyPraiseRepository, never()).save(any(DailyPraise.class));
+    }
+
+    @Test
+    @DisplayName("createWeeklyAnalysis_유저없음_실패")
+    void createWeeklyAnalysis_userNotFound_fail() {
+        // given
+        Long userId = 999L;
+        LocalDate startDate = LocalDate.of(2026, 3, 9);
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThrows(RuntimeException.class, () -> {
+            egoRoomService.createWeeklyAnalysis(userId, startDate);
+        });
+    }
+
+    @Test
+    @DisplayName("주간 분석 리포트 생성 및 저장")
+    void createWeeklyAnalysis_weeklyDataExists_success() {
+
+        Long userId = 1L;
+        LocalDate startDate = LocalDate.of(2026, 3, 9);
+        User user = User.builder().id(userId).nickname("테스트유저").counselingTone(CounselTone.SOFT).build();
+        Diary diary = Diary.builder()
+                .content("주간 일기")
+                .build();
+
+        // 가짜 생성일 주입
+        ReflectionTestUtils.setField(diary, "createdAt", startDate.atStartOfDay());
+        WeeklyCounselResDto aiRes = new WeeklyCounselResDto("테스트유저","요약", "칭찬", "개선", "조언", "응원");
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(weeklyCounselRepository.existsByUserIdAndStartDate(userId, startDate)).thenReturn(false);
+        when(diaryRepository.findByUserIdAndDateBetweenOrderByDateAsc(any(), any(), any())).thenReturn(List.of(diary));
+        when(weeklyAnalysisAiService.getAnalysis(any(), any(), any(), any())).thenReturn(aiRes);
+
+        // when
+        egoRoomService.createWeeklyAnalysis(userId, startDate);
+
+        // then
+        verify(weeklyCounselRepository, times(1)).save(any(WeeklyCounsel.class));
+        verify(notificationService, times(1)).createNotification(eq(userId), eq(NotificationType.REPORT), any());
+    }
+
+    @Test
+    @DisplayName("일기가 없으면 주간 분석서 생성 스킵")
+    void createWeeklyAnalysis_noDiary_skip() {
+        // given
+        Long userId = 1L;
+        LocalDate startDate = LocalDate.of(2026, 3, 9);
+        User user = User.builder().id(userId).build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(weeklyCounselRepository.existsByUserIdAndStartDate(userId, startDate)).thenReturn(false);
+
+        when(diaryRepository.findByUserIdAndDateBetweenOrderByDateAsc(any(), any(), any()))
+                .thenReturn(Collections.emptyList());
+
+        // when
+        egoRoomService.createWeeklyAnalysis(userId, startDate);
+
+        // then
+        verify(weeklyAnalysisAiService, never()).getAnalysis(any(), any(), any(), any());
+        verify(weeklyCounselRepository, never()).save(any());
+    }
+
+}

--- a/src/test/java/com/example/egobook_be/domain/ego_room/service/EgoStatsServiceTest.java
+++ b/src/test/java/com/example/egobook_be/domain/ego_room/service/EgoStatsServiceTest.java
@@ -81,4 +81,22 @@ class EgoStatsServiceTest {
         });
     }
 
+    @Test
+    @DisplayName("일기 데이터가 없는 경우 빈 통계 데이터를 생성하여 저장")
+    void calculateAndSaveStats_noDiaries_saveEmptyStats() throws Exception {
+        // given
+        Long userId = 1L;
+        User user = User.builder().id(userId).build();
+
+        when(diaryRepository.findAllByUserIdAndWrittenAtAfter(anyLong(), any())).thenReturn(Collections.emptyList());
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userStatsRepository.findByUserId(userId)).thenReturn(Optional.empty());
+
+        // when
+        egoStatsService.calculateAndSaveStats(userId, 2026, 3);
+
+        // then
+        verify(userStatsRepository, times(1)).save(any(UserStats.class));
+    }
+
 }

--- a/src/test/java/com/example/egobook_be/domain/ego_room/service/EgoStatsServiceTest.java
+++ b/src/test/java/com/example/egobook_be/domain/ego_room/service/EgoStatsServiceTest.java
@@ -1,0 +1,84 @@
+package com.example.egobook_be.domain.ego_room.service;
+
+import com.example.egobook_be.domain.diary.entity.Diary;
+import com.example.egobook_be.domain.diary.repository.DiaryRepository;
+import com.example.egobook_be.domain.ego_room.dto.WordCloudDto;
+import com.example.egobook_be.domain.ego_room.entity.UserStats;
+import com.example.egobook_be.domain.ego_room.repository.UserStatsRepository;
+import com.example.egobook_be.domain.user.entity.User;
+import com.example.egobook_be.domain.user.repository.UserRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EgoStatsServiceTest {
+
+    @Mock
+    private UserStatsRepository userStatsRepository;
+    @Mock private DiaryRepository diaryRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private WordCloudService wordCloudAiService;
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+    @InjectMocks
+    private EgoStatsService egoStatsService;
+
+
+
+    @Test
+    @DisplayName("월통계를 계산하고 JSON 형식으로 저장")
+    void calculateAndSaveStats_validPeriod_success() throws Exception {
+        // given
+        Long userId = 1L;
+        int year = 2026;
+        int month = 3;
+        User user = User.builder().id(userId).build();
+        Diary diary = Diary.builder().writtenAt(LocalDateTime.now()).emotionLevel(3).build();
+
+        when(diaryRepository.findAllByUserIdAndWrittenAtAfter(any(), any())).thenReturn(List.of(diary));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(wordCloudAiService.calculateWordCloud(any())).thenReturn(List.of(new WordCloudDto("행복", 10)));
+        when(userStatsRepository.findByUserId(userId)).thenReturn(Optional.empty());
+
+        // when
+        egoStatsService.calculateAndSaveStats(userId, year, month);
+
+        // then
+        verify(userStatsRepository, times(1)).save(any(UserStats.class));
+    }
+
+    @Test
+    @DisplayName("calculateAndSaveStats_유저없음_실패")
+    void calculateAndSaveStats_userNotFound_fail() {
+        // given
+        Long userId = 999L; // 없는 유저 ID
+        int year = 2026;
+        int month = 3;
+
+
+        when(diaryRepository.findAllByUserIdAndWrittenAtAfter(any(), any())).thenReturn(Collections.emptyList());
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThrows(RuntimeException.class, () -> {
+            egoStatsService.calculateAndSaveStats(userId, year, month);
+        });
+    }
+
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close #151

## 📝 작업 내용
에고룸의 일간칭찬서 생성 / 주간상담서 생성 / 통계 업데이트 로직에 대한 단위 테스트 코드를 작성했습니다.


### 테스트 케이스

**일간 칭찬서 생성 :   `createDailyPraise()`**

- 성공
1. 일기 데이터가 존재할 때 AI 칭찬 생성, 저장 및 알림 발송 완료

- 예외 (실패 및 스킵)
유저 정보가 존재하지 않을 때 (RuntimeException 발생)
이미 해당 날짜에 칭찬서가 존재하는 경우 (중복 생성 방지)
해당 날짜에 작성된 일기가 없는 경우


**주간 상담서 생성 :   `createWeeklyAnalysis()`**

- 성공
주간 데이터(일기)가 존재할 때 AI 분석 리포트 생성, 저장 및 알림 발송 완료

- 예외 (실패 및 스킵)
유저 정보가 존재하지 않을 때 (RuntimeException 발생)
이미 해당 시작일에 리포트가 존재하는 경우
주간 범위 내에 작성된 일기가 없는 경우 (AI 호출 및 저장 스킵)


**월간 통계 생성 및 업데이트 : `calculateAndSaveStats()`**

- 성공
월간 일기 데이터를 바탕으로 감정 통계 계산 및 WordCloud 생성
ObjectMapper를 통한 JSON 변환 및 UserStats 저장 완료
일기 데이터가 없을 경우 빈 통계 JSON 저장

- 예외 (실패 및 스킵)
유저 정보가 존재하지 않을 때 (RuntimeException 발생)


## ✅ 테스트 결과
- 빌드 성공 확인했습니다.