### PR TITLE
✨ Feat: 탈퇴 이유 저장 API & Swagger 사용자 기능 API / 관리자 API 분리

### DIFF
--- a/src/main/java/com/example/egobook_be/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/egobook_be/domain/user/controller/UserController.java
@@ -6,6 +6,7 @@ import com.example.egobook_be.domain.auth.sevice.AuthService;
 import com.example.egobook_be.domain.user.dto.FcmTokenReqDto;
 import com.example.egobook_be.domain.user.dto.UserNicknameResDto;
 import com.example.egobook_be.domain.user.dto.UserNicknameUpdateReqDto;
+import com.example.egobook_be.domain.user.dto.WithdrawReasonReqDto;
 import com.example.egobook_be.domain.user.service.UserService;
 import com.example.egobook_be.global.response.GlobalResponse;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -45,6 +46,17 @@ public class UserController implements UserControllerDocs{
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(GlobalResponse.success("사용자 닉네임 업데이트 성공", resDto));
+    }
+
+    @Override
+    public ResponseEntity<?> saveWithdrawReason(
+            @Parameter(hidden = true) @AuthenticationPrincipal(expression = "userAuthDto.userId") Long userId,
+            @RequestBody @Valid WithdrawReasonReqDto reqDto
+    ){
+        userService.saveWithdrawReason(userId, reqDto);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(GlobalResponse.success("탈퇴 사유 제출 성공", null));
     }
 
     @Override

--- a/src/main/java/com/example/egobook_be/domain/user/controller/UserControllerDocs.java
+++ b/src/main/java/com/example/egobook_be/domain/user/controller/UserControllerDocs.java
@@ -5,6 +5,7 @@ import com.example.egobook_be.domain.auth.dto.res.JwtTokenResDto;
 import com.example.egobook_be.domain.user.dto.FcmTokenReqDto;
 import com.example.egobook_be.domain.user.dto.UserNicknameResDto;
 import com.example.egobook_be.domain.user.dto.UserNicknameUpdateReqDto;
+import com.example.egobook_be.domain.user.dto.WithdrawReasonReqDto;
 import com.example.egobook_be.global.response.GlobalResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -81,6 +82,37 @@ public interface UserControllerDocs {
             @RequestBody @Valid UserNicknameUpdateReqDto reqDto
     );
 
+    @Operation(summary = "회원 탈퇴 이유 저장", description = """
+            회원 탈퇴 이유를 전달 받아 저장합니다.
+            
+            - **기능**:
+                사용자에게 데이터를 전달받아 회원 탈퇴 이유를 저장합니다.
+            
+            - **전달받을 변수**:
+                1. ```reasonType```: 사용자의 탈퇴 이유 ENUM
+                     - **NOT_USED_OFTEN**: 자주 사용하지 않아요
+                     - **LACK_OF_CONTENT**: 콘텐츠나 기능이 부족해요
+                     - **INCONVENIENT_UI**: 앱 사용이 불편해요
+                     - **DIFFICULT_TO_COLLECT_INK**: 잉크를 모으기 어려워요
+                     - **OTHER**: 기타
+                2. ```text```: **OTHER**(기타) 선택 시 회원 탈퇴 이유를 입력합니다.
+            
+            - **주의**:
+                1. 이 API를 호출하기 이전에 회원 탈퇴 API를 먼저 호출하면, 이 API를 호출해도 사용자의 회원 탈퇴 이유를 저장할 수 없습니다.
+            """)
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "회원 탈퇴 이유 저장 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (유효하지 않은 ENUM 값 전달 또는 text 길이 초과)", content = @Content),
+            @ApiResponse(responseCode = "401", description = "인증 실패 (유효하지 않은 토큰)", content = @Content),
+            @ApiResponse(responseCode = "409", description = "이미 탈퇴 이유를 제출한 사용자 (중복 저장 불가)", content = @Content)
+    })
+    @PostMapping("/withdraw/reason")
+    ResponseEntity<?> saveWithdrawReason(
+            @Parameter(hidden = true) @AuthenticationPrincipal(expression = "userAuthDto.userId") Long userId,
+            @RequestBody @Valid WithdrawReasonReqDto reqDto
+    );
+
+
     @Operation(summary = "사용자 회원 탈퇴", description = """
             현재 로그인된 사용자의 **계정을 삭제(탈퇴)** 처리합니다.
             
@@ -93,8 +125,8 @@ public interface UserControllerDocs {
               6. 탈퇴된 계정은 7일 뒤 완전히 정보가 삭제됩니다. 
             
             - **주의**: 
-            탈퇴 처리된 계정은 복구가 불가능하며, 동일한 소셜 계정으로 재가입 시 신규 사용자로 처리됩니다.
-            계정 복구를 원할 시, 고객센터로 연락해 복구해야합니다.
+                1. 반드시 "회원 탈퇴 이유 저장" API를 호출한 뒤에 호출해야합니다.
+                2. 탈퇴 처리된 계정은 복구가 불가능하며, 동일한 소셜 계정으로 재가입 시 신규 사용자로 처리됩니다. 계정 복구를 원할 시, 고객센터로 연락해 복구해야합니다.
             """)
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "회원 탈퇴 성공 (Resource Deleted)",

--- a/src/main/java/com/example/egobook_be/domain/user/dto/WithdrawReasonReqDto.java
+++ b/src/main/java/com/example/egobook_be/domain/user/dto/WithdrawReasonReqDto.java
@@ -1,0 +1,22 @@
+package com.example.egobook_be.domain.user.dto;
+
+import com.example.egobook_be.domain.user.enums.WithdrawReasonType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "회원 탈퇴 이유 저장 요청 DTO")
+public record WithdrawReasonReqDto(
+        @Schema(description = "탈퇴 이유 유형",
+                example = "NOT_USED_OFTEN",
+                allowableValues = {"NOT_USED_OFTEN", "LACK_OF_CONTENT", "INCONVENIENT_UI", "DIFFICULT_TO_COLLECT_INK", "OTHER"})
+        @NotNull(message = "탈퇴 이유 유형은 필수 입력 값입니다.")
+        WithdrawReasonType reasonType,
+
+        @Schema(description = "상세 탈퇴 이유 (기타 선택 시 필수 입력)",
+                example = "앱의 디자인이 전반적으로 제 취향이 아니어서 떠납니다.",
+                maxLength = 500)
+        @Size(max = 500, message = "상세 이유는 최대 500자까지 입력 가능합니다.")
+        String text
+) {
+}

--- a/src/main/java/com/example/egobook_be/domain/user/entity/WithdrawReason.java
+++ b/src/main/java/com/example/egobook_be/domain/user/entity/WithdrawReason.java
@@ -1,0 +1,34 @@
+package com.example.egobook_be.domain.user.entity;
+
+import com.example.egobook_be.domain.user.enums.WithdrawReasonType;
+import com.example.egobook_be.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "withdraw_reason")
+public class WithdrawReason extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    // User 삭제 시 WithdrawReason 엔티티의 인스턴스도 삭제되는 것을 방지하기 위해 연관관계가 아닌 userId값만 참조
+    // User 한명당 하나의 탈퇴 이유를 작성해야하므로 unique 속성 설정
+    @Column(name = "user_id", nullable = false, unique = true)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "reason_type", nullable = false)
+    private WithdrawReasonType withdrawReasonType;
+
+    @Column(length = 500)
+    private String text;
+
+    public static WithdrawReason create(Long userId, WithdrawReasonType withdrawReasonType, String text) {
+        return WithdrawReason.builder().userId(userId).withdrawReasonType(withdrawReasonType).build();
+    }
+}

--- a/src/main/java/com/example/egobook_be/domain/user/enums/UserErrorCode.java
+++ b/src/main/java/com/example/egobook_be/domain/user/enums/UserErrorCode.java
@@ -8,17 +8,17 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum UserErrorCode implements BaseErrorCode {
-    /*
-     * 400
-     */
-    ALREADY_WITHDRAW_PENDING(HttpStatus.CONFLICT, "해당 사용자는 이미 탈퇴 대기 상태입니다."),
+    // 400 BAD REQUEST
+    WITHDRAW_REASON_OTHER_TEXT_FIELD_EMPTY(HttpStatus.BAD_REQUEST, "회원탈퇴 이유가 '기타'일 때 상세 이유는 반드시 적어야합니다."),
 
-    /*
-     * 404 NOT FOUND
-     */
+    // 404 NOT FOUND
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾지 못했습니다."),
     ABILITY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자의 능력치 정보를 찾지 못했습니다."),
-    MISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자의 미션 상태 정보를 찾지 못했습니다.");
+    MISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자의 미션 상태 정보를 찾지 못했습니다."),
+
+    // 409 CONFLICT
+    ALREADY_WITHDRAW_PENDING(HttpStatus.CONFLICT, "해당 사용자는 이미 탈퇴 대기 상태입니다."),
+    WITHDRAW_REASON_ALREADY_WRITTEN(HttpStatus.CONFLICT, "해당 사용자는 이미 탈퇴 이유를 제출했습니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/com/example/egobook_be/domain/user/enums/WithdrawReasonType.java
+++ b/src/main/java/com/example/egobook_be/domain/user/enums/WithdrawReasonType.java
@@ -1,0 +1,17 @@
+package com.example.egobook_be.domain.user.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum WithdrawReasonType {
+    NOT_USED_OFTEN("자주 사용하지 않아요"),
+    LACK_OF_CONTENT("콘텐츠나 기능이 부족해요"),
+    INCONVENIENT_UI("앱 사용이 불편해요"),
+    DIFFICULT_TO_COLLECT_INK("잉크를 모으기 어려워요"),
+    OTHER("기타 (텍스트 필드)");
+
+    // 각 Enum 상수가 가질 설명값 필드
+    private final String description;
+}

--- a/src/main/java/com/example/egobook_be/domain/user/repository/WithdrawReasonRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/user/repository/WithdrawReasonRepository.java
@@ -1,0 +1,8 @@
+package com.example.egobook_be.domain.user.repository;
+
+import com.example.egobook_be.domain.user.entity.WithdrawReason;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WithdrawReasonRepository extends JpaRepository<WithdrawReason, Long> {
+    boolean existsByUserId(Long userId);
+}

--- a/src/main/java/com/example/egobook_be/domain/user/service/UserService.java
+++ b/src/main/java/com/example/egobook_be/domain/user/service/UserService.java
@@ -20,12 +20,16 @@ import com.example.egobook_be.domain.terms.repository.UserTermRepository;
 import com.example.egobook_be.domain.user.dto.FcmTokenReqDto;
 import com.example.egobook_be.domain.user.dto.UserNicknameResDto;
 import com.example.egobook_be.domain.user.dto.UserNicknameUpdateReqDto;
+import com.example.egobook_be.domain.user.dto.WithdrawReasonReqDto;
 import com.example.egobook_be.domain.user.entity.Ability;
 import com.example.egobook_be.domain.user.entity.User;
+import com.example.egobook_be.domain.user.entity.WithdrawReason;
 import com.example.egobook_be.domain.user.enums.UserErrorCode;
 import com.example.egobook_be.domain.user.enums.UserStatus;
+import com.example.egobook_be.domain.user.enums.WithdrawReasonType;
 import com.example.egobook_be.domain.user.repository.AbilityRepository;
 import com.example.egobook_be.domain.user.repository.UserRepository;
+import com.example.egobook_be.domain.user.repository.WithdrawReasonRepository;
 import com.example.egobook_be.global.exception.CustomException;
 import com.example.egobook_be.global.util.AccountCodeGenerator;
 import com.example.egobook_be.global.util.RedisUtil;
@@ -54,6 +58,7 @@ public class UserService {
     private final UserItemRepository userItemRepository;
     private final AbilityRepository abilityRepository;
     private final RefreshTokenBackupRepository refreshTokenBackupRepository;
+    private final WithdrawReasonRepository withdrawReasonRepository;
     private final RedisUtil redisUtil;
     private final UserNicknameGenerator userNicknameGenerator;
 
@@ -203,6 +208,28 @@ public class UserService {
         user.updateNickname(reqDto.nickname());
 
         return UserNicknameResDto.builder().newNickname(user.getNickname()).build();
+    }
+
+    // 사용자가 전달해준 회원 탈퇴 이유를 저장하는 함수
+    @Transactional
+    public void saveWithdrawReason(Long userId, WithdrawReasonReqDto reqDto) {
+        // 1. User가 존재하는지 확인
+        if(!userRepository.existsById(userId)) {
+            throw new CustomException(UserErrorCode.USER_NOT_FOUND);
+        }
+
+        // 2. 사용자가 존재한다면, 해당 사용자의 탈퇴 정보가 WithdrawReason 테이블에 존재하는지 확인한다.
+        if(withdrawReasonRepository.existsByUserId(userId)){
+            throw new CustomException(UserErrorCode.WITHDRAW_REASON_ALREADY_WRITTEN);
+        }
+
+        // 3. 회원 탈퇴 이유가 "기타(Others)"인 경우, text 필드가 비어있다면 예외 발생 (기타인 경우에느 반드시 text 필드가 채워져있어야 함)
+        if(reqDto.reasonType().equals(WithdrawReasonType.OTHER) && reqDto.text() != null && reqDto.text().isBlank()){
+            throw new CustomException(UserErrorCode.WITHDRAW_REASON_OTHER_TEXT_FIELD_EMPTY);
+        }
+
+        // 4. 회원 탈퇴 이유 저장
+        withdrawReasonRepository.save(WithdrawReason.create(userId, reqDto.reasonType(), reqDto.text()));
     }
 
     /**

--- a/src/main/java/com/example/egobook_be/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/egobook_be/global/config/SwaggerConfig.java
@@ -49,13 +49,25 @@ public class SwaggerConfig {
     }
 
     // Swagger 문서를 그룹화하여 구분해서 보여주는 설정
+    // 1. 기본 사용자 API 그룹
     @Bean
     public GroupedOpenApi customGroupedOpenApi() {
         return GroupedOpenApi.builder()
                 .group("전체 API")           // 그룹 이름 -> 단순 이름만 지정
                 // *:api로 시작하는 바로 아래 단계만, **: api로 시작하는 모든 것들
                 .pathsToMatch("/**")    // 전체 경로 포함
+                .pathsToExclude("/admin/**")
                 .build();
     }
+
+    // 2. 관리자(Admin) 전용 API 그룹
+    @Bean
+    public GroupedOpenApi adminGroupedOpenApi() {
+        return GroupedOpenApi.builder()
+                .group("관리자 API")
+                .pathsToMatch("/admin/**")
+                .build();
+    }
+
 
 }

--- a/src/test/java/com/example/egobook_be/domain/user/service/UserServiceUnitTest.java
+++ b/src/test/java/com/example/egobook_be/domain/user/service/UserServiceUnitTest.java
@@ -5,10 +5,14 @@ import com.example.egobook_be.domain.auth.entity.RefreshTokenBackup;
 import com.example.egobook_be.domain.auth.enums.AuthErrorCode;
 import com.example.egobook_be.domain.auth.repository.AuthAccountRepository;
 import com.example.egobook_be.domain.auth.repository.RefreshTokenBackupRepository;
+import com.example.egobook_be.domain.user.dto.WithdrawReasonReqDto;
 import com.example.egobook_be.domain.user.entity.User;
+import com.example.egobook_be.domain.user.entity.WithdrawReason;
 import com.example.egobook_be.domain.user.enums.UserErrorCode;
 import com.example.egobook_be.domain.user.enums.UserStatus;
+import com.example.egobook_be.domain.user.enums.WithdrawReasonType;
 import com.example.egobook_be.domain.user.repository.UserRepository;
+import com.example.egobook_be.domain.user.repository.WithdrawReasonRepository;
 import com.example.egobook_be.global.exception.CustomException;
 import com.example.egobook_be.global.util.RedisUtil;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,6 +46,7 @@ public class UserServiceUnitTest {
     @Mock private UserRepository userRepository;
     @Mock private AuthAccountRepository authAccountRepository;
     @Mock private RefreshTokenBackupRepository refreshTokenBackupRepository;
+    @Mock private WithdrawReasonRepository withdrawReasonRepository;
     @Mock private RedisUtil redisUtil;
 
     @BeforeEach
@@ -52,7 +57,7 @@ public class UserServiceUnitTest {
 
     @Nested
     @DisplayName("withDrawAccount() 회원 탈퇴 메서드 테스트")
-    class WithDrawAccountTest {
+    class WithdrawAccountTest {
 
         @Test
         @DisplayName("[성공] 정상적인 회원 탈퇴 요청 (상태 변경 및 토큰 무효화)")
@@ -178,6 +183,96 @@ public class UserServiceUnitTest {
             // 실패 이후의 토큰 무효화 로직이 실행되지 않았음을 검증
             verify(refreshTokenBackupRepository, never()).findAllByAuthAccount(any());
             verify(redisUtil, never()).setTokenInBlacklist(anyString());
+        }
+    }
+
+    @Nested
+    @DisplayName("saveWithdrawReason() 탈퇴 정보 저장 메서드 테스트")
+    class WithdrawReasonTest {
+
+        @Test
+        @DisplayName("[성공] 탈퇴 정보 저장 성공")
+        void saveWithdrawReason() {
+            // ========= Given =========
+            Long userId = 1L;
+            WithdrawReasonReqDto reqDto = new WithdrawReasonReqDto(WithdrawReasonType.LACK_OF_CONTENT, "콘텐츠가 부족해요");
+
+            // 1. 유저가 존재함
+            given(userRepository.existsById(userId)).willReturn(true);
+            // 2. 이전에 탈퇴 사유를 작성한 적이 없음
+            given(withdrawReasonRepository.existsByUserId(userId)).willReturn(false);
+
+            // ========= When =========
+            userService.saveWithdrawReason(userId, reqDto);
+
+            // ========= Then =========
+            // save 메서드가 정확히 1번 호출되었는지 검증
+            verify(withdrawReasonRepository, times(1)).save(any(WithdrawReason.class));
+        }
+
+        @Test
+        @DisplayName("[실패 1] 이미 존재하는 사용자의 탈퇴 정보 저장 시도")
+        void failAlreadyExistUserWithdrawReason() {
+            // ========= Given =========
+            Long userId = 1L;
+            WithdrawReasonReqDto reqDto = new WithdrawReasonReqDto(WithdrawReasonType.NOT_USED_OFTEN, null);
+
+            given(userRepository.existsById(userId)).willReturn(true);
+            // 이미 탈퇴 사유를 작성한 적이 있음 (true 반환)
+            given(withdrawReasonRepository.existsByUserId(userId)).willReturn(true);
+
+            // ========= When & Then =========
+            CustomException exception = assertThrows(CustomException.class, () -> {
+                userService.saveWithdrawReason(userId, reqDto);
+            });
+
+            // 올바른 예외 코드가 반환되었는지 확인
+            assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.WITHDRAW_REASON_ALREADY_WRITTEN);
+
+            // save가 호출되지 않고 로직이 중단되었는지 확인
+            verify(withdrawReasonRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("[실패 2] 기타(OTHER) 선택 후 상세 내용을 빈칸으로 보냄")
+        void failSelectOtherAndNoText() {
+            // ========= Given =========
+            Long userId = 1L;
+            // OTHER를 선택했지만 text를 공백("   ")으로 보냄 (isBlank()에 걸림)
+            WithdrawReasonReqDto reqDto = new WithdrawReasonReqDto(WithdrawReasonType.OTHER, "   ");
+
+            given(userRepository.existsById(userId)).willReturn(true);
+            given(withdrawReasonRepository.existsByUserId(userId)).willReturn(false);
+
+            // ========= When & Then =========
+            CustomException exception = assertThrows(CustomException.class, () -> {
+                userService.saveWithdrawReason(userId, reqDto);
+            });
+
+            assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.WITHDRAW_REASON_OTHER_TEXT_FIELD_EMPTY);
+            verify(withdrawReasonRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("[실패 3] 존재하지 않는 사용자의 탈퇴 정보 저장 시도")
+        void failUserNotFound() {
+            // ========= Given =========
+            Long invalidUserId = 999L;
+            WithdrawReasonReqDto reqDto = new WithdrawReasonReqDto(WithdrawReasonType.LACK_OF_CONTENT, null);
+
+            // DB에서 유저를 찾지 못함 (false 반환)
+            given(userRepository.existsById(invalidUserId)).willReturn(false);
+
+            // ========= When & Then =========
+            CustomException exception = assertThrows(CustomException.class, () -> {
+                userService.saveWithdrawReason(invalidUserId, reqDto);
+            });
+
+            assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
+
+            // 이후 로직(존재 여부 확인 및 저장)이 실행되지 않았는지 검증
+            verify(withdrawReasonRepository, never()).existsByUserId(any());
+            verify(withdrawReasonRepository, never()).save(any());
         }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
- #161 

## 📝작업 내용
- 회원이 탈퇴하기 이전에 탈퇴하는 이유를 받아서 저장하는 API 개발 완료
- 해당 API service 함수 단위 테스트 코드 작성
- SwaggerConfig 일반/관리자 API 문서 그룹 분리