### PR TITLE
♻️ Refactor: Report 엔티티 리팩토링

### DIFF
--- a/src/main/java/com/example/egobook_be/domain/letters/controller/PlazaLetterController.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/controller/PlazaLetterController.java
@@ -254,8 +254,8 @@ public class PlazaLetterController {
             @RequestBody LetterReportRequest request
     ) {
         letterReportService.reportLetter(
-                userId,
                 letterId,
+                userId,
                 request.getReason(),
                 request.getDescription()
         );

--- a/src/main/java/com/example/egobook_be/domain/letters/dto/ReplyItemDto.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/dto/ReplyItemDto.java
@@ -4,7 +4,7 @@ import com.example.egobook_be.domain.letters.entity.PlazaLetterMode;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 
 @Getter
 @Builder
@@ -17,5 +17,5 @@ public class ReplyItemDto {
     private String backgroundColor;
 
     private String replyText;
-    private OffsetDateTime createdAt;
+    private LocalDateTime createdAt;
 }

--- a/src/main/java/com/example/egobook_be/domain/letters/dto/request/LetterReportRequest.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/dto/request/LetterReportRequest.java
@@ -1,6 +1,6 @@
 package com.example.egobook_be.domain.letters.dto.request;
 
-import com.example.egobook_be.domain.letters.entity.ReplyReportReason;
+import com.example.egobook_be.domain.letters.enums.LetterReportReason;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
@@ -9,10 +9,9 @@ import lombok.Getter;
 public class LetterReportRequest {
 
     @Schema(description = "편지 신고 사유", example = "ABUSE", allowableValues = "ABUSE, SPAM, INAPPROPRIATE, OTHER")
-    private ReplyReportReason reason;
+    private LetterReportReason reason;
 
-    @Schema(description = "기타 사유(선택)", example = "욕설이 포함된 편지")
+    @Schema(description = "...")
     @Size(max = 500)
     private String description;
 }
-

--- a/src/main/java/com/example/egobook_be/domain/letters/dto/response/CreateLetterResponse.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/dto/response/CreateLetterResponse.java
@@ -4,7 +4,7 @@ import com.example.egobook_be.domain.letters.entity.PlazaLetterMode;
 import com.example.egobook_be.domain.letters.entity.PlazaLetterStatus;
 import lombok.Builder;
 
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 
 @Builder
 public record CreateLetterResponse(
@@ -14,6 +14,6 @@ public record CreateLetterResponse(
         PlazaLetterMode mode,
         String fromLabel,
         String backgroundColor,
-        OffsetDateTime createdAt,
+        LocalDateTime createdAt,
         String backgroundImageUrl
         ) {}

--- a/src/main/java/com/example/egobook_be/domain/letters/dto/response/DeferredInboxItemDto.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/dto/response/DeferredInboxItemDto.java
@@ -5,7 +5,7 @@ import com.example.egobook_be.domain.letters.entity.PlazaLetterStatus;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 
 @Getter
 @Builder
@@ -18,7 +18,7 @@ public class DeferredInboxItemDto {
     private String backgroundColor;
 
     private String contentPreview;      // 30자 미리보기
-    private OffsetDateTime arrivedAt;
-    private OffsetDateTime replyDeadlineAt;
+    private LocalDateTime arrivedAt;
+    private LocalDateTime replyDeadlineAt;
 }
 

--- a/src/main/java/com/example/egobook_be/domain/letters/dto/response/GiveUpResponse.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/dto/response/GiveUpResponse.java
@@ -3,7 +3,7 @@ package com.example.egobook_be.domain.letters.dto.response;
 import com.example.egobook_be.domain.letters.entity.PlazaLetterStatus;
 import lombok.*;
 
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -12,6 +12,6 @@ import java.time.OffsetDateTime;
 public class GiveUpResponse {
     private Long letterId;
     private PlazaLetterStatus status;     // "GAVE_UP"
-    private OffsetDateTime gaveUpAt;
+    private LocalDateTime gaveUpAt;
 }
 

--- a/src/main/java/com/example/egobook_be/domain/letters/dto/response/InboxNextResponse.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/dto/response/InboxNextResponse.java
@@ -5,7 +5,7 @@ import com.example.egobook_be.domain.letters.entity.PlazaLetterStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -26,8 +26,8 @@ public class InboxNextResponse {
         private PlazaLetterMode mode;
         private String fromLabel;
         private String content;
-        private OffsetDateTime arrivedAt;
-        private OffsetDateTime replyDeadlineAt;
+        private LocalDateTime arrivedAt;
+        private LocalDateTime replyDeadlineAt;
         private String backgroundColor;
     }
 

--- a/src/main/java/com/example/egobook_be/domain/letters/dto/response/PlazaLetterDetailResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/dto/response/PlazaLetterDetailResDto.java
@@ -5,7 +5,7 @@ import com.example.egobook_be.domain.letters.entity.PlazaLetterStatus;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 
 @Getter
 @Builder
@@ -21,8 +21,8 @@ public class PlazaLetterDetailResDto {
     private String content;
     private String backgroundColor;
 
-    private OffsetDateTime createdAt;
-    private OffsetDateTime arrivedAt;
+    private LocalDateTime createdAt;
+    private LocalDateTime arrivedAt;
 
     private String fromLabel;
 
@@ -38,6 +38,6 @@ public class PlazaLetterDetailResDto {
         private boolean aiGenerated;
         private boolean reported;
 
-        private OffsetDateTime createdAt;
+        private LocalDateTime createdAt;
     }
 }

--- a/src/main/java/com/example/egobook_be/domain/letters/dto/response/PlazaReceivedReplyResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/dto/response/PlazaReceivedReplyResDto.java
@@ -4,7 +4,7 @@ import com.example.egobook_be.domain.letters.entity.PlazaLetterMode;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 
 @Getter
 @Builder
@@ -15,7 +15,7 @@ public class PlazaReceivedReplyResDto {
     private Long threadId;
 
     private String replyText;
-    private OffsetDateTime repliedAt;
+    private LocalDateTime repliedAt;
 
     private boolean aiGenerated;
     private boolean reported;

--- a/src/main/java/com/example/egobook_be/domain/letters/dto/response/PlazaSentLetterResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/dto/response/PlazaSentLetterResDto.java
@@ -4,7 +4,7 @@ import com.example.egobook_be.domain.letters.entity.PlazaLetterMode;
 import com.example.egobook_be.domain.letters.entity.PlazaLetterStatus;
 import lombok.*;
 
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 
 @Getter
 @Builder
@@ -17,11 +17,11 @@ public class PlazaSentLetterResDto {
     private PlazaLetterStatus status;
 
     // createdAt + 48h (AI 대체 예정/발생 시간)
-    private OffsetDateTime aiReplaceAt;
+    private LocalDateTime aiReplaceAt;
 
     // 리스트에서 보여줄 미리보기 텍스트
     private String lastMessagePreview;
 
-    private OffsetDateTime createdAt;
+    private LocalDateTime createdAt;
     private String backgroundColor;
 }

--- a/src/main/java/com/example/egobook_be/domain/letters/dto/response/ReplyResponse.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/dto/response/ReplyResponse.java
@@ -3,7 +3,7 @@ package com.example.egobook_be.domain.letters.dto.response;
 import com.example.egobook_be.domain.letters.entity.PlazaLetterStatus;
 import lombok.*;
 
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
@@ -14,7 +14,7 @@ public class ReplyResponse {
 
     private Long letterId;
     private PlazaLetterStatus status; // "REPLIED"
-    private OffsetDateTime repliedAt;
+    private LocalDateTime repliedAt;
     private List<RewardDto> rewards;
 
     @Getter

--- a/src/main/java/com/example/egobook_be/domain/letters/entity/PlazaLetter.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/entity/PlazaLetter.java
@@ -4,7 +4,7 @@ import com.example.egobook_be.domain.letters.enums.PlazaLetterColor;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -29,7 +29,7 @@ public class PlazaLetter {
 
 
     @Column(nullable = false)
-    private OffsetDateTime createdAt;
+    private LocalDateTime createdAt;
 
     @Enumerated(EnumType.STRING)
     @Builder.Default
@@ -51,14 +51,14 @@ public class PlazaLetter {
     private String content;
 
     @Column
-    private OffsetDateTime arrivedAt;
+    private LocalDateTime arrivedAt;
 
     @Column
-    private OffsetDateTime replyDeadlineAt;
+    private LocalDateTime replyDeadlineAt;
 
-    private OffsetDateTime repliedAt;
+    private LocalDateTime repliedAt;
 
-    public void markReplied(OffsetDateTime repliedAt) {
+    public void markReplied(LocalDateTime repliedAt) {
         this.status = PlazaLetterStatus.REPLIED;
         this.repliedAt = repliedAt;
     }
@@ -68,19 +68,19 @@ public class PlazaLetter {
     }
 
     @Column
-    private OffsetDateTime gaveUpAt;
+    private LocalDateTime gaveUpAt;
 
-    public void markGaveUp(OffsetDateTime gaveUpAt) {
+    public void markGaveUp(LocalDateTime gaveUpAt) {
         this.status = PlazaLetterStatus.GAVE_UP;
         this.gaveUpAt = gaveUpAt;
     }
 
-    public void markAiReplied(OffsetDateTime repliedAt) {
+    public void markAiReplied(LocalDateTime repliedAt) {
         this.status = PlazaLetterStatus.AI_REPLIED;
         this.repliedAt = repliedAt; // repliedAt 필드를 그대로 사용 (AI 답장)
     }
 
-    public void assignToReceiver(Long receiverId, OffsetDateTime arrivedAt, OffsetDateTime replyDeadlineAt) {
+    public void assignToReceiver(Long receiverId, LocalDateTime arrivedAt, LocalDateTime replyDeadlineAt) {
         this.receiverId = receiverId;
         this.arrivedAt = arrivedAt;
         this.replyDeadlineAt = replyDeadlineAt;
@@ -89,8 +89,8 @@ public class PlazaLetter {
 
     public void assignReceiver(
             Long receiverId,
-            OffsetDateTime arrivedAt,
-            OffsetDateTime replyDeadlineAt
+            LocalDateTime arrivedAt,
+            LocalDateTime replyDeadlineAt
     ) {
         this.receiverId = receiverId;
         this.arrivedAt = arrivedAt;
@@ -107,7 +107,7 @@ public class PlazaLetter {
 
 
     // arrivedAt에 대한 setter 메서드 추가
-    public void setArrivedAt(OffsetDateTime arrivedAt) {
+    public void setArrivedAt(LocalDateTime arrivedAt) {
         this.arrivedAt = arrivedAt;
     }
 

--- a/src/main/java/com/example/egobook_be/domain/letters/entity/PlazaLetterReply.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/entity/PlazaLetterReply.java
@@ -5,7 +5,7 @@ import lombok.*;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -37,7 +37,7 @@ public class PlazaLetterReply {
     private boolean isAiGenerated;
 
     @Column(nullable = false)
-    private OffsetDateTime createdAt;
+    private LocalDateTime createdAt;
 
     // status 필드 추가
     @Enumerated(EnumType.STRING) // Enum 값이 문자열로 저장되도록 설정

--- a/src/main/java/com/example/egobook_be/domain/letters/entity/PlazaLetterReplyReport.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/entity/PlazaLetterReplyReport.java
@@ -1,18 +1,19 @@
 package com.example.egobook_be.domain.letters.entity;
 
+import com.example.egobook_be.domain.letters.entity.ReplyReportReason;
+import com.example.egobook_be.global.entity.BaseReportEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
-import java.time.OffsetDateTime;
-
 @Entity
 @Getter
-@Builder
-@NoArgsConstructor
+@SuperBuilder
+@NoArgsConstructor(force = true)
 @AllArgsConstructor
-public class PlazaLetterReplyReport {
+public class PlazaLetterReplyReport extends BaseReportEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -20,31 +21,19 @@ public class PlazaLetterReplyReport {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "reply_id")
-    @OnDelete(action = OnDeleteAction.CASCADE) // 답장이 삭제되면 신고 내역도 자동 삭제
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private PlazaLetterReply reply;
-
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "letter_id")
-    @OnDelete(action = OnDeleteAction.CASCADE) // 편지가 삭제되면 신고 내역도 자동 삭제
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private PlazaLetter letter;
 
     @Column(nullable = false)
     private Long reporterId;
 
-    private Long replierId; // 신고를 받은 편지를 작성한 작성자의 User PK
+    private Long replierId;
 
     @Enumerated(EnumType.STRING)
     private ReplyReportReason reason;
-
-    private String description;
-
-    private OffsetDateTime createdAt;
-
-    @Enumerated(EnumType.STRING)
-    private ReportStatus status;
-
-    public enum ReportStatus {
-        PENDING, RESOLVED
-    }
 }

--- a/src/main/java/com/example/egobook_be/domain/letters/entity/PlazaLetterReport.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/entity/PlazaLetterReport.java
@@ -1,18 +1,19 @@
 package com.example.egobook_be.domain.letters.entity;
 
+import com.example.egobook_be.domain.letters.enums.LetterReportReason;
+import com.example.egobook_be.global.entity.BaseReportEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
-import java.time.OffsetDateTime;
-
 @Entity
 @Getter
-@Builder
-@NoArgsConstructor
+@SuperBuilder
+@NoArgsConstructor(force = true)
 @AllArgsConstructor
-public class PlazaLetterReport {
+public class PlazaLetterReport extends BaseReportEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -21,26 +22,14 @@ public class PlazaLetterReport {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "letter_id", nullable = false)
-    @OnDelete(action = OnDeleteAction.CASCADE) // 편지가 삭제되면 신고 내역도 자동 삭제
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private PlazaLetter letter;
 
-
     @Column(name = "reporter_id", nullable = false)
-    private Long reporterId; // 신고한 사람(= 편지 받은 사람)
+    private Long reporterId;
 
-    private Long senderId;   // 신고당한 편지 작성자(익명 처리/정책에 따라 null 가능)
-
-    @Enumerated(EnumType.STRING)
-    private ReplyReportReason reason;
-
-    private String description;
-
-    private OffsetDateTime createdAt;
+    private Long senderId;
 
     @Enumerated(EnumType.STRING)
-    private ReportStatus status;
-
-    public enum ReportStatus {
-        PENDING, RESOLVED
-    }
+    private LetterReportReason reason;
 }

--- a/src/main/java/com/example/egobook_be/domain/letters/entity/PlazaLetterThread.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/entity/PlazaLetterThread.java
@@ -3,7 +3,7 @@ package com.example.egobook_be.domain.letters.entity;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -18,11 +18,11 @@ public class PlazaLetterThread {
     private Long threadId;
 
     @Column(nullable = false)
-    private OffsetDateTime createdAt;
+    private LocalDateTime createdAt;
 
     public static PlazaLetterThread createNow() {
         return PlazaLetterThread.builder()
-                .createdAt(OffsetDateTime.now())
+                .createdAt(LocalDateTime.now())
                 .build();
     }
 }

--- a/src/main/java/com/example/egobook_be/domain/letters/enums/LetterReportReason.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/enums/LetterReportReason.java
@@ -1,0 +1,8 @@
+package com.example.egobook_be.domain.letters.enums;
+
+public enum LetterReportReason {
+    ABUSE,          // 비속어/욕설/모욕
+    SPAM,           // 광고/스팸
+    INAPPROPRIATE,  // 부적절한 콘텐츠
+    OTHER           // 기타
+}

--- a/src/main/java/com/example/egobook_be/domain/letters/mapper/PlazaLetterMapper.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/mapper/PlazaLetterMapper.java
@@ -6,7 +6,7 @@ import com.example.egobook_be.domain.letters.entity.PlazaLetterReply;
 import com.example.egobook_be.domain.letters.entity.PlazaLetterStatus;
 import org.springframework.stereotype.Component;
 
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 
 @Component
 public class PlazaLetterMapper {
@@ -14,8 +14,8 @@ public class PlazaLetterMapper {
     private static final String AI_PREVIEW = "48시간 동안 답장이 없어 내가 대신...";
 
     public PlazaSentLetterResDto toDto(PlazaLetter letter) {
-        OffsetDateTime createdAt = letter.getCreatedAt();
-        OffsetDateTime aiReplaceAt = (createdAt == null) ? null : createdAt.plusHours(48);
+        LocalDateTime createdAt = letter.getCreatedAt();
+        LocalDateTime aiReplaceAt = (createdAt == null) ? null : createdAt.plusHours(48);
 
         String preview = (letter.getStatus() == PlazaLetterStatus.AI_REPLIED)
                 ? AI_PREVIEW

--- a/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterReplyRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterReplyRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -39,7 +39,7 @@ public interface PlazaLetterReplyRepository extends JpaRepository<PlazaLetterRep
             Pageable pageable
     );
 
-    boolean existsByReplierIdAndCreatedAtBetween(Long replierId, OffsetDateTime createdAtAfter, OffsetDateTime createdAtBefore);
+    boolean existsByReplierIdAndCreatedAtBetween(Long replierId, LocalDateTime createdAtAfter, LocalDateTime createdAtBefore);
 
     // 내가 쓴 답장의 작성자 ID를 NULL로 익명화
     @Modifying(clearAutomatically = true)

--- a/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.*;
 import org.springframework.data.repository.query.Param;
 
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -16,13 +16,13 @@ public interface PlazaLetterRepository extends JpaRepository<PlazaLetter, Long> 
 
     Optional<PlazaLetter> findFirstByReceiverIdAndStatusOrderByArrivedAtDesc(Long receiverId, PlazaLetterStatus status);
 
-    boolean existsBySenderIdAndCreatedAtBetween(Long senderId, OffsetDateTime start, OffsetDateTime end);
+    boolean existsBySenderIdAndCreatedAtBetween(Long senderId, LocalDateTime start, LocalDateTime end);
 
     Optional<PlazaLetter> findByThreadId(Long threadId);
 
     void deleteByThreadId(Long threadId);
 
-    long countByReceiverIdAndArrivedAtBetween(Long receiverId, OffsetDateTime start, OffsetDateTime end);
+    long countByReceiverIdAndArrivedAtBetween(Long receiverId, LocalDateTime start, LocalDateTime end);
 
     List<PlazaLetter> findByLetterIdIn(List<Long> letterIds);
 
@@ -42,7 +42,7 @@ public interface PlazaLetterRepository extends JpaRepository<PlazaLetter, Long> 
     """)
     int bulkMarkAiReplied(
             @Param("senderId") Long senderId,
-            @Param("threshold") OffsetDateTime threshold,
+            @Param("threshold") LocalDateTime threshold,
             @Param("newStatus") PlazaLetterStatus newStatus,
             @Param("newFromLabel") String newFromLabel
     );
@@ -87,7 +87,7 @@ public interface PlazaLetterRepository extends JpaRepository<PlazaLetter, Long> 
         order by l.createdAt asc
     """)
     List<PlazaLetter> findAiReplyTargets(
-            @Param("cutoff") OffsetDateTime cutoff,
+            @Param("cutoff") LocalDateTime cutoff,
             @Param("replied") PlazaLetterStatus replied,
             @Param("aiReplied") PlazaLetterStatus aiReplied,
             Pageable pageable
@@ -102,7 +102,7 @@ public interface PlazaLetterRepository extends JpaRepository<PlazaLetter, Long> 
             ") " +
             "ORDER BY l.replyDeadlineAt ASC")
     List<PlazaLetter> findGiveUpTargets(
-            @Param("now") OffsetDateTime now,
+            @Param("now") LocalDateTime now,
             @Param("arrived") PlazaLetterStatus arrived,
             @Param("deferred") PlazaLetterStatus deferred,
             Pageable pageable

--- a/src/main/java/com/example/egobook_be/domain/letters/service/LetterReportService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/LetterReportService.java
@@ -3,15 +3,17 @@ package com.example.egobook_be.domain.letters.service;
 import com.example.egobook_be.domain.letters.entity.PlazaLetter;
 import com.example.egobook_be.domain.letters.entity.PlazaLetterReport;
 import com.example.egobook_be.domain.letters.entity.ReplyReportReason;
+import com.example.egobook_be.domain.letters.enums.LetterReportReason;
 import com.example.egobook_be.domain.letters.enums.LettersErrorCode;
 import com.example.egobook_be.domain.letters.repository.PlazaLetterReportRepository;
 import com.example.egobook_be.domain.letters.repository.PlazaLetterRepository;
+import com.example.egobook_be.global.enums.ReportStatus;
 import com.example.egobook_be.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -21,10 +23,10 @@ public class LetterReportService {
     private final PlazaLetterRepository plazaLetterRepository;
 
     @Transactional
-    public void reportLetter(Long userId, Long letterId, ReplyReportReason reason, String description) {
+    public void reportLetter(Long letterId, Long userId, LetterReportReason reason, String description){
 
         // 기타면 description 필수
-        if (reason == ReplyReportReason.OTHER && (description == null || description.isBlank())) {
+        if (reason == LetterReportReason.OTHER && (description == null || description.isBlank())) {
             throw new CustomException(LettersErrorCode.INVALID_REPORT_REASON);
         }
 
@@ -41,14 +43,14 @@ public class LetterReportService {
             throw new CustomException(LettersErrorCode.FORBIDDEN);
         }
 
+
         PlazaLetterReport report = PlazaLetterReport.builder()
                 .letter(letter)
                 .reporterId(userId)
                 .senderId(letter.getSenderId())
                 .reason(reason)
                 .description(description)
-                .createdAt(OffsetDateTime.now())
-                .status(PlazaLetterReport.ReportStatus.PENDING)
+                .status(ReportStatus.PENDING)
                 .build();
 
         letterReportRepository.save(report);

--- a/src/main/java/com/example/egobook_be/domain/letters/service/LetterService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/LetterService.java
@@ -5,7 +5,7 @@ import com.example.egobook_be.domain.letters.repository.PlazaLetterRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 
 @Service
@@ -26,12 +26,12 @@ public class LetterService {
         PlazaLetter letter = plazaLetterRepository.findById(letterId)
                 .orElseThrow(() -> new IllegalArgumentException("편지를 찾을 수 없습니다."));
 
-        OffsetDateTime arrivedAt = letter.getArrivedAt();
+        LocalDateTime arrivedAt = letter.getArrivedAt();
         if (arrivedAt == null) {
             return false; // 편지가 도착하지 않았으면 AI 답장이 불필요
         }
 
         // 48시간이 경과했는지 확인
-        return arrivedAt.plus(48, ChronoUnit.HOURS).isBefore(OffsetDateTime.now());
+        return arrivedAt.plus(48, ChronoUnit.HOURS).isBefore(LocalDateTime.now());
     }
 }

--- a/src/main/java/com/example/egobook_be/domain/letters/service/PlazaLetterDispatchService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/PlazaLetterDispatchService.java
@@ -9,7 +9,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -28,7 +28,7 @@ public class PlazaLetterDispatchService {
      */
     @Transactional
     public void dispatchWaitingLetters() {
-        OffsetDateTime now = OffsetDateTime.now();
+        LocalDateTime now = LocalDateTime.now();
 
         List<PlazaLetter> waitingLetters =
                 plazaLetterRepository.findWaitingLetters(PageRequest.of(0, BATCH_SIZE));

--- a/src/main/java/com/example/egobook_be/domain/letters/service/PlazaLetterService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/PlazaLetterService.java
@@ -37,7 +37,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.beans.factory.annotation.Value;
 
 
-import java.time.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
@@ -104,7 +106,7 @@ public class PlazaLetterService {
         validateCreateLetterRequest(request);
 
         // 3. 해당 사용자가 편지를 작성할 수 있는 상태인지(이미 오늘 편지를 작성하였는지) 여부 검증
-        OffsetDateTime now = OffsetDateTime.now();
+        LocalDateTime now = LocalDateTime.now();
         enforceDailyLimit(userId, now);
 
         enforceWordAiOrThrow(request.getText());
@@ -162,8 +164,8 @@ public class PlazaLetterService {
         // ===== 핵심: receiverId/status/도착시간은 모드에 따라 다르게 =====
         Long receiverId = null;
         PlazaLetterStatus status;
-        OffsetDateTime arrivedAt = null;
-        OffsetDateTime replyDeadlineAt = null;
+        LocalDateTime arrivedAt = null;
+        LocalDateTime replyDeadlineAt = null;
 
         if (request.getMode() == PlazaLetterMode.FRIEND) {
             // FRIEND 모드일 때 친구 관계 검증 후 진행
@@ -267,11 +269,11 @@ public class PlazaLetterService {
     }
 
 
-    private void enforceDailyLimit(Long userId, OffsetDateTime now) {
+    private void enforceDailyLimit(Long userId, LocalDateTime now) {
         ZoneId zoneId = ZoneId.of("Asia/Seoul");
         LocalDate today = LocalDate.now(zoneId);
-        OffsetDateTime start = today.atStartOfDay(zoneId).toOffsetDateTime();
-        OffsetDateTime end = today.plusDays(1).atStartOfDay(zoneId).toOffsetDateTime();
+        LocalDateTime start = today.atStartOfDay(zoneId).toLocalDateTime();
+        LocalDateTime end = today.plusDays(1).atStartOfDay(zoneId).toLocalDateTime();
 
         if (plazaLetterRepository.existsBySenderIdAndCreatedAtBetween(userId, start, end)) {
             throw new CustomException(LettersErrorCode.DAILY_LETTER_LIMIT);
@@ -378,7 +380,7 @@ public class PlazaLetterService {
         validateOwnership(letter, userId);
 
         // 4. 답장 가능한 상태인지 검증
-        OffsetDateTime now = OffsetDateTime.now();
+        LocalDateTime now = LocalDateTime.now();
         validateReplyable(letter, now);
 
         // 5. 해당 편지에 대해 답장이 이미 되어있는 상태인지 확인
@@ -391,8 +393,8 @@ public class PlazaLetterService {
         // 6. plazaLetterReplyRepository로 PlazaLetterReply를 저장하기 전, 해당 사용자가 답장한 편지가 오늘 처음 답장한 편지인지 확인한다.
         ZoneId zoneId = ZoneId.of("Asia/Seoul");
         LocalDate today = LocalDate.now(zoneId);
-        OffsetDateTime startOfDay = today.atStartOfDay(zoneId).toOffsetDateTime();
-        OffsetDateTime endOfDay = today.plusDays(1).atStartOfDay(zoneId).toOffsetDateTime();
+        LocalDateTime startOfDay = today.atStartOfDay(zoneId).toLocalDateTime();
+        LocalDateTime endOfDay = today.plusDays(1).atStartOfDay(zoneId).toLocalDateTime();
         boolean isFirstReplyToday = !plazaLetterReplyRepository.existsByReplierIdAndCreatedAtBetween(userId, startOfDay, endOfDay);
 
         PlazaLetterReply reply = plazaLetterReplyRepository.save(PlazaLetterReply.builder()
@@ -479,7 +481,7 @@ public class PlazaLetterService {
         PlazaLetter letter = getLetterOrThrow(letterId);
         validateOwnership(letter, userId);
 
-        OffsetDateTime now = OffsetDateTime.now();
+        LocalDateTime now = LocalDateTime.now();
         validateDeferable(letter, now);
 
         if (letter.getStatus() == PlazaLetterStatus.ARRIVED) {
@@ -497,7 +499,7 @@ public class PlazaLetterService {
         PlazaLetter letter = getLetterOrThrow(letterId);
         validateOwnership(letter, userId);
 
-        OffsetDateTime now = OffsetDateTime.now();
+        LocalDateTime now = LocalDateTime.now();
         validateGiveUpable(letter, now);
 
         // 유저 가져오기
@@ -539,7 +541,7 @@ public class PlazaLetterService {
         }
     }
 
-    private void validateReplyable(PlazaLetter letter, OffsetDateTime now) {
+    private void validateReplyable(PlazaLetter letter, LocalDateTime now) {
         if (letter.getStatus() == PlazaLetterStatus.REPLIED || letter.getStatus() == PlazaLetterStatus.AI_REPLIED) {
             throw new CustomException(LettersErrorCode.ALREADY_REPLIED);
         }
@@ -548,7 +550,7 @@ public class PlazaLetterService {
         }
     }
 
-    private void validateDeferable(PlazaLetter letter, OffsetDateTime now) {
+    private void validateDeferable(PlazaLetter letter, LocalDateTime now) {
         if (letter.getStatus() == PlazaLetterStatus.REPLIED || letter.getStatus() == PlazaLetterStatus.AI_REPLIED) {
             throw new CustomException(LettersErrorCode.ALREADY_REPLIED);
         }
@@ -558,7 +560,7 @@ public class PlazaLetterService {
 
     }
 
-    private void validateGiveUpable(PlazaLetter letter, OffsetDateTime now) {
+    private void validateGiveUpable(PlazaLetter letter, LocalDateTime now) {
         if (letter.getStatus() == PlazaLetterStatus.REPLIED || letter.getStatus() == PlazaLetterStatus.AI_REPLIED) {
             throw new CustomException(LettersErrorCode.ALREADY_REPLIED);
         }
@@ -567,7 +569,7 @@ public class PlazaLetterService {
         }
     }
 
-    private boolean isDeadlinePassed(PlazaLetter letter, OffsetDateTime now) {
+    private boolean isDeadlinePassed(PlazaLetter letter, LocalDateTime now) {
         return letter.getReplyDeadlineAt() != null && now.isAfter(letter.getReplyDeadlineAt());
     }
 

--- a/src/main/java/com/example/egobook_be/domain/letters/service/ReplyReportService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/ReplyReportService.java
@@ -4,13 +4,14 @@ import com.example.egobook_be.domain.letters.entity.*;
 import com.example.egobook_be.domain.letters.repository.PlazaLetterReplyReportRepository;
 import com.example.egobook_be.domain.letters.repository.PlazaLetterReplyRepository;
 import com.example.egobook_be.domain.letters.repository.PlazaLetterRepository;
+import com.example.egobook_be.global.enums.ReportStatus;
 import com.example.egobook_be.global.exception.CustomException;
 import com.example.egobook_be.domain.letters.enums.LettersErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -51,8 +52,7 @@ public class ReplyReportService {
                 .replierId(reply.getReplierId())
                 .reason(reason)
                 .description(description)
-                .createdAt(OffsetDateTime.now())
-                .status(PlazaLetterReplyReport.ReportStatus.PENDING)
+                .status(ReportStatus.PENDING)
                 .build();
 
         replyReportRepository.save(report);

--- a/src/main/java/com/example/egobook_be/domain/letters/service/ai/PlazaLetterAiReplyService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/ai/PlazaLetterAiReplyService.java
@@ -13,7 +13,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.example.egobook_be.domain.letters.entity.QPlazaLetter.plazaLetter;
@@ -33,7 +33,7 @@ public class PlazaLetterAiReplyService {
 
     @Transactional
     public int generateAiReplies(int batchSize) {
-        OffsetDateTime cutoff = OffsetDateTime.now().minusHours(48);
+        LocalDateTime cutoff = LocalDateTime.now().minusHours(48);
 
 
         List<PlazaLetter> targets = plazaLetterRepository.findAiReplyTargets(
@@ -69,8 +69,8 @@ public class PlazaLetterAiReplyService {
         }
 
         // 48시간 지났는지 최종 확인 (스케줄러 지연/수동 호출 대비)
-        OffsetDateTime createdAt = letter.getCreatedAt();
-        if (createdAt == null || OffsetDateTime.now().isBefore(createdAt.plusHours(48))) {
+        LocalDateTime createdAt = letter.getCreatedAt();
+        if (createdAt == null || LocalDateTime.now().isBefore(createdAt.plusHours(48))) {
             return false;
         }
 
@@ -81,7 +81,7 @@ public class PlazaLetterAiReplyService {
         String raw = geminiClient.generateReply(nickname, letter.getContent());
         String normalized = normalizeAiReply(raw);
 
-        OffsetDateTime now = OffsetDateTime.now();
+        LocalDateTime now = LocalDateTime.now();
 
         PlazaLetterReply aiReply = PlazaLetterReply.builder()
                 .threadId(letter.getThreadId())

--- a/src/main/java/com/example/egobook_be/domain/letters/service/scheduler/PlazaLetterGiveUpService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/scheduler/PlazaLetterGiveUpService.java
@@ -11,7 +11,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -23,7 +23,7 @@ public class PlazaLetterGiveUpService {
 
     @Transactional
     public int autoGiveUpExpiredLetters() {
-        OffsetDateTime now = OffsetDateTime.now();
+        LocalDateTime now = LocalDateTime.now();
 
         PlazaLetterStatus arrived = PlazaLetterStatus.ARRIVED;
         PlazaLetterStatus deferred = PlazaLetterStatus.DEFERRED;

--- a/src/main/java/com/example/egobook_be/domain/letters/service/scheduler/PlazaLetterWaitingDispatchService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/scheduler/PlazaLetterWaitingDispatchService.java
@@ -8,7 +8,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -23,7 +23,7 @@ public class PlazaLetterWaitingDispatchService {
 
     @Transactional
     public int dispatchWaitingLetters() {
-        OffsetDateTime now = OffsetDateTime.now();
+        LocalDateTime now = LocalDateTime.now();
 
         // 1) 수신 가능 유저 찾기 (포기 후 4시간 지난 유저)
         List<Long> candidateUserIds =

--- a/src/main/java/com/example/egobook_be/domain/user/entity/User.java
+++ b/src/main/java/com/example/egobook_be/domain/user/entity/User.java
@@ -89,7 +89,7 @@ public class User extends BaseTimeEntity {
 
     // 편지 전송 조건 저장
     @Column(name = "letter_receive_blocked_until")
-    private OffsetDateTime letterReceiveBlockedUntil;
+    private LocalDateTime letterReceiveBlockedUntil;
 
     // ========= 연관관계 매핑 ========= //
 
@@ -212,11 +212,11 @@ public class User extends BaseTimeEntity {
 
 
 
-    public void blockLetterReceiveUntil(OffsetDateTime until) {
+    public void blockLetterReceiveUntil(LocalDateTime until) {
         this.letterReceiveBlockedUntil = until;
     }
 
-    public boolean canReceiveLetterAt(OffsetDateTime now) {
+    public boolean canReceiveLetterAt(LocalDateTime now) {
         return letterReceiveBlockedUntil == null || !now.isBefore(letterReceiveBlockedUntil);
     }
 
@@ -227,11 +227,11 @@ public class User extends BaseTimeEntity {
 
     // 해당 시간까지 수신 차단된 상태인지 확인하는 메서드도 필요할 수 있음.
     public boolean canReceiveLetters() {
-        return letterReceiveBlockedUntil == null || OffsetDateTime.now().isAfter(letterReceiveBlockedUntil);
+        return letterReceiveBlockedUntil == null || LocalDateTime.now().isAfter(letterReceiveBlockedUntil);
     }
 
     // getter, setter
-    public OffsetDateTime getLetterReceiveBlockedUntil() {
+    public LocalDateTime getLetterReceiveBlockedUntil() {
         return letterReceiveBlockedUntil;
     }
 

--- a/src/main/java/com/example/egobook_be/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/user/repository/UserRepository.java
@@ -64,7 +64,7 @@ public interface UserRepository extends JpaRepository<User, Long>,UserRepository
     where u.letterReceiveBlockedUntil is not null
       and u.letterReceiveBlockedUntil <= :now
 """)
-    List<Long> findReceivableUsers(OffsetDateTime now, PageRequest pageable);
+    List<Long> findReceivableUsers(LocalDateTime now, PageRequest pageable);
 
 
     @Query("""
@@ -72,7 +72,7 @@ public interface UserRepository extends JpaRepository<User, Long>,UserRepository
     from User u
     where (u.letterReceiveBlockedUntil is null or u.letterReceiveBlockedUntil <= :now)
 """)
-    List<Long> findAvailableReceivers(@Param("now") OffsetDateTime now, Pageable pageable);
+    List<Long> findAvailableReceivers(@Param("now") LocalDateTime now, Pageable pageable);
 
     Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/example/egobook_be/global/entity/BaseReportEntity.java
+++ b/src/main/java/com/example/egobook_be/global/entity/BaseReportEntity.java
@@ -1,0 +1,32 @@
+package com.example.egobook_be.global.entity;
+
+import com.example.egobook_be.global.enums.ReportStatus;
+import jakarta.persistence.*;
+        import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor(force = true)
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseReportEntity {
+
+    @Column(length = 500)
+    private String description;         // 신고 상세 설명
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;    // 자동 주입
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ReportStatus status;        // 공통 신고 상태
+
+    // reporterId는 도메인마다 타입이 달라서 각 자식에서 선언
+}

--- a/src/main/java/com/example/egobook_be/global/enums/ReportStatus.java
+++ b/src/main/java/com/example/egobook_be/global/enums/ReportStatus.java
@@ -1,0 +1,5 @@
+package com.example.egobook_be.global.enums;
+
+public enum ReportStatus {
+    PENDING, RESOLVED, REFUSED
+}

--- a/src/test/java/com/example/egobook_be/domain/letter/LetterReportServiceTest.java
+++ b/src/test/java/com/example/egobook_be/domain/letter/LetterReportServiceTest.java
@@ -4,7 +4,7 @@ import com.example.egobook_be.domain.letters.entity.PlazaLetter;
 import com.example.egobook_be.domain.letters.entity.PlazaLetterMode;
 import com.example.egobook_be.domain.letters.entity.PlazaLetterReport;
 import com.example.egobook_be.domain.letters.entity.PlazaLetterStatus;
-import com.example.egobook_be.domain.letters.entity.ReplyReportReason;
+import com.example.egobook_be.domain.letters.enums.LetterReportReason;
 import com.example.egobook_be.domain.letters.enums.LettersErrorCode;
 import com.example.egobook_be.domain.letters.repository.PlazaLetterReportRepository;
 import com.example.egobook_be.domain.letters.repository.PlazaLetterRepository;
@@ -17,7 +17,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,7 +42,7 @@ class LetterReportServiceTest {
     @Test
     @DisplayName("reportLetter_OTHER 사유인데 설명이 없으면 예외가 발생한다")
     void reportLetter_otherReasonWithoutDescription_fail() {
-        assertThatThrownBy(() -> letterReportService.reportLetter(1L, 10L, ReplyReportReason.OTHER, " "))
+        assertThatThrownBy(() -> letterReportService.reportLetter(1L, 10L, LetterReportReason.OTHER, " "))
                 .isInstanceOf(CustomException.class)
                 .extracting(e -> ((CustomException) e).getErrorCode())
                 .isEqualTo(LettersErrorCode.INVALID_REPORT_REASON);
@@ -51,9 +51,9 @@ class LetterReportServiceTest {
     @Test
     @DisplayName("reportLetter_이미 신고한 편지면 예외가 발생한다")
     void reportLetter_alreadyReported_fail() {
-        given(letterReportRepository.existsByLetter_LetterIdAndReporterId(10L, 1L)).willReturn(true);
+        given(letterReportRepository.existsByLetter_LetterIdAndReporterId(1L, 10L)).willReturn(true); // letterId=1L, userId=10L
 
-        assertThatThrownBy(() -> letterReportService.reportLetter(1L, 10L, ReplyReportReason.ABUSE, "신고"))
+        assertThatThrownBy(() -> letterReportService.reportLetter(1L, 10L, LetterReportReason.ABUSE, "신고"))
                 .isInstanceOf(CustomException.class)
                 .extracting(e -> ((CustomException) e).getErrorCode())
                 .isEqualTo(LettersErrorCode.ALREADY_REPORTED);
@@ -64,11 +64,11 @@ class LetterReportServiceTest {
     @Test
     @DisplayName("reportLetter_받은 편지가 아니면 예외가 발생한다")
     void reportLetter_notReceiver_fail() {
-        PlazaLetter letter = plazaLetter(10L, 2L, 3L);
-        given(letterReportRepository.existsByLetter_LetterIdAndReporterId(10L, 1L)).willReturn(false);
-        given(plazaLetterRepository.findById(10L)).willReturn(Optional.of(letter));
+        PlazaLetter letter = plazaLetter(1L, 2L, 3L); // letterId=1L, senderId=2L, receiverId=3L (userId=10L이 아님)
+        given(letterReportRepository.existsByLetter_LetterIdAndReporterId(1L, 10L)).willReturn(false);
+        given(plazaLetterRepository.findById(1L)).willReturn(Optional.of(letter));
 
-        assertThatThrownBy(() -> letterReportService.reportLetter(1L, 10L, ReplyReportReason.ABUSE, "신고"))
+        assertThatThrownBy(() -> letterReportService.reportLetter(1L, 10L, LetterReportReason.ABUSE, "신고"))
                 .isInstanceOf(CustomException.class)
                 .extracting(e -> ((CustomException) e).getErrorCode())
                 .isEqualTo(LettersErrorCode.FORBIDDEN);
@@ -77,26 +77,26 @@ class LetterReportServiceTest {
     @Test
     @DisplayName("reportLetter_누적 신고가 3회 이상이면 편지를 삭제한다")
     void reportLetter_reportCountThreeOrMore_deleteLetter() {
-        PlazaLetter letter = plazaLetter(10L, 2L, 1L);
-        given(letterReportRepository.existsByLetter_LetterIdAndReporterId(10L, 1L)).willReturn(false);
-        given(plazaLetterRepository.findById(10L)).willReturn(Optional.of(letter));
-        given(letterReportRepository.countByLetter_LetterId(10L)).willReturn(3L);
+        PlazaLetter letter = plazaLetter(1L, 2L, 10L); // letterId=1L, receiverId=10L (userId와 일치)
+        given(letterReportRepository.existsByLetter_LetterIdAndReporterId(1L, 10L)).willReturn(false);
+        given(plazaLetterRepository.findById(1L)).willReturn(Optional.of(letter));
+        given(letterReportRepository.countByLetter_LetterId(1L)).willReturn(3L);
 
-        letterReportService.reportLetter(1L, 10L, ReplyReportReason.ABUSE, "신고 사유");
+        letterReportService.reportLetter(1L, 10L, LetterReportReason.ABUSE, "신고 사유");
 
         verify(letterReportRepository).save(any(PlazaLetterReport.class));
-        verify(plazaLetterRepository).deleteById(10L);
+        verify(plazaLetterRepository).deleteById(1L);
     }
 
     @Test
     @DisplayName("reportLetter_정상 신고면 신고 내역을 저장한다")
     void reportLetter_validRequest_success() {
-        PlazaLetter letter = plazaLetter(10L, 2L, 1L);
-        given(letterReportRepository.existsByLetter_LetterIdAndReporterId(10L, 1L)).willReturn(false);
-        given(plazaLetterRepository.findById(10L)).willReturn(Optional.of(letter));
-        given(letterReportRepository.countByLetter_LetterId(10L)).willReturn(1L);
+        PlazaLetter letter = plazaLetter(1L, 2L, 10L); // letterId=1L, receiverId=10L (userId와 일치)
+        given(letterReportRepository.existsByLetter_LetterIdAndReporterId(1L, 10L)).willReturn(false);
+        given(plazaLetterRepository.findById(1L)).willReturn(Optional.of(letter));
+        given(letterReportRepository.countByLetter_LetterId(1L)).willReturn(1L);
 
-        letterReportService.reportLetter(1L, 10L, ReplyReportReason.SPAM, "광고 같아요");
+        letterReportService.reportLetter(1L, 10L, LetterReportReason.SPAM, "광고 같아요");
 
         verify(letterReportRepository).save(any(PlazaLetterReport.class));
         verify(plazaLetterRepository, never()).deleteById(any());
@@ -112,9 +112,9 @@ class LetterReportServiceTest {
                 .fromLabel("익명")
                 .content("내용")
                 .status(PlazaLetterStatus.ARRIVED)
-                .createdAt(OffsetDateTime.now().minusHours(1))
-                .arrivedAt(OffsetDateTime.now().minusMinutes(30))
-                .replyDeadlineAt(OffsetDateTime.now().plusHours(23))
+                .createdAt(LocalDateTime.now().minusHours(1))
+                .arrivedAt(LocalDateTime.now().minusMinutes(30))
+                .replyDeadlineAt(LocalDateTime.now().plusHours(23))
                 .build();
     }
 }

--- a/src/test/java/com/example/egobook_be/domain/letter/PlazaLetterAiReplyServiceTest.java
+++ b/src/test/java/com/example/egobook_be/domain/letter/PlazaLetterAiReplyServiceTest.java
@@ -18,7 +18,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -52,7 +52,7 @@ class PlazaLetterAiReplyServiceTest {
     @Test
     @DisplayName("generateAiReplyIfEligible_이미 답장이 있으면 false를 반환한다")
     void generateAiReplyIfEligible_replyAlreadyExists_returnFalse() {
-        PlazaLetter letter = targetLetter(10L, OffsetDateTime.now().minusHours(49), PlazaLetterStatus.ARRIVED);
+        PlazaLetter letter = targetLetter(10L, LocalDateTime.now().minusHours(49), PlazaLetterStatus.ARRIVED);
         given(plazaLetterRepository.findById(10L)).willReturn(Optional.of(letter));
         given(plazaLetterReplyRepository.existsByLetter(letter)).willReturn(true);
 
@@ -65,7 +65,7 @@ class PlazaLetterAiReplyServiceTest {
     @Test
     @DisplayName("generateAiReplyIfEligible_48시간이 지나지 않았으면 false를 반환한다")
     void generateAiReplyIfEligible_notExpired48Hours_returnFalse() {
-        PlazaLetter letter = targetLetter(10L, OffsetDateTime.now().minusHours(47), PlazaLetterStatus.ARRIVED);
+        PlazaLetter letter = targetLetter(10L, LocalDateTime.now().minusHours(47), PlazaLetterStatus.ARRIVED);
         given(plazaLetterRepository.findById(10L)).willReturn(Optional.of(letter));
         given(plazaLetterReplyRepository.existsByLetter(letter)).willReturn(false);
 
@@ -78,7 +78,7 @@ class PlazaLetterAiReplyServiceTest {
     @Test
     @DisplayName("generateAiReplyIfEligible_조건을 만족하면 AI 답장을 저장하고 상태를 AI_REPLIED로 변경한다")
     void generateAiReplyIfEligible_eligibleLetter_success() {
-        PlazaLetter letter = targetLetter(10L, OffsetDateTime.now().minusHours(49), PlazaLetterStatus.ARRIVED);
+        PlazaLetter letter = targetLetter(10L, LocalDateTime.now().minusHours(49), PlazaLetterStatus.ARRIVED);
         User sender = User.builder()
                 .id(1L)
                 .accountCode("USER1234")
@@ -103,7 +103,7 @@ class PlazaLetterAiReplyServiceTest {
         verify(plazaLetterRepository).save(letter);
     }
 
-    private PlazaLetter targetLetter(Long letterId, OffsetDateTime createdAt, PlazaLetterStatus status) {
+    private PlazaLetter targetLetter(Long letterId, LocalDateTime createdAt, PlazaLetterStatus status) {
         return PlazaLetter.builder()
                 .letterId(letterId)
                 .threadId(500L)

--- a/src/test/java/com/example/egobook_be/domain/letter/PlazaLetterGiveUpServiceTest.java
+++ b/src/test/java/com/example/egobook_be/domain/letter/PlazaLetterGiveUpServiceTest.java
@@ -14,7 +14,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -74,9 +74,9 @@ class PlazaLetterGiveUpServiceTest {
                 .fromLabel("익명")
                 .content("편지")
                 .status(status)
-                .createdAt(OffsetDateTime.now().minusDays(1))
-                .arrivedAt(OffsetDateTime.now().minusHours(25))
-                .replyDeadlineAt(OffsetDateTime.now().minusHours(1))
+                .createdAt(LocalDateTime.now().minusDays(1))
+                .arrivedAt(LocalDateTime.now().minusHours(25))
+                .replyDeadlineAt(LocalDateTime.now().minusHours(1))
                 .build();
     }
 

--- a/src/test/java/com/example/egobook_be/domain/letter/PlazaLetterServiceTest.java
+++ b/src/test/java/com/example/egobook_be/domain/letter/PlazaLetterServiceTest.java
@@ -35,7 +35,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -116,7 +116,7 @@ class PlazaLetterServiceTest {
 
         PlazaLetterThread savedThread = PlazaLetterThread.builder()
                 .threadId(10L)
-                .createdAt(OffsetDateTime.now())
+                .createdAt(LocalDateTime.now())
                 .build();
 
         given(userRepository.findById(userId)).willReturn(Optional.of(sender));
@@ -258,9 +258,9 @@ class PlazaLetterServiceTest {
                 .content("원본 편지")
                 .backgroundColor(PlazaLetterColor.WHITE)
                 .status(PlazaLetterStatus.ARRIVED)
-                .createdAt(OffsetDateTime.now().minusHours(1))
-                .arrivedAt(OffsetDateTime.now().minusMinutes(30))
-                .replyDeadlineAt(OffsetDateTime.now().plusHours(23))
+                .createdAt(LocalDateTime.now().minusHours(1))
+                .arrivedAt(LocalDateTime.now().minusMinutes(30))
+                .replyDeadlineAt(LocalDateTime.now().plusHours(23))
                 .build();
 
         given(userRepository.findById(userId)).willReturn(Optional.of(receiver));
@@ -298,7 +298,7 @@ class PlazaLetterServiceTest {
                 .content("편지 내용")
                 .backgroundColor(PlazaLetterColor.WHITE)
                 .status(PlazaLetterStatus.REPLIED)
-                .createdAt(OffsetDateTime.now())
+                .createdAt(LocalDateTime.now())
                 .build();
 
         given(plazaLetterThreadRepository.existsById(threadId)).willReturn(true);

--- a/src/test/java/com/example/egobook_be/domain/letter/PlazaLetterWaitingDispatchServiceTest.java
+++ b/src/test/java/com/example/egobook_be/domain/letter/PlazaLetterWaitingDispatchServiceTest.java
@@ -13,7 +13,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -73,7 +73,7 @@ class PlazaLetterWaitingDispatchServiceTest {
                 .fromLabel("익명")
                 .content("대기 편지")
                 .status(PlazaLetterStatus.WAITING)
-                .createdAt(OffsetDateTime.now().minusHours(2))
+                .createdAt(LocalDateTime.now().minusHours(2))
                 .build();
     }
 }

--- a/src/test/java/com/example/egobook_be/domain/letter/ReplyReportServiceTest.java
+++ b/src/test/java/com/example/egobook_be/domain/letter/ReplyReportServiceTest.java
@@ -19,7 +19,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -124,9 +124,9 @@ class ReplyReportServiceTest {
                 .fromLabel("익명")
                 .content("편지")
                 .status(PlazaLetterStatus.ARRIVED)
-                .createdAt(OffsetDateTime.now().minusHours(10))
-                .arrivedAt(OffsetDateTime.now().minusHours(9))
-                .replyDeadlineAt(OffsetDateTime.now().plusHours(15))
+                .createdAt(LocalDateTime.now().minusHours(10))
+                .arrivedAt(LocalDateTime.now().minusHours(9))
+                .replyDeadlineAt(LocalDateTime.now().plusHours(15))
                 .build();
     }
 
@@ -138,7 +138,7 @@ class ReplyReportServiceTest {
                 .replierId(replierId)
                 .text("답장")
                 .isAiGenerated(false)
-                .createdAt(OffsetDateTime.now())
+                .createdAt(LocalDateTime.now())
                 .status(PlazaLetterReply.ReplyStatus.SENT)
                 .build();
     }


### PR DESCRIPTION
## #️⃣연관된 이슈
- #163 

## 📝작업 내용
- BaseReportEntity 추상 클래스 추가 (@MappedSuperclass)
  - description, createdAt(@CreatedDate), status 공통 필드 추상화
- PlazaLetterReport, PlazaLetterReplyReport, AnswerReport → BaseReportEntity 상속
- @Builder → @SuperBuilder 전환 (부모 필드 빌더 접근)
- ReportStatus enum global/enums으로 이동
- LetterReportReason enum 신규 추가 (ReplyReportReason과 분리)
- PlazaLetter, PlazaLetterReply, User 엔티티 OffsetDateTime → LocalDateTime 전환
- 관련 서비스/레포지토리/테스트 코드 LocalDateTime으로 일괄 수정


### 스크린샷 (선택)
동작 확인
<img width="1422" height="665" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/57664de6-ef36-4263-9085-4ee4ec1c4ef6" />


## 💬리뷰 요구사항(선택)
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?