### PR TITLE
✨ Feat: 사용자 정보 조회 API 개발 완료

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(find C:UsersnahjjIntelliJ_ProjectsEgobook_BE/src/main -type f -path *user*dto* -name *.java)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ src/test/resources/application-test.yml
 
 ### firebase access key ###
 src/main/resources/firebase-service-account.json
+
+CLAUDE.md

--- a/src/main/java/com/example/egobook_be/domain/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/diary/repository/DiaryRepository.java
@@ -72,4 +72,6 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
     // 특정 기간 사이의 일기 목록 조회 (주간용)
     List<Diary> findByUserIdAndDateBetweenOrderByDateAsc(Long userId, LocalDate start, LocalDate end);
+
+    long countByUser(User user);
 }

--- a/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterReplyRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterReplyRepository.java
@@ -16,6 +16,8 @@ import java.util.Optional;
 public interface PlazaLetterReplyRepository extends JpaRepository<PlazaLetterReply, Long> {
     boolean existsByLetter(PlazaLetter letter);
 
+    long countByReplierId(Long replierId);
+
     boolean existsByLetter_LetterId(Long letterId);
 
     @Query("SELECT r FROM PlazaLetterReply r JOIN FETCH r.letter WHERE r.replyId = :replyId")

--- a/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterRepository.java
@@ -16,6 +16,8 @@ public interface PlazaLetterRepository extends JpaRepository<PlazaLetter, Long> 
 
     Optional<PlazaLetter> findFirstByReceiverIdAndStatusOrderByArrivedAtDesc(Long receiverId, PlazaLetterStatus status);
 
+    Integer countBySenderId(Long senderId);
+
     boolean existsBySenderIdAndCreatedAtBetween(Long senderId, LocalDateTime start, LocalDateTime end);
 
     Optional<PlazaLetter> findByThreadId(Long threadId);

--- a/src/main/java/com/example/egobook_be/domain/question/repository/QuestionAnswerRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/question/repository/QuestionAnswerRepository.java
@@ -20,6 +20,8 @@ import java.util.Optional;
 public interface QuestionAnswerRepository extends JpaRepository<QuestionAnswer, Long> {
     boolean existsByUserAndQuestion(User user, TodayQuestion question);
 
+    long countByUser(User user);
+
     Optional<QuestionAnswer> findByUserAndQuestion(User user, TodayQuestion question);
 
     List<QuestionAnswer> findByQuestionAndVisibility(

--- a/src/main/java/com/example/egobook_be/domain/user/controller/AdminUserController.java
+++ b/src/main/java/com/example/egobook_be/domain/user/controller/AdminUserController.java
@@ -1,5 +1,6 @@
 package com.example.egobook_be.domain.user.controller;
 
+import com.example.egobook_be.domain.user.dto.AdminUserInfoResDto;
 import com.example.egobook_be.domain.user.dto.SearchUserResDto;
 import com.example.egobook_be.domain.user.enums.UserStatus;
 import com.example.egobook_be.domain.user.service.AdminUserService;
@@ -9,8 +10,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,5 +28,13 @@ public class AdminUserController implements AdminUserControllerDocs {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(GlobalResponse.success(200, "회원 리스트 검색 성공", response));
+    }
+
+    @Override
+    public ResponseEntity<GlobalResponse<AdminUserInfoResDto>> getUserInfo(Long userId) {
+        AdminUserInfoResDto response = adminUserService.getUserInfo(userId);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(GlobalResponse.success(200, "회원 기본 정보 조회 성공", response));
     }
 }

--- a/src/main/java/com/example/egobook_be/domain/user/controller/AdminUserController.java
+++ b/src/main/java/com/example/egobook_be/domain/user/controller/AdminUserController.java
@@ -1,6 +1,7 @@
 package com.example.egobook_be.domain.user.controller;
 
 import com.example.egobook_be.domain.user.dto.AdminUserInfoResDto;
+import com.example.egobook_be.domain.user.dto.AdminUserStatsResDto;
 import com.example.egobook_be.domain.user.dto.SearchUserResDto;
 import com.example.egobook_be.domain.user.enums.UserStatus;
 import com.example.egobook_be.domain.user.service.AdminUserService;
@@ -36,5 +37,13 @@ public class AdminUserController implements AdminUserControllerDocs {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(GlobalResponse.success(200, "회원 기본 정보 조회 성공", response));
+    }
+
+    @Override
+    public ResponseEntity<GlobalResponse<AdminUserStatsResDto>> getUserStats(Long userId) {
+        AdminUserStatsResDto response = adminUserService.getUserStats(userId);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(GlobalResponse.success(200, "회원 활동 통계 조회 성공", response));
     }
 }

--- a/src/main/java/com/example/egobook_be/domain/user/controller/AdminUserControllerDocs.java
+++ b/src/main/java/com/example/egobook_be/domain/user/controller/AdminUserControllerDocs.java
@@ -72,10 +72,16 @@ public interface AdminUserControllerDocs {
             - userId: 조회할 ```ROLE_USER``` 권한을 가진 사용자의 ID
 
             [**반환 정보**]
-            - userId, accountCode, email, nickname
-            - status (계정 상태), role (권한)
-            - level (레벨), ink (보유 잉크)
-            - lastLoginAt (마지막 로그인 시각), createdAt (가입 일시)
+            - ```userId```: 사용자 PK
+            - ```accountCode```: 사용자 계정 고유 코드
+            - ```email```: 사용자 이메일 (구글 연동된 계정일 경우만 존재)
+            - ```provider```: 가입 유형 (**GUEST** | **GOOGLE**)
+            - ```nickname```: 사용자 닉네임
+            - ```createdAt```: 계정 생성 일시
+            - ```lastLoginAt```: 마지막으로 로그인한 일시
+            - ```status```: 사용자 계정 상태 (**ACTIVE** | **DORMANT** | **WITHDRAW_PENDING** | **SUSPENDED**)
+            - ```deletedAt```: 사용자가 탈퇴 신청한 일시 (SOFT DELETE 신청한 일시)
+            - ```purgeAt```: 실제 사용자 데이터가 전부 삭제 예정인 일시
             """)
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "회원 기본 정보 조회 성공",

--- a/src/main/java/com/example/egobook_be/domain/user/controller/AdminUserControllerDocs.java
+++ b/src/main/java/com/example/egobook_be/domain/user/controller/AdminUserControllerDocs.java
@@ -1,5 +1,6 @@
 package com.example.egobook_be.domain.user.controller;
 
+import com.example.egobook_be.domain.user.dto.AdminUserInfoResDto;
 import com.example.egobook_be.domain.user.dto.SearchUserResDto;
 import com.example.egobook_be.domain.user.enums.UserStatus;
 import com.example.egobook_be.global.response.GlobalResponse;
@@ -13,8 +14,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -62,5 +63,34 @@ public interface AdminUserControllerDocs {
 
         @Parameter(description = "Page 크기", required = true)
         @RequestParam(value = "size", defaultValue = "5") Integer size
+    );
+
+    @Operation(summary = "회원 기본 정보 조회", description = """
+            특정 회원의 기본 정보를 조회하는 API입니다.
+
+            [**Path Variable**]
+            - userId: 조회할 ```ROLE_USER``` 권한을 가진 사용자의 ID
+
+            [**반환 정보**]
+            - userId, accountCode, email, nickname
+            - status (계정 상태), role (권한)
+            - level (레벨), ink (보유 잉크)
+            - lastLoginAt (마지막 로그인 시각), createdAt (가입 일시)
+            """)
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "회원 기본 정보 조회 성공",
+                    content = @Content(schema = @Schema(implementation = AdminUserInfoResDto.class))),
+            @ApiResponse(responseCode = "401", description = "로그인이 필요합니다.",
+                    content = @Content),
+            @ApiResponse(responseCode = "403", description = "관리자 권한이 필요합니다.",
+                    content = @Content),
+            @ApiResponse(responseCode = "404", description = "해당 사용자를 찾을 수 없습니다.",
+                    content = @Content)
+    })
+    @SecurityRequirement(name = "bearerAuth")
+    @GetMapping("/{userId}")
+    ResponseEntity<GlobalResponse<AdminUserInfoResDto>> getUserInfo(
+            @Parameter(description = "조회할 사용자 ID", required = true)
+            @PathVariable Long userId
     );
 }

--- a/src/main/java/com/example/egobook_be/domain/user/controller/AdminUserControllerDocs.java
+++ b/src/main/java/com/example/egobook_be/domain/user/controller/AdminUserControllerDocs.java
@@ -1,6 +1,7 @@
 package com.example.egobook_be.domain.user.controller;
 
 import com.example.egobook_be.domain.user.dto.AdminUserInfoResDto;
+import com.example.egobook_be.domain.user.dto.AdminUserStatsResDto;
 import com.example.egobook_be.domain.user.dto.SearchUserResDto;
 import com.example.egobook_be.domain.user.enums.UserStatus;
 import com.example.egobook_be.global.response.GlobalResponse;
@@ -96,6 +97,48 @@ public interface AdminUserControllerDocs {
     @SecurityRequirement(name = "bearerAuth")
     @GetMapping("/{userId}")
     ResponseEntity<GlobalResponse<AdminUserInfoResDto>> getUserInfo(
+            @Parameter(description = "조회할 사용자 ID", required = true)
+            @PathVariable Long userId
+    );
+
+    @Operation(summary = "회원 활동 통계 조회", description = """
+            특정 회원의 활동 통계를 조회하는 API입니다.
+
+            [**Path Variable**]
+            - userId: 조회할 ```ROLE_USER``` 권한을 가진 사용자의 ID
+
+            [**반환 정보**]
+            - ```userId```: 사용자 PK
+            - ```activityCount```: 카테고리별 활동 횟수
+                - ```diary```: 일기 작성 횟수
+                - ```letter```: 편지 작성 횟수
+                - ```letterReply```: 편지 답변 횟수
+                - ```questionAnswer```: 오늘의 질문 답변 횟수
+            - ```abilityLevel```: 능력치별 레벨
+                - ```empathy```: 공감성 레벨
+                - ```selfEsteem```: 자존감 레벨
+                - ```emotionRegulation```: 감정조절 레벨
+                - ```positiveThinking```: 긍정적 사고 레벨
+                - ```diligence```: 성실성 레벨
+            - ```letterReceiveBlockedUntil```: 편지 수신 차단 종료 일시 (차단 없으면 ```null```)
+            - ```notificationEnabled```: 알람 수신 여부 (```true```: 수신, ```false```: 비수신)
+            - ```isFirstAttendanceToday```: 오늘 첫 출석 여부 (```true```: 첫 출석 안함, ```false```: 첫 출석 함)
+            - ```weeklyAnalysisEnabled```: 주간 분석 보고서 수신 여부 (```true```: 수신, ```false```: 비수신)
+            - ```counselingTone```: 주간 분석 말투 (**SHARP** | **SOFT** | **OBJECTIVE**)
+            """)
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "회원 활동 통계 조회 성공",
+                    content = @Content(schema = @Schema(implementation = AdminUserStatsResDto.class))),
+            @ApiResponse(responseCode = "401", description = "로그인이 필요합니다.",
+                    content = @Content),
+            @ApiResponse(responseCode = "403", description = "관리자 권한이 필요합니다.",
+                    content = @Content),
+            @ApiResponse(responseCode = "404", description = "해당 사용자를 찾을 수 없습니다.",
+                    content = @Content)
+    })
+    @SecurityRequirement(name = "bearerAuth")
+    @GetMapping("/{userId}/stats")
+    ResponseEntity<GlobalResponse<AdminUserStatsResDto>> getUserStats(
             @Parameter(description = "조회할 사용자 ID", required = true)
             @PathVariable Long userId
     );

--- a/src/main/java/com/example/egobook_be/domain/user/dto/AdminUserInfoResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/user/dto/AdminUserInfoResDto.java
@@ -1,0 +1,37 @@
+package com.example.egobook_be.domain.user.dto;
+
+import com.example.egobook_be.domain.user.entity.User;
+import com.example.egobook_be.domain.user.enums.RoleType;
+import com.example.egobook_be.domain.user.enums.UserStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "관리자 회원 기본 정보 조회 DTO")
+public record AdminUserInfoResDto(
+        @Schema(description = "사용자 ID") Long userId,
+        @Schema(description = "계정 코드") String accountCode,
+        @Schema(description = "이메일") String email,
+        @Schema(description = "닉네임") String nickname,
+        @Schema(description = "계정 상태") UserStatus status,
+        @Schema(description = "권한") RoleType role,
+        @Schema(description = "레벨") Integer level,
+        @Schema(description = "보유 잉크") Integer ink,
+        @Schema(description = "마지막 로그인 시각") LocalDateTime lastLoginAt,
+        @Schema(description = "가입 일시") LocalDateTime createdAt
+) {
+    public static AdminUserInfoResDto from(User user) {
+        return new AdminUserInfoResDto(
+                user.getId(),
+                user.getAccountCode(),
+                user.getEmail(),
+                user.getNickname(),
+                user.getStatus(),
+                user.getRole(),
+                user.getLevel(),
+                user.getInk(),
+                user.getLastLoginAt(),
+                user.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/example/egobook_be/domain/user/dto/AdminUserInfoResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/user/dto/AdminUserInfoResDto.java
@@ -1,37 +1,28 @@
 package com.example.egobook_be.domain.user.dto;
 
+import com.example.egobook_be.domain.auth.enums.Provider;
 import com.example.egobook_be.domain.user.entity.User;
 import com.example.egobook_be.domain.user.enums.RoleType;
 import com.example.egobook_be.domain.user.enums.UserStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 
 import java.time.LocalDateTime;
 
 @Schema(description = "관리자 회원 기본 정보 조회 DTO")
+@Builder
 public record AdminUserInfoResDto(
         @Schema(description = "사용자 ID") Long userId,
         @Schema(description = "계정 코드") String accountCode,
         @Schema(description = "이메일") String email,
+        @Schema(description = "가입 유형") Provider provider,
         @Schema(description = "닉네임") String nickname,
-        @Schema(description = "계정 상태") UserStatus status,
-        @Schema(description = "권한") RoleType role,
+        @Schema(description = "가입 일시") LocalDateTime createdAt,
         @Schema(description = "레벨") Integer level,
         @Schema(description = "보유 잉크") Integer ink,
         @Schema(description = "마지막 로그인 시각") LocalDateTime lastLoginAt,
-        @Schema(description = "가입 일시") LocalDateTime createdAt
+        @Schema(description = "계정 상태") UserStatus status,
+        @Schema(description = "탈퇴 신청 일시") LocalDateTime deletedAt,
+        @Schema(description = "사용자 정보 삭제 일시") LocalDateTime purgeAt
 ) {
-    public static AdminUserInfoResDto from(User user) {
-        return new AdminUserInfoResDto(
-                user.getId(),
-                user.getAccountCode(),
-                user.getEmail(),
-                user.getNickname(),
-                user.getStatus(),
-                user.getRole(),
-                user.getLevel(),
-                user.getInk(),
-                user.getLastLoginAt(),
-                user.getCreatedAt()
-        );
-    }
 }

--- a/src/main/java/com/example/egobook_be/domain/user/dto/AdminUserStatsResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/user/dto/AdminUserStatsResDto.java
@@ -1,0 +1,39 @@
+package com.example.egobook_be.domain.user.dto;
+
+import com.example.egobook_be.domain.ego_room.enums.CounselTone;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "관리자 회원 활동 통계 조회 DTO")
+@Builder
+public record AdminUserStatsResDto(
+        @Schema(description = "사용자 ID") Long userId,
+        @Schema(description = "카테고리별 활동 횟수") ActivityCount activityCount,
+        @Schema(description = "능력치별 레벨") AbilityLevel abilityLevel,
+        @Schema(description = "편지 수신 차단 종료 일시 (null이면 차단 없음)") LocalDateTime letterReceiveBlockedUntil,
+        @Schema(description = "알림 수신 여부 (true: 수신, false: 비수신)") boolean notificationEnabled,
+        @Schema(description = "오늘 첫 출석 여부 (true: 첫 출석 안함, false: 첫 출석 함)") boolean isFirstAttendanceToday,
+        @Schema(description = "주간 분석 보고서 수신 여부 (true: 수신, false: 비수신)") boolean weeklyAnalysisEnabled,
+        @Schema(description = "주간 분석 말투 (SHARP | SOFT | OBJECTIVE)") CounselTone counselingTone
+) {
+    @Schema(description = "카테고리별 활동 횟수")
+    @Builder
+    public record ActivityCount(
+            @Schema(description = "일기 작성 횟수") long diary,
+            @Schema(description = "편지 작성 횟수") long letter,
+            @Schema(description = "편지 답변 횟수") long letterReply,
+            @Schema(description = "오늘의 질문 답변 횟수") long questionAnswer
+    ) {}
+
+    @Schema(description = "능력치별 레벨")
+    @Builder
+    public record AbilityLevel(
+            @Schema(description = "공감성 레벨") int empathy,
+            @Schema(description = "자존감 레벨") int selfEsteem,
+            @Schema(description = "감정조절 레벨") int emotionRegulation,
+            @Schema(description = "긍정적 사고 레벨") int positiveThinking,
+            @Schema(description = "성실성 레벨") int diligence
+    ) {}
+}

--- a/src/main/java/com/example/egobook_be/domain/user/entity/User.java
+++ b/src/main/java/com/example/egobook_be/domain/user/entity/User.java
@@ -101,7 +101,8 @@ public class User extends BaseTimeEntity {
     private Ability ability;
 
     @Enumerated(EnumType.STRING)
-    private CounselTone counselingTone;
+    @Builder.Default
+    private CounselTone counselingTone = CounselTone.SOFT;
 
     public void updateCounselingTone(CounselTone toneStyle) {
         this.counselingTone = toneStyle;

--- a/src/main/java/com/example/egobook_be/domain/user/exception/AdminUserErrorCode.java
+++ b/src/main/java/com/example/egobook_be/domain/user/exception/AdminUserErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum AdminUserErrorCode implements BaseErrorCode {
-    KEYWORD_IS_NULL_OR_BLANK(HttpStatus.BAD_REQUEST, "검색 키워드가 비었습니다.");
+    KEYWORD_IS_NULL_OR_BLANK(HttpStatus.BAD_REQUEST, "검색 키워드가 비었습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/egobook_be/domain/user/exception/AdminUserErrorCode.java
+++ b/src/main/java/com/example/egobook_be/domain/user/exception/AdminUserErrorCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum AdminUserErrorCode implements BaseErrorCode {
     KEYWORD_IS_NULL_OR_BLANK(HttpStatus.BAD_REQUEST, "검색 키워드가 비었습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),
-    AUTH_ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 인증 정보를 찾을 수 없습니다.");
+    AUTH_ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 인증 정보를 찾을 수 없습니다."),
+    ABILITY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자의 능력치 정보를 찾을 수 없습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/egobook_be/domain/user/exception/AdminUserErrorCode.java
+++ b/src/main/java/com/example/egobook_be/domain/user/exception/AdminUserErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum AdminUserErrorCode implements BaseErrorCode {
     KEYWORD_IS_NULL_OR_BLANK(HttpStatus.BAD_REQUEST, "검색 키워드가 비었습니다."),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다.");
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),
+    AUTH_ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 인증 정보를 찾을 수 없습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/egobook_be/domain/user/mapper/UserMapper.java
+++ b/src/main/java/com/example/egobook_be/domain/user/mapper/UserMapper.java
@@ -2,6 +2,8 @@ package com.example.egobook_be.domain.user.mapper;
 
 import com.example.egobook_be.domain.auth.entity.AuthAccount;
 import com.example.egobook_be.domain.user.dto.AdminUserInfoResDto;
+import com.example.egobook_be.domain.user.dto.AdminUserStatsResDto;
+import com.example.egobook_be.domain.user.entity.Ability;
 import com.example.egobook_be.domain.user.entity.User;
 import org.springframework.stereotype.Component;
 
@@ -21,6 +23,30 @@ public class UserMapper {
                 .status(user.getStatus())
                 .deletedAt(user.getDeletedAt())
                 .purgeAt(user.getPurgeAt())
+                .build();
+    }
+
+    public AdminUserStatsResDto toAdminUserStatsResDto(User user, Ability ability, long diaryCount, long letterCount, long letterReplyCount, long questionAnswerCount) {
+        return AdminUserStatsResDto.builder()
+                .userId(user.getId())
+                .activityCount(AdminUserStatsResDto.ActivityCount.builder()
+                        .diary(diaryCount)
+                        .letter(letterCount)
+                        .letterReply(letterReplyCount)
+                        .questionAnswer(questionAnswerCount)
+                        .build())
+                .abilityLevel(AdminUserStatsResDto.AbilityLevel.builder()
+                        .empathy(ability.getEmpathy().getLevel())
+                        .selfEsteem(ability.getSelfEsteem().getLevel())
+                        .emotionRegulation(ability.getEmotionRegulation().getLevel())
+                        .positiveThinking(ability.getPositiveThinking().getLevel())
+                        .diligence(ability.getDiligence().getLevel())
+                        .build())
+                .letterReceiveBlockedUntil(user.getLetterReceiveBlockedUntil())
+                .notificationEnabled(user.isNotificationEnabled())
+                .isFirstAttendanceToday(user.isFirstAttendanceToday())
+                .weeklyAnalysisEnabled(user.getWeeklyAnalysisEnabled())
+                .counselingTone(user.getCounselingTone())
                 .build();
     }
 }

--- a/src/main/java/com/example/egobook_be/domain/user/mapper/UserMapper.java
+++ b/src/main/java/com/example/egobook_be/domain/user/mapper/UserMapper.java
@@ -1,0 +1,26 @@
+package com.example.egobook_be.domain.user.mapper;
+
+import com.example.egobook_be.domain.auth.entity.AuthAccount;
+import com.example.egobook_be.domain.user.dto.AdminUserInfoResDto;
+import com.example.egobook_be.domain.user.entity.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserMapper {
+    public AdminUserInfoResDto toAdminUserInfoResDto(User user, AuthAccount authAccount) {
+        return AdminUserInfoResDto.builder()
+                .userId(user.getId())
+                .accountCode(user.getAccountCode())
+                .email(user.getEmail())
+                .provider(authAccount.getProvider())
+                .nickname(user.getNickname())
+                .createdAt(user.getCreatedAt())
+                .level(user.getLevel())
+                .ink(user.getInk())
+                .lastLoginAt(user.getLastLoginAt())
+                .status(user.getStatus())
+                .deletedAt(user.getDeletedAt())
+                .purgeAt(user.getPurgeAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/egobook_be/domain/user/service/AdminUserService.java
+++ b/src/main/java/com/example/egobook_be/domain/user/service/AdminUserService.java
@@ -2,12 +2,19 @@ package com.example.egobook_be.domain.user.service;
 
 import com.example.egobook_be.domain.auth.entity.AuthAccount;
 import com.example.egobook_be.domain.auth.repository.AuthAccountRepository;
+import com.example.egobook_be.domain.diary.repository.DiaryRepository;
+import com.example.egobook_be.domain.letters.repository.PlazaLetterReplyRepository;
+import com.example.egobook_be.domain.letters.repository.PlazaLetterRepository;
+import com.example.egobook_be.domain.question.repository.QuestionAnswerRepository;
 import com.example.egobook_be.domain.user.dto.AdminUserInfoResDto;
+import com.example.egobook_be.domain.user.dto.AdminUserStatsResDto;
 import com.example.egobook_be.domain.user.dto.SearchUserResDto;
+import com.example.egobook_be.domain.user.entity.Ability;
 import com.example.egobook_be.domain.user.entity.User;
 import com.example.egobook_be.domain.user.enums.UserStatus;
 import com.example.egobook_be.domain.user.exception.AdminUserErrorCode;
 import com.example.egobook_be.domain.user.mapper.UserMapper;
+import com.example.egobook_be.domain.user.repository.AbilityRepository;
 import com.example.egobook_be.domain.user.repository.UserRepository;
 import com.example.egobook_be.global.exception.CustomException;
 import com.example.egobook_be.global.response.SliceResponse;
@@ -27,6 +34,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class AdminUserService {
     private final UserRepository userRepository;
     private final AuthAccountRepository authAccountRepository;
+    private final AbilityRepository abilityRepository;
+    private final DiaryRepository diaryRepository;
+    private final PlazaLetterRepository plazaLetterRepository;
+    private final PlazaLetterReplyRepository plazaLetterReplyRepository;
+    private final QuestionAnswerRepository questionAnswerRepository;
     private final UserMapper userMapper;
 
     // 페이지 최대 크기 제한
@@ -58,12 +70,41 @@ public class AdminUserService {
         return SliceResponse.of(resDtos);
     }
 
+    /**
+     * 관리자가 특정 사용자의 기본 정보를 조회하는 함수
+     * @param userId : 조회할 사용자의 PK
+     * @return AdminUserInfoResDto
+     */
     @Transactional(readOnly = true)
     public AdminUserInfoResDto getUserInfo(Long userId) {
         User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(AdminUserErrorCode.USER_NOT_FOUND));
         AuthAccount authAccount = authAccountRepository.findByUser(user).orElseThrow(() -> new CustomException(AdminUserErrorCode.AUTH_ACCOUNT_NOT_FOUND));
         log.info("관리자 회원 기본 정보 조회 성공 - userId: {}", userId);
         return userMapper.toAdminUserInfoResDto(user, authAccount);
+    }
+
+    /**
+     * 특정 사용자의 활동 통계를 조회하는 함수
+     * @param userId : 활동 통계를 조회할 사용자의 PK
+     * @return AdminUserStatsResDto : 해당 사용자의 활동 통계 dto
+     */
+    @Transactional(readOnly = true)
+    public AdminUserStatsResDto getUserStats(Long userId) {
+        // 1. 해당 사용자, 사용자의 능력치 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(AdminUserErrorCode.USER_NOT_FOUND));
+        Ability ability = abilityRepository.findByUser(user)
+                .orElseThrow(() -> new CustomException(AdminUserErrorCode.ABILITY_NOT_FOUND));
+
+        // 2. 해당 사용자의 각 활동(일기, 편지, 편지 답변, 오늘의 질문)의 횟수 조회
+        long diaryCount = diaryRepository.countByUser(user);
+        long letterCount = plazaLetterRepository.countBySenderId(userId);
+        long letterReplyCount = plazaLetterReplyRepository.countByReplierId(userId);
+        long questionAnswerCount = questionAnswerRepository.countByUser(user);
+
+        log.info("관리자 회원 활동 통계 조회 성공 - userId: {}", userId);
+
+        return userMapper.toAdminUserStatsResDto(user, ability, diaryCount, letterCount, letterReplyCount, questionAnswerCount);
     }
 
     private boolean isKeywordNullOrBlank(String keyword) {

--- a/src/main/java/com/example/egobook_be/domain/user/service/AdminUserService.java
+++ b/src/main/java/com/example/egobook_be/domain/user/service/AdminUserService.java
@@ -1,6 +1,8 @@
 package com.example.egobook_be.domain.user.service;
 
+import com.example.egobook_be.domain.user.dto.AdminUserInfoResDto;
 import com.example.egobook_be.domain.user.dto.SearchUserResDto;
+import com.example.egobook_be.domain.user.entity.User;
 import com.example.egobook_be.domain.user.enums.UserStatus;
 import com.example.egobook_be.domain.user.exception.AdminUserErrorCode;
 import com.example.egobook_be.domain.user.repository.UserRepository;
@@ -49,6 +51,14 @@ public class AdminUserService {
         Slice<SearchUserResDto> resDtos = userRepository.findUsersByKeywordAndStatus(keyword, status, pageable);
         log.info("관리자 회원 리스트 조회 성공 - keyword: {}, status: {}, page: {}, size: {}", keyword, status, validPage, validSize);
         return SliceResponse.of(resDtos);
+    }
+
+    @Transactional(readOnly = true)
+    public AdminUserInfoResDto getUserInfo(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(AdminUserErrorCode.USER_NOT_FOUND));
+        log.info("관리자 회원 기본 정보 조회 성공 - userId: {}", userId);
+        return AdminUserInfoResDto.from(user);
     }
 
     private boolean isKeywordNullOrBlank(String keyword) {

--- a/src/main/java/com/example/egobook_be/domain/user/service/AdminUserService.java
+++ b/src/main/java/com/example/egobook_be/domain/user/service/AdminUserService.java
@@ -1,10 +1,13 @@
 package com.example.egobook_be.domain.user.service;
 
+import com.example.egobook_be.domain.auth.entity.AuthAccount;
+import com.example.egobook_be.domain.auth.repository.AuthAccountRepository;
 import com.example.egobook_be.domain.user.dto.AdminUserInfoResDto;
 import com.example.egobook_be.domain.user.dto.SearchUserResDto;
 import com.example.egobook_be.domain.user.entity.User;
 import com.example.egobook_be.domain.user.enums.UserStatus;
 import com.example.egobook_be.domain.user.exception.AdminUserErrorCode;
+import com.example.egobook_be.domain.user.mapper.UserMapper;
 import com.example.egobook_be.domain.user.repository.UserRepository;
 import com.example.egobook_be.global.exception.CustomException;
 import com.example.egobook_be.global.response.SliceResponse;
@@ -23,6 +26,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class AdminUserService {
     private final UserRepository userRepository;
+    private final AuthAccountRepository authAccountRepository;
+    private final UserMapper userMapper;
 
     // 페이지 최대 크기 제한
     private static final int MAX_PAGE_SIZE = 10;
@@ -55,10 +60,10 @@ public class AdminUserService {
 
     @Transactional(readOnly = true)
     public AdminUserInfoResDto getUserInfo(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(AdminUserErrorCode.USER_NOT_FOUND));
+        User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(AdminUserErrorCode.USER_NOT_FOUND));
+        AuthAccount authAccount = authAccountRepository.findByUser(user).orElseThrow(() -> new CustomException(AdminUserErrorCode.AUTH_ACCOUNT_NOT_FOUND));
         log.info("관리자 회원 기본 정보 조회 성공 - userId: {}", userId);
-        return AdminUserInfoResDto.from(user);
+        return userMapper.toAdminUserInfoResDto(user, authAccount);
     }
 
     private boolean isKeywordNullOrBlank(String keyword) {


### PR DESCRIPTION
## #️⃣연관된 이슈
- #165 

## 📝작업 내용
- CLAUDE CODE 연동
- 관리자가 특정 사용자의 기본 정보를 조회하는 API
- 관리자가 특정 사용자의 활동 통계를 조회하는 API
- User Entity의 CounselTone 컬럼(AI 주간 상담 말투)의 Default값이 설정되어있지 않은 것 수

### 스크린샷
1. 특정 사용자 기본 정보 조회

<img width="1300" height="639" alt="image" src="https://github.com/user-attachments/assets/24a4b1f9-d416-4dd4-bde9-1e81d841c06b" />

2. 특정 사용자 활동 통계 조회
<img width="1298" height="802" alt="image" src="https://github.com/user-attachments/assets/19c342d2-dfaf-4e8d-98c5-3fe462ac3870" />
