### PR TITLE
✨Feat: 콘텐츠 관리자 API

### DIFF
--- a/src/main/java/com/example/egobook_be/domain/diary/entity/Diary.java
+++ b/src/main/java/com/example/egobook_be/domain/diary/entity/Diary.java
@@ -41,6 +41,7 @@ public class Diary extends BaseTimeEntity {
     @CollectionTable(name = "diary_type", joinColumns = @JoinColumn(name = "diary_id"))
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
+    @Builder.Default
     private Set<DiaryType> type = EnumSet.noneOf(DiaryType.class);
     private LocalDateTime writtenAt;
 

--- a/src/main/java/com/example/egobook_be/domain/ego_room/entity/DailyPraiseSendFailLog.java
+++ b/src/main/java/com/example/egobook_be/domain/ego_room/entity/DailyPraiseSendFailLog.java
@@ -1,0 +1,51 @@
+package com.example.egobook_be.domain.ego_room.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * AI 일간 칭찬서 발송 실패 로그
+ * AiScheduler에서 createDailyPraise() 실패 시 기록
+ */
+@Entity
+@Table(name = "daily_praise_send_fail_log")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class DailyPraiseSendFailLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    /** 발송 대상 날짜 */
+    @Column(nullable = false)
+    private LocalDate targetDate;
+
+    /** 실패 사유 (FCM_TOKEN_NOT_FOUND, AI_RESPONSE_TIMEOUT 등) */
+    @Column(nullable = false, length = 100)
+    private String reason;
+
+    @Column(nullable = false)
+    private LocalDateTime failedAt;
+
+    /** 재발송 완료 여부 */
+    @Column(nullable = false)
+    @Builder.Default
+    private boolean resent = false;
+
+    @Column
+    private LocalDateTime resentAt;
+
+    public void markResent() {
+        this.resent = true;
+        this.resentAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/example/egobook_be/domain/ego_room/entity/DailyPraiseSendFailLog.java
+++ b/src/main/java/com/example/egobook_be/domain/ego_room/entity/DailyPraiseSendFailLog.java
@@ -1,5 +1,6 @@
 package com.example.egobook_be.domain.ego_room.entity;
 
+import com.example.egobook_be.domain.ego_room.enums.SendFailReason;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -30,8 +31,9 @@ public class DailyPraiseSendFailLog {
     private LocalDate targetDate;
 
     /** 실패 사유 (FCM_TOKEN_NOT_FOUND, AI_RESPONSE_TIMEOUT 등) */
-    @Column(nullable = false, length = 100)
-    private String reason;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private SendFailReason reason;
 
     @Column(nullable = false)
     private LocalDateTime failedAt;

--- a/src/main/java/com/example/egobook_be/domain/ego_room/entity/WeeklyReportSendFailLog.java
+++ b/src/main/java/com/example/egobook_be/domain/ego_room/entity/WeeklyReportSendFailLog.java
@@ -1,0 +1,49 @@
+package com.example.egobook_be.domain.ego_room.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * AI 주간 리포트 발송 실패 로그
+ * AiScheduler에서 createWeeklyAnalysis() 실패 시 기록
+ */
+@Entity
+@Table(name = "weekly_report_send_fail_log")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class WeeklyReportSendFailLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    /** 해당 주의 월요일 날짜 */
+    @Column(nullable = false)
+    private LocalDate weekStartDate;
+
+    @Column(nullable = false, length = 100)
+    private String reason;
+
+    @Column(nullable = false)
+    private LocalDateTime failedAt;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private boolean resent = false;
+
+    @Column
+    private LocalDateTime resentAt;
+
+    public void markResent() {
+        this.resent = true;
+        this.resentAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/example/egobook_be/domain/ego_room/entity/WeeklyReportSendFailLog.java
+++ b/src/main/java/com/example/egobook_be/domain/ego_room/entity/WeeklyReportSendFailLog.java
@@ -1,5 +1,6 @@
 package com.example.egobook_be.domain.ego_room.entity;
 
+import com.example.egobook_be.domain.ego_room.enums.SendFailReason;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -29,8 +30,9 @@ public class WeeklyReportSendFailLog {
     @Column(nullable = false)
     private LocalDate weekStartDate;
 
-    @Column(nullable = false, length = 100)
-    private String reason;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private SendFailReason reason;
 
     @Column(nullable = false)
     private LocalDateTime failedAt;

--- a/src/main/java/com/example/egobook_be/domain/ego_room/enums/SendFailReason.java
+++ b/src/main/java/com/example/egobook_be/domain/ego_room/enums/SendFailReason.java
@@ -1,0 +1,8 @@
+package com.example.egobook_be.domain.ego_room.enums;
+
+public enum SendFailReason {
+    FCM_TOKEN_NOT_FOUND,
+    AI_RESPONSE_TIMEOUT,
+    USER_NOT_FOUND,
+    UNKNOWN_ERROR
+}

--- a/src/main/java/com/example/egobook_be/domain/ego_room/repository/DailyPraiseRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/ego_room/repository/DailyPraiseRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 public interface DailyPraiseRepository extends JpaRepository<DailyPraise, Long> {
@@ -16,5 +17,19 @@ public interface DailyPraiseRepository extends JpaRepository<DailyPraise, Long> 
 
     Optional<DailyPraise> findByUserIdAndPraiseDate(Long userId, LocalDate praiseDate);
 
+    // 날짜별 발송 성공 건수 집계 (관리자 API용)
+    @Query("""
+        SELECT dp.praiseDate, COUNT(dp)
+        FROM DailyPraise dp
+        WHERE dp.praiseDate BETWEEN :startDate AND :endDate
+        GROUP BY dp.praiseDate
+        ORDER BY dp.praiseDate ASC
+    """)
+    List<Object[]> countSuccessByDateRange(
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate
+    );
+
+    long countByPraiseDateBetween(LocalDate startDate, LocalDate endDate);
 
 }

--- a/src/main/java/com/example/egobook_be/domain/ego_room/repository/DailyPraiseSendFailLogRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/ego_room/repository/DailyPraiseSendFailLogRepository.java
@@ -1,0 +1,28 @@
+package com.example.egobook_be.domain.ego_room.repository;
+
+import com.example.egobook_be.domain.ego_room.entity.DailyPraiseSendFailLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface DailyPraiseSendFailLogRepository extends JpaRepository<DailyPraiseSendFailLog, Long> {
+
+    List<DailyPraiseSendFailLog> findByTargetDateBetweenOrderByFailedAtDesc(
+            LocalDate startDate, LocalDate endDate
+    );
+
+    @Query("""
+        SELECT f.targetDate, COUNT(f)
+        FROM DailyPraiseSendFailLog f
+        WHERE f.targetDate BETWEEN :startDate AND :endDate
+        GROUP BY f.targetDate
+        ORDER BY f.targetDate ASC
+    """)
+    List<Object[]> countByDateRange(
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate
+    );
+}

--- a/src/main/java/com/example/egobook_be/domain/ego_room/repository/WeeklyCounselRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/ego_room/repository/WeeklyCounselRepository.java
@@ -33,4 +33,7 @@ public interface WeeklyCounselRepository extends JpaRepository<WeeklyCounsel, Lo
     Optional<WeeklyCounsel> findByIdAndUser(Long id, User user);
     Optional<WeeklyCounsel> findTopByUserAndStartDateLessThanOrderByStartDateDesc(User user, LocalDate startDate);
 
+    // 날짜 범위 내 생성된 WeeklyCounsel 수 (관리자 API용 - 주간 리포트 발송 성공 건수)
+    long countByStartDateBetween(LocalDate startDate, LocalDate endDate);
+
 }

--- a/src/main/java/com/example/egobook_be/domain/ego_room/repository/WeeklyReportSendFailLogRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/ego_room/repository/WeeklyReportSendFailLogRepository.java
@@ -1,0 +1,14 @@
+package com.example.egobook_be.domain.ego_room.repository;
+
+import com.example.egobook_be.domain.ego_room.entity.WeeklyReportSendFailLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface WeeklyReportSendFailLogRepository extends JpaRepository<WeeklyReportSendFailLog, Long> {
+
+    List<WeeklyReportSendFailLog> findByWeekStartDateBetweenOrderByFailedAtDesc(
+            LocalDate startDate, LocalDate endDate
+    );
+}

--- a/src/main/java/com/example/egobook_be/domain/ego_room/scheduler/AiScheduler.java
+++ b/src/main/java/com/example/egobook_be/domain/ego_room/scheduler/AiScheduler.java
@@ -1,5 +1,9 @@
 package com.example.egobook_be.domain.ego_room.scheduler;
 
+import com.example.egobook_be.domain.ego_room.entity.DailyPraiseSendFailLog;
+import com.example.egobook_be.domain.ego_room.entity.WeeklyReportSendFailLog;
+import com.example.egobook_be.domain.ego_room.repository.DailyPraiseSendFailLogRepository;
+import com.example.egobook_be.domain.ego_room.repository.WeeklyReportSendFailLogRepository;
 import com.example.egobook_be.domain.ego_room.service.EgoRoomService;
 import com.example.egobook_be.domain.user.entity.User;
 import com.example.egobook_be.domain.user.repository.UserRepository;
@@ -9,6 +13,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Component
@@ -18,6 +23,8 @@ public class AiScheduler {
 
     private final UserRepository userRepository;
     private final EgoRoomService egoRoomService;
+    private final DailyPraiseSendFailLogRepository dailyPraiseFailLogRepo;    // ← 추가
+    private final WeeklyReportSendFailLogRepository weeklyReportFailLogRepo;  // ← 추가
 
 
     //0시 1분마다 실행
@@ -36,6 +43,14 @@ public class AiScheduler {
                 egoRoomService.createDailyPraise(user.getId(), yesterday);
             } catch (Exception e) {
                 log.error("[스케줄러 오류] 유저 {}의 일간 칭찬 생성 중 실패: {}", user.getId(), e.getMessage());
+
+                // 실패 로그 저장
+                dailyPraiseFailLogRepo.save(DailyPraiseSendFailLog.builder()
+                        .userId(user.getId())
+                        .targetDate(yesterday)
+                        .reason(resolveReason(e))
+                        .failedAt(LocalDateTime.now())
+                        .build());
             }
         }
 
@@ -57,9 +72,25 @@ public class AiScheduler {
                 egoRoomService.createWeeklyAnalysis(user.getId(), lastMonday);
             } catch (Exception e) {
                 log.error("[스케줄러 오류] 유저 {}의 주간 분석 생성 중 실패: {}", user.getId(), e.getMessage());
+
+                // 실패 로그 저장
+                weeklyReportFailLogRepo.save(WeeklyReportSendFailLog.builder()
+                        .userId(user.getId())
+                        .weekStartDate(lastMonday)
+                        .reason(resolveReason(e))
+                        .failedAt(LocalDateTime.now())
+                        .build());
             }
         }
 
         log.info("[스케줄러 종료] 주간 분석 생성이 완료되었습니다.");
+    }
+
+    private String resolveReason(Exception e) {
+        String msg = e.getMessage() != null ? e.getMessage().toUpperCase() : "";
+        if (msg.contains("FCM") || msg.contains("TOKEN")) return "FCM_TOKEN_NOT_FOUND";
+        if (msg.contains("TIMEOUT") || msg.contains("AI"))  return "AI_RESPONSE_TIMEOUT";
+        if (msg.contains("USER"))                            return "USER_NOT_FOUND";
+        return "UNKNOWN_ERROR";
     }
 }

--- a/src/main/java/com/example/egobook_be/domain/ego_room/scheduler/AiScheduler.java
+++ b/src/main/java/com/example/egobook_be/domain/ego_room/scheduler/AiScheduler.java
@@ -2,6 +2,7 @@ package com.example.egobook_be.domain.ego_room.scheduler;
 
 import com.example.egobook_be.domain.ego_room.entity.DailyPraiseSendFailLog;
 import com.example.egobook_be.domain.ego_room.entity.WeeklyReportSendFailLog;
+import com.example.egobook_be.domain.ego_room.enums.SendFailReason;
 import com.example.egobook_be.domain.ego_room.repository.DailyPraiseSendFailLogRepository;
 import com.example.egobook_be.domain.ego_room.repository.WeeklyReportSendFailLogRepository;
 import com.example.egobook_be.domain.ego_room.service.EgoRoomService;
@@ -86,11 +87,11 @@ public class AiScheduler {
         log.info("[스케줄러 종료] 주간 분석 생성이 완료되었습니다.");
     }
 
-    private String resolveReason(Exception e) {
+    private SendFailReason resolveReason(Exception e) {
         String msg = e.getMessage() != null ? e.getMessage().toUpperCase() : "";
-        if (msg.contains("FCM") || msg.contains("TOKEN")) return "FCM_TOKEN_NOT_FOUND";
-        if (msg.contains("TIMEOUT") || msg.contains("AI"))  return "AI_RESPONSE_TIMEOUT";
-        if (msg.contains("USER"))                            return "USER_NOT_FOUND";
-        return "UNKNOWN_ERROR";
+        if (msg.contains("FCM") || msg.contains("TOKEN")) return SendFailReason.FCM_TOKEN_NOT_FOUND;
+        if (msg.contains("TIMEOUT") || msg.contains("AI"))  return SendFailReason.AI_RESPONSE_TIMEOUT;
+        if (msg.contains("USER"))                            return SendFailReason.USER_NOT_FOUND;
+        return SendFailReason.UNKNOWN_ERROR;
     }
 }

--- a/src/main/java/com/example/egobook_be/domain/ego_room/service/EgoRoomService.java
+++ b/src/main/java/com/example/egobook_be/domain/ego_room/service/EgoRoomService.java
@@ -180,11 +180,9 @@ public class EgoRoomService {
                     .build();
         }
 
-        // 잠금이 풀려있으면 읽음 처리 후 전체 데이터 반환
         counsel.markAsRead();
         return WeeklyCounselDetailResDto.from(counsel, false);
     }
-
 
     @Transactional
     public CounselToneResDto updateNextWeekTone(Long userId, CounselTone toneStyle) {
@@ -206,7 +204,6 @@ public class EgoRoomService {
         Optional<DailyPraise> existingPraise = dailyPraiseRepository.findByUserIdAndPraiseDate(userId, date);
         if (existingPraise.isPresent()) {
             log.info("이미 생성된 칭찬이 있어 스킵합니다. (유저: {}, 날짜: {})", userId, date);
-            existingPraise.get();
             return;
         }
 
@@ -247,7 +244,45 @@ public class EgoRoomService {
         }
     }
 
-    // 주간 분석서 생성 로직
+    // ── 일간 칭찬서 재발송 (관리자 수동 재발송용) ─────────────────────────────
+    // createDailyPraise와 동일한 로직, 중복 체크 없이 강제 재생성
+    @Transactional
+    public void resendDailyPraise(Long userId, LocalDate date) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("유저를 찾을 수 없습니다. ID: " + userId));
+        List<Diary> diaries = diaryRepository.findByUserIdAndDate(userId, date);
+
+        if (diaries.isEmpty()) return;
+
+        String combinedContent = diaries.stream()
+                .map(Diary::getContent)
+                .collect(Collectors.joining("\n"));
+
+        String praiseContent = dailyPraiseAiService.getPraise(combinedContent);
+
+        DailyPraise dailyPraise = DailyPraise.builder()
+                .user(user)
+                .praiseDate(date)
+                .content(praiseContent)
+                .build();
+
+        dailyPraiseRepository.save(dailyPraise);
+
+        try {
+            notificationService.createNotification(
+                    userId,
+                    NotificationType.PRAISE,
+                    dailyPraise.getId(),
+                    dailyPraise.getPraiseDate().format(DateTimeFormatter.ofPattern("M.d"))
+            );
+        } catch (Exception e) {
+            log.error("일간 칭찬서 재발송 알림 생성 실패. UserId: {}, dailyPraiseId: {}",
+                    userId, dailyPraise.getId(), e);
+        }
+    }
+
+    // ── 주간 분석서 생성 (스케줄러용) ────────────────────────────────────────
     @Transactional
     public void createWeeklyAnalysis(Long userId, LocalDate startDate) {
 
@@ -258,7 +293,8 @@ public class EgoRoomService {
             return;
         }
 
-        String lastSummary = weeklyCounselRepository.findTopByUserAndStartDateLessThanOrderByStartDateDesc(user, startDate)
+        String lastSummary = weeklyCounselRepository
+                .findTopByUserAndStartDateLessThanOrderByStartDateDesc(user, startDate)
                 .map(WeeklyCounsel::getSummary)
                 .orElse("첫 주 분석입니다. 이전 데이터가 없습니다.");
 
@@ -311,6 +347,69 @@ public class EgoRoomService {
             );
         } catch (Exception e) {
             log.error("주간 리포트 도착 알림 생성 실패. UserId: {}, CounselId: {}",
+                    userId, counsel.getId(), e);
+        }
+    }
+
+    // ── 주간 분석서 재발송 (관리자 수동 재발송용) ─────────────────────────────
+    // createWeeklyAnalysis와 동일한 로직, 중복 체크 없이 강제 재생성
+    @Transactional
+    public void resendWeeklyAnalysis(Long userId, LocalDate startDate) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("유저를 찾을 수 없습니다."));
+
+        String lastSummary = weeklyCounselRepository
+                .findTopByUserAndStartDateLessThanOrderByStartDateDesc(user, startDate)
+                .map(WeeklyCounsel::getSummary)
+                .orElse("첫 주 분석입니다. 이전 데이터가 없습니다.");
+
+        String userTone = (user.getCounselingTone() != null) ? user.getCounselingTone().name() : "SOFT";
+
+        LocalDate endDate = startDate.plusDays(6);
+
+        List<Diary> diaries = diaryRepository.findByUserIdAndDateBetweenOrderByDateAsc(userId, startDate, endDate);
+        if (diaries.isEmpty()) return;
+
+        String formattedDiaries = diaries.stream()
+                .collect(Collectors.groupingBy(
+                        diary -> diary.getCreatedAt().toLocalDate(),
+                        TreeMap::new,
+                        Collectors.mapping(diary -> {
+                            String scoreInfo = (diary.getEmotionLevel() != null)
+                                    ? String.format("[%d점/5점]", diary.getEmotionLevel())
+                                    : "[점수 미기록]";
+                            return String.format("%s %s", scoreInfo, diary.getContent());
+                        }, Collectors.joining("\n- "))
+                ))
+                .entrySet().stream()
+                .map(entry -> String.format("[%s]\n- %s", entry.getKey(), entry.getValue()))
+                .collect(Collectors.joining("\n\n"));
+
+        WeeklyCounselResDto aiResponse = weeklyAnalysisAiService.getAnalysis(
+                user.getNickname(), formattedDiaries, lastSummary, userTone);
+
+        WeeklyCounsel counsel = WeeklyCounsel.builder()
+                .user(user)
+                .startDate(startDate)
+                .endDate(endDate)
+                .summary(aiResponse.summary())
+                .praisePoints(aiResponse.praisePoints())
+                .improvementPoints(aiResponse.improvementPoints())
+                .managementAdvice(aiResponse.managementAdvice())
+                .supportMessage(aiResponse.supportMessage())
+                .build();
+
+        weeklyCounselRepository.save(counsel);
+
+        try {
+            notificationService.createNotification(
+                    userId,
+                    NotificationType.REPORT,
+                    counsel.getId()
+            );
+        } catch (Exception e) {
+            log.error("주간 리포트 재발송 알림 생성 실패. UserId: {}, CounselId: {}",
                     userId, counsel.getId(), e);
         }
     }

--- a/src/main/java/com/example/egobook_be/domain/letters/entity/AiRequestCountLog.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/entity/AiRequestCountLog.java
@@ -1,0 +1,30 @@
+package com.example.egobook_be.domain.letters.entity;
+
+import com.example.egobook_be.domain.letters.enums.BlockType;
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+/**
+ * 나쁜말 AI 전체 요청 수 카운트
+ * blockRate = blockedCount / totalCount * 100 계산용
+ */
+@Entity
+@Table(name = "ai_request_count_log")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class AiRequestCountLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private BlockType type;  // LETTER, REPLY, PRAISE
+
+    @Column(nullable = false)
+    private LocalDateTime requestedAt;
+}

--- a/src/main/java/com/example/egobook_be/domain/letters/entity/BadWordBlockLog.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/entity/BadWordBlockLog.java
@@ -1,0 +1,53 @@
+package com.example.egobook_be.domain.letters.entity;
+
+import com.example.egobook_be.domain.letters.enums.BlockType;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 나쁜말 AI 차단 이력
+ * WordClientService.shouldBlock() 이 true 일 때 기록
+ * 차단 기준: percentage >= 80.0
+ */
+@Entity
+@Table(name = "bad_word_block_log")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class BadWordBlockLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    /** 차단 유형 (LETTER, REPLY, PRAISE) */
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private BlockType type;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String originalText;
+
+    /** 감지된 나쁜말 목록 */
+    @ElementCollection
+    @CollectionTable(
+            name = "bad_word_block_log_words",
+            joinColumns = @JoinColumn(name = "block_log_id")
+    )
+    @Column(name = "word")
+    private List<String> badWords;
+
+    /** 차단 점수 (0.0 ~ 1.0) */
+    @Column(nullable = false)
+    private double score;
+
+    @Column(nullable = false)
+    private LocalDateTime blockedAt;
+}

--- a/src/main/java/com/example/egobook_be/domain/letters/entity/LetterSendFailLog.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/entity/LetterSendFailLog.java
@@ -1,0 +1,33 @@
+package com.example.egobook_be.domain.letters.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+/**
+ * 편지 발송 실패 로그
+ * 수신자 배정 실패 등 편지 운영 중 발생한 실패 기록
+ */
+@Entity
+@Table(name = "letter_send_fail_log")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class LetterSendFailLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long letterId;
+
+    /** 실패 사유 (NO_RECEIVER_AVAILABLE, FCM_SEND_FAIL 등) */
+    @Column(nullable = false, length = 100)
+    private String reason;
+
+    @Column(nullable = false)
+    private LocalDateTime failedAt;
+}

--- a/src/main/java/com/example/egobook_be/domain/letters/enums/BlockType.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/enums/BlockType.java
@@ -1,0 +1,8 @@
+package com.example.egobook_be.domain.letters.enums;
+
+public enum BlockType {
+    LETTER,
+    REPLY,
+    PRAISE,
+    ALL  // 조회 필터용 (저장 시엔 사용 안 함)
+}

--- a/src/main/java/com/example/egobook_be/domain/letters/repository/AiRequestCountLogRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/repository/AiRequestCountLogRepository.java
@@ -1,0 +1,20 @@
+package com.example.egobook_be.domain.letters.repository;
+
+import com.example.egobook_be.domain.letters.entity.AiRequestCountLog;
+import com.example.egobook_be.domain.letters.enums.BlockType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface AiRequestCountLogRepository extends JpaRepository<AiRequestCountLog, Long> {
+
+    // 전체 유형 요청 수
+    long countByRequestedAtBetween(LocalDateTime start, LocalDateTime end);
+
+    // 특정 유형 요청 수
+    long countByRequestedAtBetweenAndType(
+            LocalDateTime start, LocalDateTime end, BlockType type
+    );
+}

--- a/src/main/java/com/example/egobook_be/domain/letters/repository/BadWordBlockLogRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/repository/BadWordBlockLogRepository.java
@@ -1,0 +1,19 @@
+package com.example.egobook_be.domain.letters.repository;
+
+import com.example.egobook_be.domain.letters.entity.BadWordBlockLog;
+import com.example.egobook_be.domain.letters.enums.BlockType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface BadWordBlockLogRepository extends JpaRepository<BadWordBlockLog, Long> {
+
+    List<BadWordBlockLog> findByBlockedAtBetweenOrderByBlockedAtDesc(
+            LocalDateTime start, LocalDateTime end
+    );
+
+    List<BadWordBlockLog> findByBlockedAtBetweenAndTypeOrderByBlockedAtDesc(
+            LocalDateTime start, LocalDateTime end, BlockType type
+    );
+}

--- a/src/main/java/com/example/egobook_be/domain/letters/repository/LetterSendFailLogRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/repository/LetterSendFailLogRepository.java
@@ -1,0 +1,14 @@
+package com.example.egobook_be.domain.letters.repository;
+
+import com.example.egobook_be.domain.letters.entity.LetterSendFailLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface LetterSendFailLogRepository extends JpaRepository<LetterSendFailLog, Long> {
+
+    List<LetterSendFailLog> findByFailedAtBetweenOrderByFailedAtDesc(
+            LocalDateTime start, LocalDateTime end
+    );
+}

--- a/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterRepository.java
@@ -163,5 +163,28 @@ public interface PlazaLetterRepository extends JpaRepository<PlazaLetter, Long> 
             @Param("userId") Long userId
     );
 
-}
+    // ── 관리자 API용 - 날짜 범위 + status 집계 ──────────────────────────────
 
+    @Query("""
+        SELECT COUNT(l) FROM PlazaLetter l
+        WHERE l.createdAt BETWEEN :start AND :end
+          AND l.status = :status
+    """)
+    long countByCreatedAtBetweenAndStatus(
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end,
+            @Param("status") PlazaLetterStatus status
+    );
+
+    @Query("""
+        SELECT COUNT(l) FROM PlazaLetter l
+        WHERE l.createdAt BETWEEN :start AND :end
+          AND l.status IN :statuses
+    """)
+    long countByCreatedAtBetweenAndStatuses(
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end,
+            @Param("statuses") List<PlazaLetterStatus> statuses
+    );
+
+}

--- a/src/main/java/com/example/egobook_be/domain/letters/service/PlazaLetterService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/PlazaLetterService.java
@@ -11,6 +11,9 @@ import com.example.egobook_be.domain.letters.dto.response.WordDetectResponse;
 import com.example.egobook_be.domain.letters.dto.response.*;
 import com.example.egobook_be.domain.letters.enums.LettersErrorCode;
 import com.example.egobook_be.domain.letters.enums.PlazaLetterColor;
+import com.example.egobook_be.domain.letters.entity.BadWordBlockLog;
+import com.example.egobook_be.domain.letters.enums.BlockType;
+import com.example.egobook_be.domain.letters.repository.BadWordBlockLogRepository;
 import com.example.egobook_be.domain.letters.repository.PlazaLetterReplyRepository;
 import com.example.egobook_be.domain.letters.repository.PlazaLetterRepository;
 import com.example.egobook_be.domain.letters.repository.PlazaLetterThreadRepository;
@@ -61,6 +64,7 @@ public class PlazaLetterService {
     private final MissionRepository missionRepository;
     private final AbilityRepository abilityRepository;
     private final WordClientService wordClient;
+    private final BadWordBlockLogRepository badWordBlockLogRepo;
     private final InkLogUtil inkLogUtil;
 
     private final PlazaLetterMapper plazaLetterMapper;
@@ -79,10 +83,18 @@ public class PlazaLetterService {
                 .orElseGet(InboxNextResponse::empty);
     }
 
-    private void enforceWordAiOrThrow(String text) {
+    private void enforceWordAiOrThrow(String text, Long userId, BlockType blockType) {
         try {
             WordDetectResponse res = wordClient.detect(text);
             if (wordClient.shouldBlock(res)) {
+                badWordBlockLogRepo.save(BadWordBlockLog.builder()
+                        .userId(userId)
+                        .type(blockType)
+                        .originalText(text)
+                        .badWords(res.getBadWords() != null ? res.getBadWords() : List.of())
+                        .score(res.getPercentage() / 100.0)
+                        .blockedAt(LocalDateTime.now())
+                        .build());
                 throw new CustomException(LettersErrorCode.AI_MODERATION_FAILED);
             }
         } catch (CustomException e) {
@@ -220,7 +232,15 @@ public class PlazaLetterService {
         }
 
         if (wordClient.shouldBlock(result)) {
-            // 욕설 감지 → 편지 삭제 or BLOCKED 처리
+            // 욕설 감지 → 차단 로그 저장 후 편지 삭제
+            badWordBlockLogRepo.save(BadWordBlockLog.builder()
+                    .userId(letter.getSenderId())
+                    .type(BlockType.LETTER)
+                    .originalText(result.getText())
+                    .badWords(result.getBadWords() != null ? result.getBadWords() : List.of())
+                    .score(result.getPercentage() / 100.0)
+                    .blockedAt(LocalDateTime.now())
+                    .build());
             plazaLetterRepository.delete(letter);
             return;
         }
@@ -395,7 +415,7 @@ public class PlazaLetterService {
             throw new CustomException(LettersErrorCode.ALREADY_REPLIED);
         }
 
-        enforceWordAiOrThrow(text);
+        enforceWordAiOrThrow(text, userId, BlockType.REPLY);
 
         // 6. plazaLetterReplyRepository로 PlazaLetterReply를 저장하기 전, 해당 사용자가 답장한 편지가 오늘 처음 답장한 편지인지 확인한다.
         ZoneId zoneId = ZoneId.of("Asia/Seoul");

--- a/src/main/java/com/example/egobook_be/domain/letters/service/PlazaLetterService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/PlazaLetterService.java
@@ -13,10 +13,7 @@ import com.example.egobook_be.domain.letters.enums.LettersErrorCode;
 import com.example.egobook_be.domain.letters.enums.PlazaLetterColor;
 import com.example.egobook_be.domain.letters.entity.BadWordBlockLog;
 import com.example.egobook_be.domain.letters.enums.BlockType;
-import com.example.egobook_be.domain.letters.repository.BadWordBlockLogRepository;
-import com.example.egobook_be.domain.letters.repository.PlazaLetterReplyRepository;
-import com.example.egobook_be.domain.letters.repository.PlazaLetterRepository;
-import com.example.egobook_be.domain.letters.repository.PlazaLetterThreadRepository;
+import com.example.egobook_be.domain.letters.repository.*;
 import com.example.egobook_be.domain.notification.enums.NotificationType;
 import com.example.egobook_be.domain.notification.service.NotificationService;
 import com.example.egobook_be.domain.user.entity.Ability;
@@ -71,6 +68,8 @@ public class PlazaLetterService {
 
     private final NotificationService notificationService;
 
+    private final AiRequestCountLogRepository aiRequestCountLogRepo;
+
     @Value("${spring.cloud.aws.cloudfront.domain}")
     private String cloudfrontDomain;
 
@@ -84,6 +83,11 @@ public class PlazaLetterService {
     }
 
     private void enforceWordAiOrThrow(String text, Long userId, BlockType blockType) {
+        // AI 요청 수 카운트 저장
+        aiRequestCountLogRepo.save(AiRequestCountLog.builder()
+                .type(blockType)
+                .requestedAt(LocalDateTime.now())
+                .build());
         try {
             WordDetectResponse res = wordClient.detect(text);
             if (wordClient.shouldBlock(res)) {
@@ -223,6 +227,11 @@ public class PlazaLetterService {
     public void handleAiResult(Long letterId, WordDetectResponse result,
                                Long receiverId, LocalDateTime now,
                                PlazaLetterMode mode, User sender) {
+        aiRequestCountLogRepo.save(AiRequestCountLog.builder()
+                .type(BlockType.LETTER)
+                .requestedAt(LocalDateTime.now())
+                .build());
+
         PlazaLetter letter = plazaLetterRepository.findById(letterId).orElse(null);
         if (letter == null) return;
 

--- a/src/main/java/com/example/egobook_be/domain/user/controller/AdminContentController.java
+++ b/src/main/java/com/example/egobook_be/domain/user/controller/AdminContentController.java
@@ -1,0 +1,66 @@
+package com.example.egobook_be.domain.user.controller;
+
+import com.example.egobook_be.domain.letters.enums.BlockType;
+import com.example.egobook_be.domain.user.dto.ResendReqDto;
+import com.example.egobook_be.domain.user.dto.AdminContentResDto.*;
+import com.example.egobook_be.domain.user.service.AdminContentService;
+import com.example.egobook_be.global.response.GlobalResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+
+@RestController
+@RequiredArgsConstructor
+public class AdminContentController implements AdminContentControllerDocs {
+
+    private final AdminContentService adminContentService;
+
+    @Override
+    public ResponseEntity<GlobalResponse<DailyPraiseStatusRes>> getDailyPraiseStatus(
+            LocalDate startDate, LocalDate endDate) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(GlobalResponse.success(200, "일간 칭찬서 발송 현황 조회 성공",
+                        adminContentService.getDailyPraiseStatus(startDate, endDate)));
+    }
+
+    @Override
+    public ResponseEntity<GlobalResponse<ResendRes>> resendDailyPraise(ResendReqDto reqDto) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(GlobalResponse.success(200, "일간 칭찬서 재발송 처리 완료",
+                        adminContentService.resendDailyPraise(reqDto)));
+    }
+
+    @Override
+    public ResponseEntity<GlobalResponse<WeeklyReportStatusRes>> getWeeklyReportStatus(
+            LocalDate startDate, LocalDate endDate) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(GlobalResponse.success(200, "주간 리포트 발송 현황 조회 성공",
+                        adminContentService.getWeeklyReportStatus(startDate, endDate)));
+    }
+
+    @Override
+    public ResponseEntity<GlobalResponse<ResendRes>> resendWeeklyReport(ResendReqDto reqDto) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(GlobalResponse.success(200, "주간 리포트 재발송 처리 완료",
+                        adminContentService.resendWeeklyReport(reqDto)));
+    }
+
+    @Override
+    public ResponseEntity<GlobalResponse<LetterStatusRes>> getLetterStatus(
+            LocalDate startDate, LocalDate endDate) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(GlobalResponse.success(200, "편지 운영 현황 조회 성공",
+                        adminContentService.getLetterStatus(startDate, endDate)));
+    }
+
+    @Override
+    public ResponseEntity<GlobalResponse<BadWordStatusRes>> getBadWordStatus(
+            LocalDate startDate, LocalDate endDate, BlockType type) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(GlobalResponse.success(200, "나쁜말 AI 차단 현황 조회 성공",
+                        adminContentService.getBadWordStatus(startDate, endDate, type)));
+    }
+}

--- a/src/main/java/com/example/egobook_be/domain/user/controller/AdminContentControllerDocs.java
+++ b/src/main/java/com/example/egobook_be/domain/user/controller/AdminContentControllerDocs.java
@@ -1,0 +1,105 @@
+package com.example.egobook_be.domain.user.controller;
+
+import com.example.egobook_be.domain.letters.enums.BlockType;
+import com.example.egobook_be.domain.user.dto.ResendReqDto;
+import com.example.egobook_be.domain.user.dto.AdminContentResDto.*;
+import com.example.egobook_be.global.response.GlobalResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+
+@Tag(name = "Admin Content Controller", description = "콘텐츠 관리 관리자 API")
+@RequestMapping("/admin")
+public interface AdminContentControllerDocs {
+
+    @Operation(summary = "AI 일간 칭찬서 발송 현황 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "일간 칭찬서 발송 현황 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 날짜 범위", content = @Content),
+            @ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 필요", content = @Content)
+    })
+    @SecurityRequirement(name = "bearerAuth")
+    @GetMapping("/ai/daily-praise/status")
+    ResponseEntity<GlobalResponse<DailyPraiseStatusRes>> getDailyPraiseStatus(
+            @Parameter(description = "조회 시작일 (yyyy-MM-dd)", required = true)
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @Parameter(description = "조회 종료일 (yyyy-MM-dd)", required = true)
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate
+    );
+
+    @Operation(summary = "AI 일간 칭찬서 실패 건 수동 재발송")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "일간 칭찬서 재발송 처리 완료"),
+            @ApiResponse(responseCode = "400", description = "failIds가 비어 있음", content = @Content),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 필요", content = @Content)
+    })
+    @SecurityRequirement(name = "bearerAuth")
+    @PostMapping("/ai/daily-praise/resend")
+    ResponseEntity<GlobalResponse<ResendRes>> resendDailyPraise(
+            @RequestBody ResendReqDto reqDto
+    );
+
+    @Operation(summary = "AI 주간 리포트 발송 현황 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "주간 리포트 발송 현황 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 날짜 범위", content = @Content),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 필요", content = @Content)
+    })
+    @SecurityRequirement(name = "bearerAuth")
+    @GetMapping("/ai/weekly-report/status")
+    ResponseEntity<GlobalResponse<WeeklyReportStatusRes>> getWeeklyReportStatus(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate
+    );
+
+    @Operation(summary = "AI 주간 리포트 실패 건 수동 재발송")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "주간 리포트 재발송 처리 완료"),
+            @ApiResponse(responseCode = "400", description = "failIds가 비어 있음", content = @Content),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 필요", content = @Content)
+    })
+    @SecurityRequirement(name = "bearerAuth")
+    @PostMapping("/ai/weekly-report/resend")
+    ResponseEntity<GlobalResponse<ResendRes>> resendWeeklyReport(
+            @RequestBody ResendReqDto reqDto
+    );
+
+    @Operation(summary = "편지 운영 현황 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "편지 운영 현황 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 날짜 범위", content = @Content),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 필요", content = @Content)
+    })
+    @SecurityRequirement(name = "bearerAuth")
+    @GetMapping("/letters/status")
+    ResponseEntity<GlobalResponse<LetterStatusRes>> getLetterStatus(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate
+    );
+
+    @Operation(summary = "나쁜말 AI 차단 현황 조회",
+            description = "type: LETTER / REPLY / PRAISE / ALL (기본값 ALL). 차단 기준 80% 이상.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "나쁜말 AI 차단 현황 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 날짜 범위 또는 type 값", content = @Content),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 필요", content = @Content)
+    })
+    @SecurityRequirement(name = "bearerAuth")
+    @GetMapping("/ai/bad-words/status")
+    ResponseEntity<GlobalResponse<BadWordStatusRes>> getBadWordStatus(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+            @Parameter(description = "차단 유형 필터 (LETTER | REPLY | PRAISE | ALL)")
+            @RequestParam(required = false, defaultValue = "ALL") BlockType type
+    );
+}

--- a/src/main/java/com/example/egobook_be/domain/user/dto/AdminContentResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/user/dto/AdminContentResDto.java
@@ -1,0 +1,146 @@
+package com.example.egobook_be.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class AdminContentResDto {
+
+    // ── B1. 일간 칭찬서 발송 현황 ────────────────────────────────────────────
+
+    @Getter
+    @Builder
+    public static class DailyPraiseStatusRes {
+        private SummaryWithDaily summary;
+        private List<DailyStat> dailyStats;
+        private List<PraiseFailLog> failLogs;
+    }
+
+    @Getter
+    @Builder
+    public static class SummaryWithDaily {
+        private long scheduledCount;
+        private long successCount;
+        private long failCount;
+    }
+
+    @Getter
+    @Builder
+    public static class DailyStat {
+        private LocalDate date;
+        private long scheduledCount;
+        private long successCount;
+        private long failCount;
+    }
+
+    @Getter
+    @Builder
+    public static class PraiseFailLog {
+        private Long failId;
+        private Long userId;
+        private LocalDateTime failedAt;
+        private String reason;
+    }
+
+    // ── B2. 주간 리포트 발송 현황 ────────────────────────────────────────────
+
+    @Getter
+    @Builder
+    public static class WeeklyReportStatusRes {
+        private SimpleSummary summary;
+        private List<WeeklyFailLog> failLogs;
+    }
+
+    @Getter
+    @Builder
+    public static class SimpleSummary {
+        private long scheduledCount;
+        private long successCount;
+        private long failCount;
+    }
+
+    @Getter
+    @Builder
+    public static class WeeklyFailLog {
+        private Long failId;
+        private Long userId;
+        private LocalDateTime failedAt;
+        private String reason;
+    }
+
+    // ── B3. 편지 운영 현황 ───────────────────────────────────────────────────
+
+    @Getter
+    @Builder
+    public static class LetterStatusRes {
+        private LetterSummary summary;
+        private List<LetterFailLog> failLogs;
+    }
+
+    @Getter
+    @Builder
+    public static class LetterSummary {
+        private long sentCount;
+        private long waitingCount;
+        private long aiReplyCount;
+        private long failCount;
+    }
+
+    @Getter
+    @Builder
+    public static class LetterFailLog {
+        private Long logId;
+        private Long letterId;
+        private LocalDateTime failedAt;
+        private String reason;
+    }
+
+    // ── B4. 나쁜말 차단 현황 ─────────────────────────────────────────────────
+
+    @Getter
+    @Builder
+    public static class BadWordStatusRes {
+        private BadWordSummary summary;
+        private List<BlockedLog> blockedLogs;
+    }
+
+    @Getter
+    @Builder
+    public static class BadWordSummary {
+        private long blockedCount;
+        private double blockRate;
+    }
+
+    @Getter
+    @Builder
+    public static class BlockedLog {
+        private Long blockId;
+        private Long userId;
+        private String type;
+        private String originalText;
+        private List<String> badWords;
+        private double score;
+        private LocalDateTime blockedAt;
+    }
+
+    // ── 재발송 공통 응답 ─────────────────────────────────────────────────────
+
+    @Getter
+    @Builder
+    public static class ResendRes {
+        private long successCount;
+        private long failCount;
+        private List<ResendResult> results;
+    }
+
+    @Getter
+    @Builder
+    public static class ResendResult {
+        private Long failId;
+        private String status;   // SUCCESS | FAIL
+        private String reason;   // FAIL 시에만
+    }
+}

--- a/src/main/java/com/example/egobook_be/domain/user/dto/AdminContentResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/user/dto/AdminContentResDto.java
@@ -1,5 +1,6 @@
 package com.example.egobook_be.domain.user.dto;
 
+import com.example.egobook_be.domain.ego_room.enums.SendFailReason;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -42,7 +43,7 @@ public class AdminContentResDto {
         private Long failId;
         private Long userId;
         private LocalDateTime failedAt;
-        private String reason;
+        private SendFailReason reason;
     }
 
     // ── B2. 주간 리포트 발송 현황 ────────────────────────────────────────────
@@ -68,7 +69,7 @@ public class AdminContentResDto {
         private Long failId;
         private Long userId;
         private LocalDateTime failedAt;
-        private String reason;
+        private SendFailReason reason;
     }
 
     // ── B3. 편지 운영 현황 ───────────────────────────────────────────────────

--- a/src/main/java/com/example/egobook_be/domain/user/dto/ResendReqDto.java
+++ b/src/main/java/com/example/egobook_be/domain/user/dto/ResendReqDto.java
@@ -1,0 +1,15 @@
+package com.example.egobook_be.domain.user.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class ResendReqDto {
+
+    @NotEmpty(message = "재발송 대상 ID 목록이 비어 있습니다.")
+    private List<Long> failIds;
+}

--- a/src/main/java/com/example/egobook_be/domain/user/exception/AdminContentErrorCode.java
+++ b/src/main/java/com/example/egobook_be/domain/user/exception/AdminContentErrorCode.java
@@ -1,0 +1,23 @@
+package com.example.egobook_be.domain.user.exception;
+
+import com.example.egobook_be.global.exception.model.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum AdminContentErrorCode implements BaseErrorCode {
+
+    INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "조회 시작일은 종료일보다 이전이어야 합니다."),
+    FAIL_IDS_EMPTY(HttpStatus.BAD_REQUEST, "재발송 대상 ID 목록이 비어 있습니다."),
+    FAIL_LOG_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 실패 로그를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public HttpStatus getStatus() {
+        return this.httpStatus;
+    }
+}

--- a/src/main/java/com/example/egobook_be/domain/user/service/AdminContentService.java
+++ b/src/main/java/com/example/egobook_be/domain/user/service/AdminContentService.java
@@ -11,11 +11,11 @@ import com.example.egobook_be.domain.letters.entity.BadWordBlockLog;
 import com.example.egobook_be.domain.letters.entity.LetterSendFailLog;
 import com.example.egobook_be.domain.letters.entity.PlazaLetterStatus;
 import com.example.egobook_be.domain.letters.enums.BlockType;
+import com.example.egobook_be.domain.letters.repository.AiRequestCountLogRepository;
 import com.example.egobook_be.domain.letters.repository.BadWordBlockLogRepository;
 import com.example.egobook_be.domain.letters.repository.LetterSendFailLogRepository;
 import com.example.egobook_be.domain.letters.repository.PlazaLetterRepository;
 import com.example.egobook_be.domain.user.dto.ResendReqDto;
-import com.example.egobook_be.domain.user.dto.AdminContentResDto;
 import com.example.egobook_be.domain.user.dto.AdminContentResDto.*;
 import com.example.egobook_be.domain.user.exception.AdminContentErrorCode;
 import com.example.egobook_be.domain.user.repository.UserRepository;
@@ -44,6 +44,7 @@ public class AdminContentService {
     private final PlazaLetterRepository plazaLetterRepo;
     private final UserRepository userRepository;
     private final EgoRoomService egoRoomService;
+    private final AiRequestCountLogRepository aiRequestCountLogRepo;
 
     // ─────────────────────────────────────────────────────────────────────────
     // B1. AI 일간 칭찬서
@@ -125,7 +126,8 @@ public class AdminContentService {
             }
 
             try {
-                egoRoomService.createDailyPraise(failLog.getUserId(), failLog.getTargetDate());
+                // createDailyPraise와 로직은 동일하되 재발송 전용 메서드 호출 (중복 체크 없이 강제 재생성)
+                egoRoomService.resendDailyPraise(failLog.getUserId(), failLog.getTargetDate());
                 failLog.markResent();
                 results.add(successResult(failId));
                 successCount++;
@@ -202,7 +204,8 @@ public class AdminContentService {
             }
 
             try {
-                egoRoomService.createWeeklyAnalysis(failLog.getUserId(), failLog.getWeekStartDate());
+                // createWeeklyAnalysis와 로직은 동일하되 재발송 전용 메서드 호출 (중복 체크 없이 강제 재생성)
+                egoRoomService.resendWeeklyAnalysis(failLog.getUserId(), failLog.getWeekStartDate());
                 failLog.markResent();
                 results.add(successResult(failId));
                 successCount++;
@@ -280,9 +283,17 @@ public class AdminContentService {
                 ? badWordBlockLogRepo.findByBlockedAtBetweenOrderByBlockedAtDesc(start, end)
                 : badWordBlockLogRepo.findByBlockedAtBetweenAndTypeOrderByBlockedAtDesc(start, end, type);
 
+        // AiRequestCountLog 기반 전체 요청 수로 차단율 계산
+        long totalCount = (type == null || type == BlockType.ALL)
+                ? aiRequestCountLogRepo.countByRequestedAtBetween(start, end)
+                : aiRequestCountLogRepo.countByRequestedAtBetweenAndType(start, end, type);
+
+        double blockRate = totalCount == 0 ? 0.0
+                : Math.round((double) blockedLogs.size() / totalCount * 1000) / 10.0; // 소수점 1자리 %
+
         BadWordSummary summary = BadWordSummary.builder()
                 .blockedCount(blockedLogs.size())
-                .blockRate(0.0) // 전체 요청 수 카운팅 테이블 추가 시 수정
+                .blockRate(blockRate)
                 .build();
 
         List<BlockedLog> logDtos = blockedLogs.stream()

--- a/src/main/java/com/example/egobook_be/domain/user/service/AdminContentService.java
+++ b/src/main/java/com/example/egobook_be/domain/user/service/AdminContentService.java
@@ -1,0 +1,347 @@
+package com.example.egobook_be.domain.user.service;
+
+import com.example.egobook_be.domain.ego_room.entity.DailyPraiseSendFailLog;
+import com.example.egobook_be.domain.ego_room.entity.WeeklyReportSendFailLog;
+import com.example.egobook_be.domain.ego_room.repository.DailyPraiseSendFailLogRepository;
+import com.example.egobook_be.domain.ego_room.repository.DailyPraiseRepository;
+import com.example.egobook_be.domain.ego_room.repository.WeeklyCounselRepository;
+import com.example.egobook_be.domain.ego_room.repository.WeeklyReportSendFailLogRepository;
+import com.example.egobook_be.domain.ego_room.service.EgoRoomService;
+import com.example.egobook_be.domain.letters.entity.BadWordBlockLog;
+import com.example.egobook_be.domain.letters.entity.LetterSendFailLog;
+import com.example.egobook_be.domain.letters.entity.PlazaLetterStatus;
+import com.example.egobook_be.domain.letters.enums.BlockType;
+import com.example.egobook_be.domain.letters.repository.BadWordBlockLogRepository;
+import com.example.egobook_be.domain.letters.repository.LetterSendFailLogRepository;
+import com.example.egobook_be.domain.letters.repository.PlazaLetterRepository;
+import com.example.egobook_be.domain.user.dto.ResendReqDto;
+import com.example.egobook_be.domain.user.dto.AdminContentResDto;
+import com.example.egobook_be.domain.user.dto.AdminContentResDto.*;
+import com.example.egobook_be.domain.user.exception.AdminContentErrorCode;
+import com.example.egobook_be.domain.user.repository.UserRepository;
+import com.example.egobook_be.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdminContentService {
+
+    private final DailyPraiseSendFailLogRepository dailyPraiseFailLogRepo;
+    private final WeeklyReportSendFailLogRepository weeklyReportFailLogRepo;
+    private final LetterSendFailLogRepository letterFailLogRepo;
+    private final BadWordBlockLogRepository badWordBlockLogRepo;
+    private final DailyPraiseRepository dailyPraiseRepo;
+    private final WeeklyCounselRepository weeklyCounselRepo;
+    private final PlazaLetterRepository plazaLetterRepo;
+    private final UserRepository userRepository;
+    private final EgoRoomService egoRoomService;
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // B1. AI 일간 칭찬서
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Transactional(readOnly = true)
+    public DailyPraiseStatusRes getDailyPraiseStatus(LocalDate startDate, LocalDate endDate) {
+        validateDateRange(startDate, endDate);
+
+        List<DailyPraiseSendFailLog> failLogs =
+                dailyPraiseFailLogRepo.findByTargetDateBetweenOrderByFailedAtDesc(startDate, endDate);
+
+        // 날짜별 성공 건수 (DailyPraise 생성 = 발송 성공)
+        List<Object[]> successByDate = dailyPraiseRepo.countSuccessByDateRange(startDate, endDate);
+        // 날짜별 실패 건수
+        List<Object[]> failByDate = dailyPraiseFailLogRepo.countByDateRange(startDate, endDate);
+
+        Map<LocalDate, Long> successMap = toDateCountMap(successByDate);
+        Map<LocalDate, Long> failMap = toDateCountMap(failByDate);
+
+        // scheduledCount = dailyPraise=true 유저 수 (현재 기준)
+        long scheduledPerDay = userRepository.findByDailyPraiseTrue().size();
+        List<LocalDate> dateRange = buildDateRange(startDate, endDate);
+
+        List<DailyStat> dailyStats = dateRange.stream()
+                .map(date -> DailyStat.builder()
+                        .date(date)
+                        .scheduledCount(scheduledPerDay)
+                        .successCount(successMap.getOrDefault(date, 0L))
+                        .failCount(failMap.getOrDefault(date, 0L))
+                        .build())
+                .collect(Collectors.toList());
+
+        long totalSuccess = successMap.values().stream().mapToLong(Long::longValue).sum();
+
+        SummaryWithDaily summary = SummaryWithDaily.builder()
+                .scheduledCount(scheduledPerDay * dateRange.size())
+                .successCount(totalSuccess)
+                .failCount(failLogs.size())
+                .build();
+
+        List<PraiseFailLog> failLogDtos = failLogs.stream()
+                .map(f -> PraiseFailLog.builder()
+                        .failId(f.getId())
+                        .userId(f.getUserId())
+                        .failedAt(f.getFailedAt())
+                        .reason(f.getReason())
+                        .build())
+                .collect(Collectors.toList());
+
+        return DailyPraiseStatusRes.builder()
+                .summary(summary)
+                .dailyStats(dailyStats)
+                .failLogs(failLogDtos)
+                .build();
+    }
+
+    @Transactional
+    public ResendRes resendDailyPraise(ResendReqDto reqDto) {
+        validateFailIds(reqDto.getFailIds());
+
+        List<ResendResult> results = new ArrayList<>();
+        long successCount = 0, failCount = 0;
+
+        for (Long failId : reqDto.getFailIds()) {
+            Optional<DailyPraiseSendFailLog> opt = dailyPraiseFailLogRepo.findById(failId);
+
+            if (opt.isEmpty()) {
+                results.add(failResult(failId, "NOT_FOUND"));
+                failCount++;
+                continue;
+            }
+
+            DailyPraiseSendFailLog failLog = opt.get();
+            if (failLog.isResent()) {
+                results.add(failResult(failId, "ALREADY_SENT"));
+                failCount++;
+                continue;
+            }
+
+            try {
+                egoRoomService.createDailyPraise(failLog.getUserId(), failLog.getTargetDate());
+                failLog.markResent();
+                results.add(successResult(failId));
+                successCount++;
+            } catch (Exception e) {
+                log.error("[AdminContent] 일간 칭찬서 재발송 실패 failId={}: {}", failId, e.getMessage());
+                results.add(failResult(failId, "RESEND_FAILED"));
+                failCount++;
+            }
+        }
+
+        return ResendRes.builder()
+                .successCount(successCount)
+                .failCount(failCount)
+                .results(results)
+                .build();
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // B2. AI 주간 리포트
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Transactional(readOnly = true)
+    public WeeklyReportStatusRes getWeeklyReportStatus(LocalDate startDate, LocalDate endDate) {
+        validateDateRange(startDate, endDate);
+
+        List<WeeklyReportSendFailLog> failLogs =
+                weeklyReportFailLogRepo.findByWeekStartDateBetweenOrderByFailedAtDesc(startDate, endDate);
+
+        long successCount = weeklyCounselRepo.countByStartDateBetween(startDate, endDate);
+        long scheduledCount = userRepository.findAllByWeeklyAnalysisEnabledTrue().size();
+
+        SimpleSummary summary = SimpleSummary.builder()
+                .scheduledCount(scheduledCount)
+                .successCount(successCount)
+                .failCount(failLogs.size())
+                .build();
+
+        List<WeeklyFailLog> failLogDtos = failLogs.stream()
+                .map(f -> WeeklyFailLog.builder()
+                        .failId(f.getId())
+                        .userId(f.getUserId())
+                        .failedAt(f.getFailedAt())
+                        .reason(f.getReason())
+                        .build())
+                .collect(Collectors.toList());
+
+        return WeeklyReportStatusRes.builder()
+                .summary(summary)
+                .failLogs(failLogDtos)
+                .build();
+    }
+
+    @Transactional
+    public ResendRes resendWeeklyReport(ResendReqDto reqDto) {
+        validateFailIds(reqDto.getFailIds());
+
+        List<ResendResult> results = new ArrayList<>();
+        long successCount = 0, failCount = 0;
+
+        for (Long failId : reqDto.getFailIds()) {
+            Optional<WeeklyReportSendFailLog> opt = weeklyReportFailLogRepo.findById(failId);
+
+            if (opt.isEmpty()) {
+                results.add(failResult(failId, "NOT_FOUND"));
+                failCount++;
+                continue;
+            }
+
+            WeeklyReportSendFailLog failLog = opt.get();
+            if (failLog.isResent()) {
+                results.add(failResult(failId, "ALREADY_SENT"));
+                failCount++;
+                continue;
+            }
+
+            try {
+                egoRoomService.createWeeklyAnalysis(failLog.getUserId(), failLog.getWeekStartDate());
+                failLog.markResent();
+                results.add(successResult(failId));
+                successCount++;
+            } catch (Exception e) {
+                log.error("[AdminContent] 주간 리포트 재발송 실패 failId={}: {}", failId, e.getMessage());
+                results.add(failResult(failId, "RESEND_FAILED"));
+                failCount++;
+            }
+        }
+
+        return ResendRes.builder()
+                .successCount(successCount)
+                .failCount(failCount)
+                .results(results)
+                .build();
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // B3. 편지
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Transactional(readOnly = true)
+    public LetterStatusRes getLetterStatus(LocalDate startDate, LocalDate endDate) {
+        validateDateRange(startDate, endDate);
+
+        LocalDateTime start = startDate.atStartOfDay();
+        LocalDateTime end = endDate.plusDays(1).atStartOfDay();
+
+        long sentCount = plazaLetterRepo.countByCreatedAtBetweenAndStatuses(
+                start, end, List.of(PlazaLetterStatus.REPLIED, PlazaLetterStatus.AI_REPLIED));
+
+        long waitingCount = plazaLetterRepo.countByCreatedAtBetweenAndStatus(
+                start, end, PlazaLetterStatus.WAITING);
+
+        long aiReplyCount = plazaLetterRepo.countByCreatedAtBetweenAndStatus(
+                start, end, PlazaLetterStatus.AI_REPLIED);
+
+        List<LetterSendFailLog> failLogs =
+                letterFailLogRepo.findByFailedAtBetweenOrderByFailedAtDesc(start, end);
+
+        LetterSummary summary = LetterSummary.builder()
+                .sentCount(sentCount)
+                .waitingCount(waitingCount)
+                .aiReplyCount(aiReplyCount)
+                .failCount(failLogs.size())
+                .build();
+
+        List<LetterFailLog> failLogDtos = failLogs.stream()
+                .map(f -> LetterFailLog.builder()
+                        .logId(f.getId())
+                        .letterId(f.getLetterId())
+                        .failedAt(f.getFailedAt())
+                        .reason(f.getReason())
+                        .build())
+                .collect(Collectors.toList());
+
+        return LetterStatusRes.builder()
+                .summary(summary)
+                .failLogs(failLogDtos)
+                .build();
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // B4. 나쁜말 AI 차단
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Transactional(readOnly = true)
+    public BadWordStatusRes getBadWordStatus(LocalDate startDate, LocalDate endDate, BlockType type) {
+        validateDateRange(startDate, endDate);
+
+        LocalDateTime start = startDate.atStartOfDay();
+        LocalDateTime end = endDate.plusDays(1).atStartOfDay();
+
+        List<BadWordBlockLog> blockedLogs = (type == null || type == BlockType.ALL)
+                ? badWordBlockLogRepo.findByBlockedAtBetweenOrderByBlockedAtDesc(start, end)
+                : badWordBlockLogRepo.findByBlockedAtBetweenAndTypeOrderByBlockedAtDesc(start, end, type);
+
+        BadWordSummary summary = BadWordSummary.builder()
+                .blockedCount(blockedLogs.size())
+                .blockRate(0.0) // 전체 요청 수 카운팅 테이블 추가 시 수정
+                .build();
+
+        List<BlockedLog> logDtos = blockedLogs.stream()
+                .map(b -> BlockedLog.builder()
+                        .blockId(b.getId())
+                        .userId(b.getUserId())
+                        .type(b.getType().name())
+                        .originalText(b.getOriginalText())
+                        .badWords(b.getBadWords())
+                        .score(b.getScore())
+                        .blockedAt(b.getBlockedAt())
+                        .build())
+                .collect(Collectors.toList());
+
+        return BadWordStatusRes.builder()
+                .summary(summary)
+                .blockedLogs(logDtos)
+                .build();
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // 공통 유틸
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private void validateDateRange(LocalDate startDate, LocalDate endDate) {
+        if (startDate.isAfter(endDate)) {
+            throw new CustomException(AdminContentErrorCode.INVALID_DATE_RANGE);
+        }
+    }
+
+    private void validateFailIds(List<Long> failIds) {
+        if (failIds == null || failIds.isEmpty()) {
+            throw new CustomException(AdminContentErrorCode.FAIL_IDS_EMPTY);
+        }
+    }
+
+    private List<LocalDate> buildDateRange(LocalDate startDate, LocalDate endDate) {
+        List<LocalDate> dates = new ArrayList<>();
+        LocalDate cursor = startDate;
+        while (!cursor.isAfter(endDate)) {
+            dates.add(cursor);
+            cursor = cursor.plusDays(1);
+        }
+        return dates;
+    }
+
+    private Map<LocalDate, Long> toDateCountMap(List<Object[]> rows) {
+        Map<LocalDate, Long> map = new HashMap<>();
+        for (Object[] row : rows) {
+            map.put((LocalDate) row[0], (Long) row[1]);
+        }
+        return map;
+    }
+
+    private ResendResult successResult(Long failId) {
+        return ResendResult.builder().failId(failId).status("SUCCESS").build();
+    }
+
+    private ResendResult failResult(Long failId, String reason) {
+        return ResendResult.builder().failId(failId).status("FAIL").reason(reason).build();
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
- #171 
## 📝작업 내용
- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
신규 엔티티 추가

DailyPraiseSendFailLog : 일간 칭찬서 발송 실패 이력 테이블
WeeklyReportSendFailLog : 주간 리포트 발송 실패 이력 테이블
LetterSendFailLog : 편지 발송 실패 이력 테이블
BadWordBlockLog : 나쁜말 AI 차단 이력 테이블
BlockType enum : 차단 유형 (LETTER / REPLY / PRAISE / ALL)

기존 코드 수정

AiScheduler : 일간 칭찬서 / 주간 리포트 생성 실패 시 실패 로그 자동 저장
PlazaLetterService : 나쁜말 AI 차단 감지 시 BadWordBlockLog 저장 (편지 생성 / 답장 각각 처리)
DailyPraiseRepository / WeeklyCounselRepository / PlazaLetterRepository : 관리자 API용 집계 쿼리 메서드 추가

### 스크린샷 (선택)
￼
<img width="1109" height="771" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/2e43ed4d-5766-4e75-a944-c0f7c1423ae6" />
<img width="1079" height="756" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/a750800b-e75f-4a26-b387-d084002d554e" />
<img width="1009" height="780" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/bb5e95c9-c76b-4990-906d-f7721c81a643" />
<img width="736" height="696" alt="Pasted Graphic 3" src="https://github.com/user-attachments/assets/708cfc70-7319-458a-979a-7246af1c2ca5" />
<img width="732" height="687" alt="Pasted Graphic 4" src="https://github.com/user-attachments/assets/5ba3a828-c4cc-4ed2-8952-42ab202c179c" />
<img width="747" height="690" alt="Pasted Graphic 5" src="https://github.com/user-attachments/assets/045a5712-e1a2-48e8-a84b-1242584ca132" />


## 💬리뷰 요구사항(선택)
- 재발송 로직에서 egoRoomService.createDailyPraise() / createWeeklyAnalysis()를 그대로 재호출하는 방식으로 구현했는데, 재발송 전용 메서드를 별도로 분리하는 게 나을지 의견 부탁드립니다
- blockRate 계산을 위한 전체 AI 요청 수 카운팅을 현재 미구현 상태(0.0 고정)인데, 별도 테이블로 관리하는 방향이 맞을지 확인 부탁드립니다