### PR TITLE
✨Feat: 신고 편지, 편지 답장, 오늘의 질문 수동 삭제 관리자 API

### DIFF
--- a/src/main/java/com/example/egobook_be/domain/letters/dto/response/PlazaLetterReplyReportAdminResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/dto/response/PlazaLetterReplyReportAdminResDto.java
@@ -13,5 +13,6 @@ public record PlazaLetterReplyReportAdminResDto(
         ReplyReportReason reason,
         String description,
         ReportStatus status,
+        long reportCount,
         LocalDateTime createdAt
 ) {}

--- a/src/main/java/com/example/egobook_be/domain/letters/dto/response/PlazaLetterReportAdminResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/dto/response/PlazaLetterReportAdminResDto.java
@@ -13,5 +13,6 @@ public record PlazaLetterReportAdminResDto(
         LetterReportReason reason,
         String description,
         ReportStatus status,
+        long reportCount,
         LocalDateTime createdAt
 ) {}

--- a/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterReplyReportRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterReplyReportRepository.java
@@ -60,4 +60,9 @@ public interface PlazaLetterReplyReportRepository extends JpaRepository<PlazaLet
         WHERE r.reportId = :reportId
     """)
     Optional<PlazaLetterReplyReport> findByIdWithReply(@Param("reportId") Long reportId);
+
+    //수돌 삭제
+    @Modifying
+    @Query("DELETE FROM PlazaLetterReplyReport r WHERE r.reply.replyId = :replyId")
+    void deleteAllByReplyId(@Param("replyId") Long replyId);
 }

--- a/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterReplyReportRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterReplyReportRepository.java
@@ -61,8 +61,8 @@ public interface PlazaLetterReplyReportRepository extends JpaRepository<PlazaLet
     """)
     Optional<PlazaLetterReplyReport> findByIdWithReply(@Param("reportId") Long reportId);
 
-    //수돌 삭제
-    @Modifying
+    //수동 삭제
+    @Modifying(clearAutomatically = true)
     @Query("DELETE FROM PlazaLetterReplyReport r WHERE r.reply.replyId = :replyId")
     void deleteAllByReplyId(@Param("replyId") Long replyId);
 }

--- a/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterReportRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterReportRepository.java
@@ -45,7 +45,7 @@ public interface PlazaLetterReportRepository extends JpaRepository<PlazaLetterRe
     Optional<PlazaLetterReport> findByIdWithLetter(@Param("reportId") Long reportId);
 
     //수동 삭제
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("DELETE FROM PlazaLetterReport r WHERE r.letter.letterId = :letterId")
     void deleteAllByLetterId(@Param("letterId") Long letterId);
 }

--- a/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterReportRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterReportRepository.java
@@ -4,6 +4,7 @@ import com.example.egobook_be.domain.letters.entity.PlazaLetterReport;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -43,5 +44,9 @@ public interface PlazaLetterReportRepository extends JpaRepository<PlazaLetterRe
     """)
     Optional<PlazaLetterReport> findByIdWithLetter(@Param("reportId") Long reportId);
 
+    //수동 삭제
+    @Modifying
+    @Query("DELETE FROM PlazaLetterReport r WHERE r.letter.letterId = :letterId")
+    void deleteAllByLetterId(@Param("letterId") Long letterId);
 }
 

--- a/src/main/java/com/example/egobook_be/domain/letters/service/LetterReportAdminService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/LetterReportAdminService.java
@@ -31,7 +31,10 @@ public class LetterReportAdminService {
 
         Slice<PlazaLetterReport> slice = letterReportRepository.findAllWithLetter(pageable);
 
-        return SliceResponse.of(slice, report -> new PlazaLetterReportAdminResDto(
+        return SliceResponse.of(slice, report -> {
+            long reportCount = letterReportRepository.countByLetter_LetterId(report.getLetter().getLetterId());
+
+            return new PlazaLetterReportAdminResDto(
                 report.getReportId(),
                 report.getLetter().getLetterId(),
                 report.getLetter().getContent(),
@@ -39,8 +42,10 @@ public class LetterReportAdminService {
                 report.getReason(),
                 report.getDescription(),
                 report.getStatus(),
+                reportCount,
                 report.getCreatedAt()
-        ));
+            );
+        });
     }
 
     public SliceResponse<PlazaLetterReplyReportAdminResDto> getReportedReplies(int page, int size) {
@@ -50,7 +55,10 @@ public class LetterReportAdminService {
 
         Slice<PlazaLetterReplyReport> slice = replyReportRepository.findAllWithReply(pageable);
 
-        return SliceResponse.of(slice, report -> new PlazaLetterReplyReportAdminResDto(
+        return SliceResponse.of(slice, report -> {
+            long reportCount = replyReportRepository.countByReply_ReplyId(report.getReply().getReplyId());
+
+            return new PlazaLetterReplyReportAdminResDto(
                 report.getReportId(),
                 report.getReply().getReplyId(),
                 report.getReply().getText(),
@@ -58,8 +66,10 @@ public class LetterReportAdminService {
                 report.getReason(),
                 report.getDescription(),
                 report.getStatus(),
+                reportCount,
                 report.getCreatedAt()
-        ));
+            );
+        });
     }
 
     //상세 조회
@@ -67,15 +77,18 @@ public class LetterReportAdminService {
         PlazaLetterReport report = letterReportRepository.findByIdWithLetter(reportId)
                 .orElseThrow(() -> new CustomException(LettersErrorCode.LETTER_NOT_FOUND));
 
+        long reportCount = letterReportRepository.countByLetter_LetterId(report.getLetter().getLetterId());
+
         return new PlazaLetterReportAdminResDto(
-                report.getReportId(),
-                report.getLetter().getLetterId(),
-                report.getLetter().getContent(),
-                report.getReporterId(),
-                report.getReason(),
-                report.getDescription(),
-                report.getStatus(),
-                report.getCreatedAt()
+            report.getReportId(),
+            report.getLetter().getLetterId(),
+            report.getLetter().getContent(),
+            report.getReporterId(),
+            report.getReason(),
+            report.getDescription(),
+            report.getStatus(),
+            reportCount,
+            report.getCreatedAt()
         );
     }
 
@@ -83,15 +96,18 @@ public class LetterReportAdminService {
         PlazaLetterReplyReport report = replyReportRepository.findByIdWithReply(reportId)
                 .orElseThrow(() -> new CustomException(LettersErrorCode.LETTER_NOT_FOUND));
 
+        long reportCount = replyReportRepository.countByReply_ReplyId(report.getReply().getReplyId());
+
         return new PlazaLetterReplyReportAdminResDto(
-                report.getReportId(),
-                report.getReply().getReplyId(),
-                report.getReply().getText(),
-                report.getReporterId(),
-                report.getReason(),
-                report.getDescription(),
-                report.getStatus(),
-                report.getCreatedAt()
+            report.getReportId(),
+            report.getReply().getReplyId(),
+            report.getReply().getText(),
+            report.getReporterId(),
+            report.getReason(),
+            report.getDescription(),
+            report.getStatus(),
+            reportCount,
+            report.getCreatedAt()
         );
     }
 }

--- a/src/main/java/com/example/egobook_be/domain/letters/service/LetterReportAdminService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/LetterReportAdminService.java
@@ -5,8 +5,10 @@ import com.example.egobook_be.domain.letters.dto.response.PlazaLetterReplyReport
 import com.example.egobook_be.domain.letters.entity.PlazaLetterReport;
 import com.example.egobook_be.domain.letters.entity.PlazaLetterReplyReport;
 import com.example.egobook_be.domain.letters.enums.LettersErrorCode;
+import com.example.egobook_be.domain.letters.repository.PlazaLetterReplyRepository;
 import com.example.egobook_be.domain.letters.repository.PlazaLetterReportRepository;
 import com.example.egobook_be.domain.letters.repository.PlazaLetterReplyReportRepository;
+import com.example.egobook_be.domain.letters.repository.PlazaLetterRepository;
 import com.example.egobook_be.global.exception.CustomException;
 import com.example.egobook_be.global.response.SliceResponse;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +25,8 @@ public class LetterReportAdminService {
 
     private final PlazaLetterReportRepository letterReportRepository;
     private final PlazaLetterReplyReportRepository replyReportRepository;
+    private final PlazaLetterRepository letterRepository;
+    private final PlazaLetterReplyRepository replyRepository;
 
     public SliceResponse<PlazaLetterReportAdminResDto> getReportedLetters(int page, int size) {
         int safePage = Math.max(page, 1);
@@ -109,5 +113,24 @@ public class LetterReportAdminService {
             reportCount,
             report.getCreatedAt()
         );
+    }
+
+    //수동 삭제
+    @Transactional
+    public void deleteLetter(Long letterId) {
+        if (!letterRepository.existsById(letterId)) {
+            throw new CustomException(LettersErrorCode.LETTER_NOT_FOUND);
+        }
+        letterReportRepository.deleteAllByLetterId(letterId);   // 신고 내역 먼저 삭제
+        letterRepository.deleteById(letterId);
+    }
+
+    @Transactional
+    public void deleteReply(Long replyId) {
+        if (!replyRepository.existsById(replyId)) {
+            throw new CustomException(LettersErrorCode.LETTER_NOT_FOUND);
+        }
+        replyReportRepository.deleteAllByReplyId(replyId);      // 신고 내역 먼저 삭제
+        replyRepository.deleteById(replyId);
     }
 }

--- a/src/main/java/com/example/egobook_be/domain/question/controller/AdminReportController.java
+++ b/src/main/java/com/example/egobook_be/domain/question/controller/AdminReportController.java
@@ -81,4 +81,31 @@ public class AdminReportController implements AdminReportControllerDocs {
                 GlobalResponse.success("신고된 답변 상세 조회 성공", answerReportAdminService.getReportedAnswerDetail(reportId))
         );
     }
+
+    @Override
+    @DeleteMapping("/letters/{letterId}")
+    public ResponseEntity<GlobalResponse<Void>> deleteLetter(
+            @PathVariable Long letterId
+    ) {
+        letterReportAdminService.deleteLetter(letterId);
+        return ResponseEntity.ok(GlobalResponse.success("신고된 편지 수동 삭제 성공", null));
+    }
+
+    @Override
+    @DeleteMapping("/replies/{replyId}")
+    public ResponseEntity<GlobalResponse<Void>> deleteReply(
+            @PathVariable Long replyId
+    ) {
+        letterReportAdminService.deleteReply(replyId);
+        return ResponseEntity.ok(GlobalResponse.success("신고된 편지 답장 수동 삭제 성공", null));
+    }
+
+    @Override
+    @DeleteMapping("/answers/{answerId}")
+    public ResponseEntity<GlobalResponse<Void>> deleteAnswer(
+            @PathVariable Long answerId
+    ) {
+        answerReportAdminService.deleteAnswer(answerId);
+        return ResponseEntity.ok(GlobalResponse.success("신고된 오늘의 질문 답변 수동 삭제 성공", null));
+    }
 }

--- a/src/main/java/com/example/egobook_be/domain/question/controller/AdminReportControllerDocs.java
+++ b/src/main/java/com/example/egobook_be/domain/question/controller/AdminReportControllerDocs.java
@@ -42,8 +42,23 @@ public interface AdminReportControllerDocs {
             @RequestParam(defaultValue = "20") int size
     );
 
-    @Operation(summary = "[관리자] 신고된 오늘의 질문 답변 상세 조회", description = "신고된 오늘의 질문 답변 1건을 상세 조회합니다.")
+    @Operation(summary = "[관리자] 오늘의 질문 답변 상세 조회", description = "신고된 오늘의 질문 답변 1건을 상세 조회합니다.")
     ResponseEntity<GlobalResponse<AnswerReportAdminResDto>> getReportedAnswerDetail(
             @PathVariable Long reportId
+    );
+
+    @Operation(summary = "[관리자] 편지 수동 삭제", description = "편지를 수동으로 삭제합니다.")
+    ResponseEntity<GlobalResponse<Void>> deleteLetter(
+            @PathVariable Long letterId
+    );
+
+    @Operation(summary = "[관리자] 편지 답장 수동 삭제", description = "편지 답장을 수동으로 삭제합니다.")
+    ResponseEntity<GlobalResponse<Void>> deleteReply(
+            @PathVariable Long replyId
+    );
+
+    @Operation(summary = "[관리자] 오늘의 질문 답변 수동 삭제", description = "오늘의 질문 답변을 수동으로 삭제합니다.")
+    ResponseEntity<GlobalResponse<Void>> deleteAnswer(
+            @PathVariable Long answerId
     );
 }

--- a/src/main/java/com/example/egobook_be/domain/question/dto/AnswerReportAdminResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/question/dto/AnswerReportAdminResDto.java
@@ -12,5 +12,6 @@ public record AnswerReportAdminResDto(
         String reporterNickname,
         QuestionReportReason reason,
         String description,
+        long reportCount,
         LocalDateTime reportedAt
 ) {}

--- a/src/main/java/com/example/egobook_be/domain/question/repository/AnswerReportRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/question/repository/AnswerReportRepository.java
@@ -35,4 +35,7 @@ public interface AnswerReportRepository
         WHERE ar.id = :reportId
     """)
     Optional<AnswerReport> findByIdWithAnswerAndUser(@Param("reportId") Long reportId);
+
+    @Query("SELECT COUNT(ar) FROM AnswerReport ar WHERE ar.answer.id = :answerId")
+    long countByAnswerId(@Param("answerId") Long answerId);
 }

--- a/src/main/java/com/example/egobook_be/domain/question/repository/AnswerReportRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/question/repository/AnswerReportRepository.java
@@ -6,6 +6,7 @@ import com.example.egobook_be.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -38,4 +39,9 @@ public interface AnswerReportRepository
 
     @Query("SELECT COUNT(ar) FROM AnswerReport ar WHERE ar.answer.id = :answerId")
     long countByAnswerId(@Param("answerId") Long answerId);
+
+    //수동 삭제
+    @Modifying
+    @Query("DELETE FROM AnswerReport ar WHERE ar.answer.id = :answerId")
+    void deleteAllByAnswerId(@Param("answerId") Long answerId);
 }

--- a/src/main/java/com/example/egobook_be/domain/question/repository/AnswerReportRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/question/repository/AnswerReportRepository.java
@@ -41,7 +41,7 @@ public interface AnswerReportRepository
     long countByAnswerId(@Param("answerId") Long answerId);
 
     //수동 삭제
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("DELETE FROM AnswerReport ar WHERE ar.answer.id = :answerId")
     void deleteAllByAnswerId(@Param("answerId") Long answerId);
 }

--- a/src/main/java/com/example/egobook_be/domain/question/service/AnswerReportAdminService.java
+++ b/src/main/java/com/example/egobook_be/domain/question/service/AnswerReportAdminService.java
@@ -4,6 +4,7 @@ import com.example.egobook_be.domain.question.dto.AnswerReportAdminResDto;
 import com.example.egobook_be.domain.question.entity.AnswerReport;
 import com.example.egobook_be.domain.question.exception.QuestionErrorCode;
 import com.example.egobook_be.domain.question.repository.AnswerReportRepository;
+import com.example.egobook_be.domain.question.repository.QuestionAnswerRepository;
 import com.example.egobook_be.global.exception.CustomException;
 import com.example.egobook_be.global.response.SliceResponse;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AnswerReportAdminService {
 
     private final AnswerReportRepository answerReportRepository;
+    private final QuestionAnswerRepository questionAnswerRepository;
 
     @Transactional(readOnly = true)
     public SliceResponse<AnswerReportAdminResDto> getReportedAnswers(
@@ -53,5 +55,15 @@ public class AnswerReportAdminService {
                 .orElseThrow(() -> new CustomException(QuestionErrorCode.ANSWER_NOT_FOUND));
 
         return toDto(report);
+    }
+
+    //수동 삭제
+    @Transactional
+    public void deleteAnswer(Long answerId) {
+        if (!questionAnswerRepository.existsById(answerId)) {
+            throw new CustomException(QuestionErrorCode.ANSWER_NOT_FOUND);
+        }
+        answerReportRepository.deleteAllByAnswerId(answerId);   // 신고 내역 먼저 삭제
+        questionAnswerRepository.deleteById(answerId);
     }
 }

--- a/src/main/java/com/example/egobook_be/domain/question/service/AnswerReportAdminService.java
+++ b/src/main/java/com/example/egobook_be/domain/question/service/AnswerReportAdminService.java
@@ -32,6 +32,8 @@ public class AnswerReportAdminService {
     }
 
     private AnswerReportAdminResDto toDto(AnswerReport report) {
+        long reportCount = answerReportRepository.countByAnswerId(report.getAnswer().getId());
+
         return new AnswerReportAdminResDto(
                 report.getId(),
                 report.getAnswer().getId(),
@@ -40,6 +42,7 @@ public class AnswerReportAdminService {
                 report.getUser().getNickname(),
                 report.getReason(),
                 report.getDescription(),
+                reportCount,
                 report.getCreatedAt()
         );
     }


### PR DESCRIPTION
## #️⃣연관된 이슈
- #172 

## 📝작업 내용
1. 신고 횟수 조회 추가
기존 관리자 신고 조회 API(목록 / 상세)에 해당 콘텐츠의 누적 신고 횟수(`reportCount`) 필드를 추가했습니다.

2. 관리자 수동 삭제 API 추가
관리자가 신고된 콘텐츠를 직접 삭제할 수 있는 API를 개발했습니다.
삭제 시 FK 제약을 고려해 신고 내역을 먼저 삭제한 뒤 본 콘텐츠를 삭제하도록 했습니다.

### 스크린샷 (선택)
<img width="511" height="334" alt="스크린샷 2026-04-09 054142" src="https://github.com/user-attachments/assets/ea2d479b-56b2-4007-84d0-31e5dfae49d7" />
<img width="519" height="333" alt="스크린샷 2026-04-09 054851" src="https://github.com/user-attachments/assets/d0b9ef3a-a66f-445d-b38e-cb6af43ea4c0" />
<img width="471" height="326" alt="스크린샷 2026-04-09 054859" src="https://github.com/user-attachments/assets/e48f596d-0d32-4738-a3e6-9f56e487cc53" />



## 💬리뷰 요구사항(선택)
- 관리자가 수동으로 삭제하는 경우에는 DB 자체에서 지우는 거라서 다시 기록을 해둘 필요가 없을 것 같아서 삭제된 글의 신고 내역도 모두 삭제되도록 구현해두었는데 신고 내역도 지워도 괜찮을 것 같은지 의견 부탁드립니다.
