### PR TITLE
:sparkles: Feat: 관리자 회원가입/로그인 API

### DIFF
--- a/src/main/java/com/example/egobook_be/domain/admin/entity/Admin.java
+++ b/src/main/java/com/example/egobook_be/domain/admin/entity/Admin.java
@@ -1,0 +1,47 @@
+package com.example.egobook_be.domain.admin.entity;
+
+import com.example.egobook_be.domain.admin.enums.AdminApprovalStatus;
+import com.example.egobook_be.domain.user.enums.RoleType;
+import com.example.egobook_be.global.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "admin")
+public class Admin extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "admin_id", nullable = false, unique = true, length = 50)
+    private String adminId;
+
+    @Column(name = "password", nullable = false, length = 255)
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false, length = 20)
+    @Builder.Default
+    private RoleType role = RoleType.ROLE_ADMIN;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "approval_status", nullable = false, length = 20)
+    @Builder.Default
+    private AdminApprovalStatus approvalStatus = AdminApprovalStatus.PENDING;
+}

--- a/src/main/java/com/example/egobook_be/domain/admin/enums/AdminApprovalStatus.java
+++ b/src/main/java/com/example/egobook_be/domain/admin/enums/AdminApprovalStatus.java
@@ -1,0 +1,7 @@
+package com.example.egobook_be.domain.admin.enums;
+
+public enum AdminApprovalStatus {
+    PENDING,
+    APPROVED,
+    REJECTED
+}

--- a/src/main/java/com/example/egobook_be/domain/admin/exception/AdminAuthErrorCode.java
+++ b/src/main/java/com/example/egobook_be/domain/admin/exception/AdminAuthErrorCode.java
@@ -1,0 +1,20 @@
+package com.example.egobook_be.domain.admin.exception;
+
+import com.example.egobook_be.global.exception.model.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum AdminAuthErrorCode implements BaseErrorCode {
+    ADMIN_ID_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 ID입니다."),
+    ADMIN_LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "인증에 실패했습니다."),
+    ADMIN_NOT_APPROVED(HttpStatus.FORBIDDEN, "아직 관리자 계정이 승인되지 않았습니다."),
+    ADMIN_SIGNUP_REJECTED(HttpStatus.FORBIDDEN, "관리자 계정 회원가입 요청이 거절되었습니다."),
+    ADMIN_REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "Redis에 Refresh Token 정보가 없습니다. 관리자 계정으로 다시 로그인하세요."),
+    INVALID_ADMIN_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 관리자 Refresh Token입니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/example/egobook_be/domain/admin/repository/AdminRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/admin/repository/AdminRepository.java
@@ -1,0 +1,15 @@
+package com.example.egobook_be.domain.admin.repository;
+
+import com.example.egobook_be.domain.admin.entity.Admin;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface AdminRepository extends JpaRepository<Admin, Long> {
+
+    boolean existsByAdminId(String adminId);
+
+    Optional<Admin> findByAdminId(String adminId);
+}

--- a/src/main/java/com/example/egobook_be/domain/auth/controller/AdminAuthController.java
+++ b/src/main/java/com/example/egobook_be/domain/auth/controller/AdminAuthController.java
@@ -1,7 +1,8 @@
 package com.example.egobook_be.domain.auth.controller;
 
-import com.example.egobook_be.domain.auth.dto.req.GuestRecertificationReqDto;
+import com.example.egobook_be.domain.auth.dto.req.AdminAuthReqDto;
 import com.example.egobook_be.domain.auth.dto.req.RefreshReqDto;
+import com.example.egobook_be.domain.auth.dto.res.AdminLoginResDto;
 import com.example.egobook_be.domain.auth.dto.res.JwtTokenResDto;
 import com.example.egobook_be.domain.auth.sevice.AdminAuthService;
 import com.example.egobook_be.global.response.GlobalResponse;
@@ -18,6 +19,24 @@ public class AdminAuthController implements AdminAuthControllerDocs {
 
     private final AdminAuthService adminAuthService;
 
+    // [AI-GEN] 관리자 회원가입 엔드포인트 처리
+    @Override
+    public ResponseEntity<GlobalResponse<Void>> registerAdmin(@RequestBody @Valid AdminAuthReqDto reqDto) {
+        adminAuthService.registerAdmin(reqDto);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(GlobalResponse.success("관리자 회원가입이 완료되었습니다.", null));
+    }
+
+    // [AI-GEN] 관리자 로그인 엔드포인트 처리
+    @Override
+    public ResponseEntity<GlobalResponse<AdminLoginResDto>> loginAdmin(@RequestBody @Valid AdminAuthReqDto reqDto) {
+        AdminLoginResDto resDto = adminAuthService.loginAdmin(reqDto);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(GlobalResponse.success("로그인 성공입니다.", resDto));
+    }
+
     /**
      * [관리자 Access Token 재발급]
      * POST /admin/auth/refresh
@@ -30,15 +49,4 @@ public class AdminAuthController implements AdminAuthControllerDocs {
                 .body(GlobalResponse.success("Access Token이 정상적으로 재발급되었습니다.", jwtTokenResDto));
     }
 
-    /**
-     * [관리자 Recover Token으로 토큰 재발급]
-     * POST /admin/auth/recertification
-     */
-    @Override
-    public ResponseEntity<GlobalResponse<JwtTokenResDto>> recertificationAdminToken(@RequestBody @Valid GuestRecertificationReqDto reqDto) {
-        JwtTokenResDto jwtTokenResDto = adminAuthService.recertificationAdminToken(reqDto);
-        return ResponseEntity
-                .status(HttpStatus.OK)
-                .body(GlobalResponse.success("Access/Refresh/Recover Token이 정상적으로 재발급되었습니다.", jwtTokenResDto));
-    }
 }

--- a/src/main/java/com/example/egobook_be/domain/auth/controller/AdminAuthControllerDocs.java
+++ b/src/main/java/com/example/egobook_be/domain/auth/controller/AdminAuthControllerDocs.java
@@ -1,7 +1,8 @@
 package com.example.egobook_be.domain.auth.controller;
 
-import com.example.egobook_be.domain.auth.dto.req.GuestRecertificationReqDto;
+import com.example.egobook_be.domain.auth.dto.req.AdminAuthReqDto;
 import com.example.egobook_be.domain.auth.dto.req.RefreshReqDto;
+import com.example.egobook_be.domain.auth.dto.res.AdminLoginResDto;
 import com.example.egobook_be.domain.auth.dto.res.JwtTokenResDto;
 import com.example.egobook_be.global.response.GlobalResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -21,6 +22,53 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @RequestMapping("/admin/auth")
 public interface AdminAuthControllerDocs {
 
+    @Operation(summary = "관리자 회원가입", description = """
+            관리자가 아이디와 비밀번호를 입력하여 신규 계정을 등록하는 API입니다.
+
+            [ **입력값** ]
+            1. `adminId`: 관리자 아이디
+            2. `password`: 관리자 비밀번호
+
+            - **기능**: 신규 관리자 계정을 생성합니다.
+            - **실패 시**:
+              - 400: 필수 값 누락
+              - 409: 이미 존재하는 관리자 아이디
+
+            - **주의사항** -
+                - 회원가입을 한다 해서 바로 로그인할 수 없습니다.
+                - 직접 해당 계정의 설정을 변경해야 로그인이 가능합니다.
+            """)
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "회원가입 성공",
+                    content = @Content),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (아이디/비밀번호 누락)", content = @Content),
+            @ApiResponse(responseCode = "409", description = "이미 존재하는 관리자 아이디", content = @Content)
+    })
+    @PostMapping("/register")
+    ResponseEntity<GlobalResponse<Void>> registerAdmin(@RequestBody @Valid AdminAuthReqDto reqDto);
+
+    @Operation(summary = "관리자 로그인", description = """
+            관리자가 아이디와 비밀번호를 입력하여 로그인하는 API입니다.
+
+            [ **입력값** ]
+            1. `adminId`: 관리자 아이디
+            2. `password`: 관리자 비밀번호
+
+            - **기능**: 아이디/비밀번호 검증 후 Access Token, Refresh Token을 발급합니다.
+            - **실패 시**:
+              - 400: 필수 값 누락
+              - 401: 아이디 또는 비밀번호 불일치
+            """)
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "로그인 성공",
+                    content = @Content(schema = @Schema(implementation = AdminLoginResDto.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (아이디/비밀번호 누락)", content = @Content),
+            @ApiResponse(responseCode = "401", description = "아이디 또는 비밀번호 불일치", content = @Content)
+    })
+    @PostMapping("/login")
+    ResponseEntity<GlobalResponse<AdminLoginResDto>> loginAdmin(@RequestBody @Valid AdminAuthReqDto reqDto);
+
+
     @Operation(summary = "관리자 Access Token 재발급", description = """
             관리자가 Refresh Token을 이용하여 Access Token을 재발급받는 API입니다.
 
@@ -30,7 +78,7 @@ public interface AdminAuthControllerDocs {
             2. `refreshToken`: 만료되지 않은 Refresh Token (Bearer 제외)
 
             - **기능**: 유효한 Refresh Token을 검증하고, **새로운 Access Token**을 발급합니다.
-            - **실패 시**: 401 Unauthorized 반환 → 관리자 계정으로 재로그인이 필요합니다.
+            - **실패 시**: Redis에 Refresh Token 정보가 없으면 401 Unauthorized 반환 → 관리자 계정으로 재로그인이 필요합니다.
             """)
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Access Token 재발급 성공 (Refresh Token은 기존 토큰 그대로 반환)",
@@ -42,31 +90,4 @@ public interface AdminAuthControllerDocs {
     @SecurityRequirement(name = "bearerAuth")
     @PostMapping("/refresh")
     ResponseEntity<GlobalResponse<JwtTokenResDto>> refreshAccessToken(@RequestBody @Valid RefreshReqDto reqDto);
-
-    @Operation(summary = "관리자 Recover Token으로 토큰 재발급", description = """
-            관리자의 Refresh Token이 만료되었을 때, 기기에 영구 저장된 Recover Token으로 세션을 복구하는 API입니다.
-
-            [ **입력값** ]
-            1. `deviceUid`: 기기 고유 UUID
-            2. `accessToken`: 만료되었거나 만료되지 않은, 기존에 사용하던 Access Token (Bearer 제외)
-            3. `recoverToken`: 기기에 영구 저장된 Recover Token
-
-            - **기능**:
-              1. Recover Token과 서버의 저장값을 대조하여 검증합니다.
-              2. 검증 성공 시, **새로운 Access Token, Refresh Token, Recover Token**을 발급합니다.
-              3. 새로운 Recover Token이 발급되어 서버에 갱신됩니다. **발급된 Recover Token을 다시 저장하세요.**
-
-            - **실패 시(400)**: Recover Token이 유효하지 않음 → 계정을 삭제 대기 상태로 전환합니다.
-            """)
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Access / Refresh / Recover Token이 정상적으로 재발급되었습니다.",
-                    content = @Content(schema = @Schema(implementation = JwtTokenResDto.class))),
-            @ApiResponse(responseCode = "400", description = "유효하지 않은 Recover Token (계정 삭제 대기 처리됨)", content = @Content),
-            @ApiResponse(responseCode = "401", description = "로그인이 필요합니다.", content = @Content),
-            @ApiResponse(responseCode = "403", description = "관리자 권한이 필요합니다. 또는 탈퇴 대기 중인 계정입니다.", content = @Content),
-            @ApiResponse(responseCode = "404", description = "해당 인증 정보를 찾을 수 없습니다.", content = @Content)
-    })
-    @SecurityRequirement(name = "bearerAuth")
-    @PostMapping("/recertification")
-    ResponseEntity<GlobalResponse<JwtTokenResDto>> recertificationAdminToken(@RequestBody @Valid GuestRecertificationReqDto reqDto);
 }

--- a/src/main/java/com/example/egobook_be/domain/auth/dto/req/AdminAuthReqDto.java
+++ b/src/main/java/com/example/egobook_be/domain/auth/dto/req/AdminAuthReqDto.java
@@ -1,0 +1,18 @@
+package com.example.egobook_be.domain.auth.dto.req;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * 관리자 회원가입 & 로그인 요청 시 사용되는 DTO
+ */
+public record AdminAuthReqDto(
+        @Schema(description = "관리자 아이디", example = "admin123")
+        @NotBlank(message = "관리자 아이디는 필수입니다.")
+        String adminId,
+
+        @Schema(description = "관리자 비밀번호", example = "securePassword123!")
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        String password
+) {
+}

--- a/src/main/java/com/example/egobook_be/domain/auth/dto/res/AdminLoginResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/auth/dto/res/AdminLoginResDto.java
@@ -1,0 +1,19 @@
+package com.example.egobook_be.domain.auth.dto.res;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+/**
+ * 관리자 로그인 성공 시 클라이언트에게 내려줄 토큰 정보
+ */
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record AdminLoginResDto(
+        @Schema(description = "Access Token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+        String accessToken,
+
+        @Schema(description = "Refresh Token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+        String refreshToken
+) {
+}

--- a/src/main/java/com/example/egobook_be/domain/auth/sevice/AdminAuthService.java
+++ b/src/main/java/com/example/egobook_be/domain/auth/sevice/AdminAuthService.java
@@ -1,17 +1,14 @@
 package com.example.egobook_be.domain.auth.sevice;
 
-import com.example.egobook_be.domain.auth.dto.req.GuestRecertificationReqDto;
+import com.example.egobook_be.domain.admin.entity.Admin;
+import com.example.egobook_be.domain.admin.enums.AdminApprovalStatus;
+import com.example.egobook_be.domain.admin.exception.AdminAuthErrorCode;
+import com.example.egobook_be.domain.admin.repository.AdminRepository;
+import com.example.egobook_be.domain.auth.dto.req.AdminAuthReqDto;
 import com.example.egobook_be.domain.auth.dto.req.RefreshReqDto;
+import com.example.egobook_be.domain.auth.dto.res.AdminLoginResDto;
 import com.example.egobook_be.domain.auth.dto.res.JwtTokenResDto;
-import com.example.egobook_be.domain.auth.entity.AuthAccount;
-import com.example.egobook_be.domain.auth.entity.RefreshTokenBackup;
-import com.example.egobook_be.domain.auth.enums.AuthErrorCode;
-import com.example.egobook_be.domain.auth.enums.Provider;
-import com.example.egobook_be.domain.auth.repository.AuthAccountRepository;
-import com.example.egobook_be.domain.auth.repository.RefreshTokenBackupRepository;
-import com.example.egobook_be.domain.user.entity.User;
 import com.example.egobook_be.domain.user.enums.RoleType;
-import com.example.egobook_be.domain.user.enums.UserStatus;
 import com.example.egobook_be.global.exception.CustomException;
 import com.example.egobook_be.global.security.CustomUserDetails;
 import com.example.egobook_be.global.util.HashingUtil;
@@ -22,200 +19,133 @@ import com.example.egobook_be.global.util.module.TokenInfo;
 import com.example.egobook_be.global.util.module.UserAuthDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class AdminAuthService {
 
+    private final AdminRepository adminRepository;
     private final TokenManagementService tokenManagementService;
-    private final AuthAccountRepository authAccountRepository;
-    private final RefreshTokenBackupRepository refreshTokenBackupRepository;
     private final JwtUtil jwtUtil;
     private final HashingUtil hashingUtil;
     private final RedisUtil redisUtil;
 
-    @Value("${app.data.purge-duration-in-ms}")
-    private Long purgeDurationInMs;
+    /**
+     * 관리자가 회원가입을 신청하는 함수
+     * @param reqDto 회원가입 요청 DTO
+     */
+    @Transactional
+    public void registerAdmin(AdminAuthReqDto reqDto) {
+        if (adminRepository.existsByAdminId(reqDto.adminId())) {
+            throw new CustomException(AdminAuthErrorCode.ADMIN_ID_ALREADY_EXISTS);
+        }
+
+        String hashedPassword = hashingUtil.hashingValue(reqDto.password());
+        Admin admin = Admin.builder()
+                .adminId(reqDto.adminId())
+                .password(hashedPassword)
+                .build();
+        adminRepository.save(admin);
+    }
 
     /**
-     * 관리자용 Access Token 재발급 (FallBack 전략 적용)
-     *
-     * 1. Hashed Refresh Token으로 Redis 조회 시도
-     *    → 성공 시: 기존 Access Token 블랙리스트 처리 후 새 Access Token 즉시 발급
-     * 2. Redis 조회 실패 시 → RefreshTokenBackup 테이블 조회 (Fallback)
-     * 3. DB 조회 성공 시 → 만료 여부 검증 후 Redis 복구 및 새 Access Token 발급
-     * 4. DB에서도 찾지 못하거나 만료된 경우 → 재로그인 안내 에러 반환
-     *
+     * 관리자 로그인 함수
+     * @param reqDto 로그인 요청 DTO
+     * @return 관리자 로그인 응답 DTO
+     */
+    @Transactional(readOnly = true)
+    public AdminLoginResDto loginAdmin(AdminAuthReqDto reqDto) {
+        Admin admin = adminRepository.findByAdminId(reqDto.adminId())
+                .orElseThrow(() -> new CustomException(AdminAuthErrorCode.ADMIN_LOGIN_FAILED));
+
+        String hashedPassword = hashingUtil.hashingValue(reqDto.password());
+        if (!hashedPassword.equals(admin.getPassword())) {
+            throw new CustomException(AdminAuthErrorCode.ADMIN_LOGIN_FAILED);
+        }
+
+        validateAdminApprovalStatus(admin.getApprovalStatus());
+
+        UserAuthDto userAuthDto = UserAuthDto.ofAdmin(admin.getId(), admin.getAdminId(), admin.getRole());
+        CustomUserDetails customUserDetails = new CustomUserDetails(userAuthDto);
+
+        TokenInfo accessTokenInfo = jwtUtil.createAccessToken(customUserDetails);
+        TokenInfo refreshTokenInfo = jwtUtil.createRefreshToken(customUserDetails);
+
+        String hashedRefreshToken = hashingUtil.hashingValue(refreshTokenInfo.token());
+        RedisValue redisValue = RedisValue.builder()
+                .userId(null)
+                .authAccountId(null)
+                .subject(customUserDetails.getUsername())
+                .role(admin.getRole())
+                .expiresAt(refreshTokenInfo.expiresAt())
+                .build();
+        long ttlInMillis = jwtUtil.getExpirationInMs(refreshTokenInfo.token()) - System.currentTimeMillis();
+        if (ttlInMillis > 0) {
+            redisUtil.setHashedRefreshTokenValue(hashedRefreshToken, redisValue, ttlInMillis);
+        }
+
+        return AdminLoginResDto.builder()
+                .accessToken(accessTokenInfo.token())
+                .refreshToken(refreshTokenInfo.token())
+                .build();
+    }
+
+    /**
+     * 관리자용 Access Token 재발급
+     * Redis에 저장된 Refresh Token 정보만 사용한다.
      * @param reqDto RefreshReqDto (accessToken, refreshToken)
      * @return JwtTokenResDto (새 accessToken, 기존 refreshToken)
      */
     @Transactional
     public JwtTokenResDto refreshAdminToken(RefreshReqDto reqDto) {
-        // 1. 전달받은 Refresh Token 해싱
         String hashedRefreshToken = hashingUtil.hashingValue(reqDto.refreshToken());
-
-        /*
-         * 2. Redis에서 조회 시도
-         * - 조회 성공 시: 기존 Access Token을 블랙리스트에 등록하고 새 Access Token 발급
-         */
         RedisValue redisValue = redisUtil.getHashedRefreshTokenValue(hashedRefreshToken);
-        if (redisValue != null) {
-            validateAdminRole(redisValue.role());
-            tokenManagementService.addAccessTokenInRedisBlackList(reqDto.accessToken());
-            TokenInfo newAccessTokenInfo = jwtUtil.createAccessToken(
-                    redisValue.userId(), redisValue.authAccountId(), redisValue.subject(), redisValue.role()
-            );
-            return buildJwtTokenResDto(newAccessTokenInfo.token(), reqDto.refreshToken());
+
+        if (redisValue == null) {
+            throw new CustomException(AdminAuthErrorCode.ADMIN_REFRESH_TOKEN_NOT_FOUND);
         }
 
-        /*
-         * 3. Redis 조회 실패 시 RefreshTokenBackup 테이블에서 조회 (Fallback)
-         */
-        log.warn("[AdminAuthService] Redis에서 HashedRefreshToken을 찾을 수 없습니다. RefreshTokenBackup Table을 조회합니다.");
-        RefreshTokenBackup backup = refreshTokenBackupRepository.findByHashedTokenValue(hashedRefreshToken)
-                .orElseThrow(() -> new CustomException(AuthErrorCode.REFRESH_TOKEN_NOT_FOUND));
+        validateAdminRole(redisValue.role());
+        validateAdminSubject(redisValue.subject());
 
-        /*
-         * 4. DB에서 가져온 Refresh Token의 만료 여부 검증
-         * - 만료된 경우: 관리자 계정으로 재로그인 안내
-         */
-        if (backup.getExpiresAt().isBefore(LocalDateTime.now())) {
-            throw new CustomException(AuthErrorCode.REFRESH_TOKEN_EXPIRED_ADMIN);
-        }
-
-        /*
-         * 5. 모든 검증 통과 시 Redis 복구 후 새 Access Token 발급
-         * - DB에 저장된 Refresh Token 정보를 Redis에 복구한다.
-         */
-        AuthAccount authAccount = backup.getAuthAccount();
-        User user = authAccount.getUser();
-
-        validateAdminRole(user.getRole());
-
-        tokenManagementService.restoreHashedRefreshTokenRedisValue(hashedRefreshToken, user, authAccount, backup.getExpiresAt());
-
-        // 6. 기존 Access Token Redis 블랙리스트에 등록
         tokenManagementService.addAccessTokenInRedisBlackList(reqDto.accessToken());
 
-        // 7. 새 Access Token 발급 후 반환
-        String subject = jwtUtil.createSubject(authAccount.getProvider(), authAccount.getHashedDeviceUid());
-        TokenInfo newAccessTokenInfo = jwtUtil.createAccessToken(user.getId(), authAccount.getId(), subject, user.getRole());
-        return buildJwtTokenResDto(newAccessTokenInfo.token(), reqDto.refreshToken());
-    }
+        TokenInfo newAccessTokenInfo = jwtUtil.createAccessToken(
+                redisValue.userId(),
+                redisValue.authAccountId(),
+                redisValue.subject(),
+                redisValue.role()
+        );
 
-    /**
-     * 관리자용 Recover Token으로 Refresh Token 재발급
-     *
-     * Refresh Token이 만료된 관리자가 기기에 영구 저장된 Recover Token으로 세션을 복구하는 함수.
-     * AuthService.recertificationGuestToken()과 동일한 흐름이며, ROLE_ADMIN 검증이 추가된다.
-     *
-     * 1. deviceUid, recoverToken 해싱
-     * 2. AuthAccount 조회 (Provider.GUEST)
-     * 3. ROLE_ADMIN 검증
-     * 4. Recover Token 일치 여부 검증 (불일치 시 계정 삭제 대기 처리)
-     * 5. 계정 탈퇴 대기 상태 여부 확인
-     * 6. 기존 토큰 무효화 (Access 블랙리스트 + Refresh Redis/DB 삭제)
-     * 7. 새 Access, Refresh, Recover Token 발급 및 저장
-     *
-     * @param reqDto GuestRecertificationReqDto (deviceUid, accessToken, recoverToken)
-     * @return JwtTokenResDto (새 accessToken, refreshToken, recoverToken)
-     */
-    @Transactional
-    public JwtTokenResDto recertificationAdminToken(GuestRecertificationReqDto reqDto) {
-        // 1. deviceUid, recoverToken 해싱
-        String hashedDeviceUid = hashingUtil.hashingValue(reqDto.deviceUid());
-        String hashedRecoverToken = hashingUtil.hashingValue(reqDto.recoverToken());
-
-        // 2. AuthAccount 조회 (관리자 계정은 GUEST Provider 기반으로 Recover Token을 발급받는다)
-        AuthAccount authAccount = authAccountRepository.findByHashedDeviceUidAndProvider(hashedDeviceUid, Provider.GUEST)
-                .orElseThrow(() -> new CustomException(AuthErrorCode.USER_AUTH_ACCOUNT_NOT_FOUND));
-
-        User user = authAccount.getUser();
-
-        // 3. ROLE_ADMIN 검증
-        validateAdminRole(user.getRole());
-
-        /*
-         * 4. Recover Token 일치 여부 검증
-         * - 불일치 시: 비정상 접근으로 간주하여 계정을 삭제 대기 상태로 전환
-         */
-        if (!authAccount.getHashedRecoverToken().equals(hashedRecoverToken)) {
-            log.warn("[AdminAuthService] HashedDeviceUid: {}, 유효하지 않은 Recover Token으로 복구 시도를 하였습니다.", hashedDeviceUid);
-            user.withdrawUser(purgeDurationInMs);
-            throw new CustomException(AuthErrorCode.INVALID_RECOVER_TOKEN);
-        }
-
-        // 5. 탈퇴 대기 상태 검증
-        if (user.getStatus().equals(UserStatus.WITHDRAW_PENDING)) {
-            throw new CustomException(AuthErrorCode.RECERTIFICATION_FAIL_USER_WITHDRAW_PENDING);
-        }
-
-        /*
-         * 6. 기존 토큰 무효화
-         * (1) 기존 Access Token 블랙리스트 등록
-         * (2) 기존 Refresh Token Redis/DB에서 삭제
-         */
-        tokenManagementService.invalidatePreviousTokens(reqDto.accessToken(), authAccount, user.getId());
-
-        /*
-         * 7. 새 Access, Refresh, Recover Token 발급
-         * - Recover Token 갱신 후 AuthAccount에 저장
-         */
-        CustomUserDetails userDetails = buildCustomUserDetails(user, authAccount);
-        String subject = jwtUtil.createSubject(authAccount.getProvider(), authAccount.getHashedDeviceUid());
-        TokenInfo newAccessTokenInfo = jwtUtil.createAccessToken(user.getId(), authAccount.getId(), subject, user.getRole());
-        TokenInfo newRefreshTokenInfo = jwtUtil.createRefreshToken(subject, user.getRole());
-        TokenInfo newRecoverTokenInfo = jwtUtil.createRecoverToken(userDetails);
-        authAccount.updateHashedRecoverToken(hashingUtil.hashingValue(newRecoverTokenInfo.token()));
-
-        // 8. 새 Refresh Token을 DB & Redis에 저장
-        tokenManagementService.saveRefreshTokenToTableAndRedis(newRefreshTokenInfo, user, authAccount);
-
-        return buildJwtTokenResDto(newAccessTokenInfo.token(), newRefreshTokenInfo.token(), newRecoverTokenInfo.token());
-    }
-
-    /**
-     * 요청한 토큰의 Role이 ROLE_ADMIN인지 검증하는 함수
-     * Security 레이어에서 이미 차단되지만, 서비스 레이어에서도 이중으로 검증한다.
-     */
-    private void validateAdminRole(RoleType role) {
-        if (role != RoleType.ROLE_ADMIN) {
-            throw new CustomException(AuthErrorCode.REFRESH_TOKEN_NOT_FOUND);
-        }
-    }
-
-    private CustomUserDetails buildCustomUserDetails(User user, AuthAccount authAccount) {
-        UserAuthDto userAuthDto = UserAuthDto.builder()
-                .userId(user.getId())
-                .authAccountId(authAccount.getId())
-                .provider(authAccount.getProvider())
-                .hashedDeviceUid(authAccount.getHashedDeviceUid())
-                .role(user.getRole())
-                .build();
-        return new CustomUserDetails(userAuthDto);
-    }
-
-    private JwtTokenResDto buildJwtTokenResDto(String accessToken, String refreshToken) {
         return JwtTokenResDto.builder()
-                .accessToken(accessToken)
-                .refreshToken(refreshToken)
+                .accessToken(newAccessTokenInfo.token())
+                .refreshToken(reqDto.refreshToken())
                 .recoverToken(null)
                 .email(null)
                 .build();
     }
 
-    private JwtTokenResDto buildJwtTokenResDto(String accessToken, String refreshToken, String recoverToken) {
-        return JwtTokenResDto.builder()
-                .accessToken(accessToken)
-                .refreshToken(refreshToken)
-                .recoverToken(recoverToken)
-                .email(null)
-                .build();
+    private void validateAdminApprovalStatus(AdminApprovalStatus approvalStatus) {
+        if (approvalStatus == AdminApprovalStatus.PENDING) {
+            throw new CustomException(AdminAuthErrorCode.ADMIN_NOT_APPROVED);
+        }
+        if (approvalStatus == AdminApprovalStatus.REJECTED) {
+            throw new CustomException(AdminAuthErrorCode.ADMIN_SIGNUP_REJECTED);
+        }
+    }
+
+    private void validateAdminRole(RoleType role) {
+        if (role != RoleType.ROLE_ADMIN) {
+            throw new CustomException(AdminAuthErrorCode.INVALID_ADMIN_REFRESH_TOKEN);
+        }
+    }
+
+    private void validateAdminSubject(String subject) {
+        if (subject == null || !subject.startsWith("ADMIN:")) {
+            throw new CustomException(AdminAuthErrorCode.INVALID_ADMIN_REFRESH_TOKEN);
+        }
     }
 }

--- a/src/main/java/com/example/egobook_be/domain/auth/sevice/AuthService.java
+++ b/src/main/java/com/example/egobook_be/domain/auth/sevice/AuthService.java
@@ -502,6 +502,7 @@ public class AuthService {
                 .authAccountId(authAccount.getId())
                 .provider(authAccount.getProvider())
                 .hashedDeviceUid(authAccount.getHashedDeviceUid()) // authAccount에 들어있는 deviceUid는 해싱된 상태이다.
+                .subject(authAccount.getProvider().toString() + ":" + authAccount.getHashedDeviceUid()) // JWT Subject
                 .role(user.getRole())
                 .build();
         return new CustomUserDetails(userAuthDto);

--- a/src/main/java/com/example/egobook_be/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/egobook_be/global/config/SecurityConfig.java
@@ -46,7 +46,8 @@ public class SecurityConfig {
             "/manage/prometheus", // Prometheus Metrics 수집 경로
             "/ads/admob/callback", // AdMob의 광고 보상 수령 여부 확인 경로
             "/admin/auth/refresh",
-            "/admin/auth/recertification",
+            "/admin/auth/register",
+            "/admin/auth/login"
     };
 
     /**

--- a/src/main/java/com/example/egobook_be/global/security/CustomUserDetailService.java
+++ b/src/main/java/com/example/egobook_be/global/security/CustomUserDetailService.java
@@ -88,6 +88,7 @@ public class CustomUserDetailService implements UserDetailsService {
                 .authAccountId(authAccount.getId()) // AuthAccount 테이블의 PK (토큰 백업용)
                 .provider(authAccount.getProvider()) // provider 설정
                 .hashedDeviceUid(authAccount.getHashedDeviceUid()) // hashing된 기기 고유 ID
+                .subject(authAccount.getProvider().toString() + ":" + authAccount.getHashedDeviceUid()) // JWT Subject
                 .role(user.getRole())           // 사용자 권한 (RoleType)
                 .build();
 

--- a/src/main/java/com/example/egobook_be/global/security/CustomUserDetails.java
+++ b/src/main/java/com/example/egobook_be/global/security/CustomUserDetails.java
@@ -21,7 +21,7 @@ import java.util.List;
 @Getter
 @RequiredArgsConstructor
 public class CustomUserDetails implements UserDetails {
-    private final UserAuthDto userAuthDto; // 사용자 인증 정보를 담고 있는 dto
+private final UserAuthDto userAuthDto; // 사용자 인증 정보를 담고 있는 dto
 
     /**
      * [사용자 권한(Role)을 처리하는 함수]
@@ -54,13 +54,15 @@ public class CustomUserDetails implements UserDetails {
     }
 
     /**
-     * [Username 처리 -> Provider:HashedDeviceUid]
+     * [Username 처리 -> Provider:HashedDeviceUid 또는 ADMIN:adminId]
      * JWT의 Subject에 들어갈 값이자, Spring Security 내에서 이 유저를 식별하는 고유 ID입니다.
-     * 단순히 deviceUid만 반환하면 Guest/Google 계정이 중복될 수 있으므로,
-     * 반드시 "PROVIDER:UID" 형태로 조합해서 반환해야 합니다.
+     * Admin인 경우 "ADMIN:adminId" 형식을, User인 경우 "PROVIDER:UID" 형식을 반환합니다.
      */
     @Override
     public String getUsername() {
+        if (userAuthDto.subject().startsWith("ADMIN:")) {
+            return userAuthDto.subject();
+        }
         return userAuthDto.provider().toString() + ":" + userAuthDto.hashedDeviceUid();
     }
 

--- a/src/main/java/com/example/egobook_be/global/security/JwtAuthFilter.java
+++ b/src/main/java/com/example/egobook_be/global/security/JwtAuthFilter.java
@@ -136,8 +136,9 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     /**
      * [Authentication 객체 생성 메서드]
      * DB를 거치지 않고 JWT Claims에서 정보를 추출하여 Principal을 구성한다.
-     * @param accessToken : 클라이언트로부터 받은
-     * @return
+     * Admin과 User를 subject 접두사로 분기하여 처리한다.
+     * @param accessToken : 클라이언트로부터 받은 Access Token
+     * @return Authentication 객체
      */
     private Authentication createAuthentication(String accessToken) {
         // 1. Access Token에서 데이터 추출
@@ -146,10 +147,17 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         String subject = jwtUtil.getSubjectFromToken(accessToken);
         String roleString = jwtUtil.getRoleFromToken(accessToken);
 
-        /*
-         * 2. Subject를 Provider와 HashedDeviceUid로 분리한다.
-         * - 만약 형식이 잘못되었다면, INVALID_TYPE_TOKEN으로 예외처리를 한다.
-         */
+        // 2. Admin 분기: subject가 "ADMIN:"으로 시작
+        if (subject.startsWith("ADMIN:")) {
+            UserAuthDto userAuthDto = UserAuthDto.builder()
+                    .subject(subject)
+                    .role(RoleType.valueOf(roleString))
+                    .build();
+            CustomUserDetails customUserDetails = new CustomUserDetails(userAuthDto);
+            return new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+        }
+
+        // 3. User 분기: 기존 로직 유지
         String[] parts = subject.split(":", 2);
         if (parts.length < 2) {
             throw new CustomException(AuthErrorCode.INVALID_TYPE_TOKEN);
@@ -157,7 +165,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         Provider provider = Provider.valueOf(parts[0]);
         String hashedDeviceUid = parts[1];
 
-        // 3. UserAuthDto & CustomUserDetails 생성
+        // 4. UserAuthDto & CustomUserDetails 생성
         UserAuthDto userAuthDto = UserAuthDto.builder()
                 .userId(userId)
                 .authAccountId(authAccountId)
@@ -167,7 +175,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                 .build();
         CustomUserDetails customUserDetails = new CustomUserDetails(userAuthDto);
 
-        // 4. Spring Security 인증 토큰 생성 및 반환
+        // 5. Spring Security 인증 토큰 생성 및 반환
         return new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
     }
 

--- a/src/main/java/com/example/egobook_be/global/util/JwtUtil.java
+++ b/src/main/java/com/example/egobook_be/global/util/JwtUtil.java
@@ -203,6 +203,15 @@ public class JwtUtil {
         return provider.toString() + ":" + hashedDeviceUid;
     }
 
+    /**
+     * Admin용 Subject 생성
+     * @param adminId 관리자 로그인 아이디
+     * @return "ADMIN:adminId"
+     */
+    public String createAdminSubject(String adminId) {
+        return "ADMIN:" + adminId;
+    }
+
 
     // ===============================================================
     // [Getter]

--- a/src/main/java/com/example/egobook_be/global/util/module/UserAuthDto.java
+++ b/src/main/java/com/example/egobook_be/global/util/module/UserAuthDto.java
@@ -8,18 +8,29 @@ import lombok.Builder;
  * [JWT 토큰을 생성할 때 필요한 사용자 인증 정보들을 담고 있는 Dto]
  * Entity들을 직접 CustomUserDetails에 넣으면 트랜잭션 범위 밖에서의 Lazy Loading이 발생할 수 있다.
  * 따라서, 이 DTO를 사용하여 그런 문제를 방지한다.
- * @param userId : User Entity PK
- * @param authAccountId : AuthAccount Entity PK
- * @param provider : Provider
- * @param hashedDeviceUid : 해싱된 기기의 고유 UID
+ * @param userId : User Entity PK (Admin은 null)
+ * @param authAccountId : AuthAccount Entity PK (Admin은 null)
+ * @param adminId : Admin Entity PK (User는 null)
+ * @param subject : JWT Subject ("ADMIN:adminId" 또는 "PROVIDER:hashedDeviceUid")
+ * @param provider : Provider (User 전용, Admin은 null)
+ * @param hashedDeviceUid : 해싱된 기기의 고유 UID (User 전용, Admin은 null)
  * @param role : 사용자 권한
  */
 @Builder
 public record UserAuthDto(
         Long userId,
         Long authAccountId,
+        Long adminId,
+        String subject,
         Provider provider,
         String hashedDeviceUid,
         RoleType role
 ) {
+    public static UserAuthDto ofAdmin(Long adminId, String adminLoginId, RoleType role) {
+        return UserAuthDto.builder()
+                .adminId(adminId)
+                .subject("ADMIN:" + adminLoginId)
+                .role(role)
+                .build();
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
- #200 

## 📝작업 내용
1. 기존 CustomUserDetails 내부에 들어가던 UserAuthDto의 내용에 관리자 전용 데이터를 추가했습니다.
  - 기존에 사용하던 UserAuthDto를 재사용할 수 있도록 Admin 전용 데이터만 추가하여 UserAuthDto를 사용하도록 했습니다.

2. 관리자 회원가입 API를 구현했습니다.
  - adminId 중복 여부를 검사합니다.
  - 비밀번호는 HashingUtil로 단방향 해싱 후 저장합니다.
  - role은 ROLE_ADMIN, approvalStatus는 PENDING 기본값으로 저장됩니다.

3. 관리자 로그인 API를 구현했습니다.
  - adminId로 관리자 계정을 조회한 뒤, 입력 비밀번호를 해싱하여 저장값과 비교합니다.
  - 승인 상태가 PENDING, REJECTED인 경우 각각 전용 예외를 반환합니다.
  - 승인 완료(APPROVED)된 계정만 로그인 가능하며 Access/Refresh Token을 발급합니다.
  - CustomUserDetails 생성 시 UserAuthDto.ofAdmin(...)를 사용하도록 반영했습니다.

4. 관리자 토큰 재발급 API를 기존 Refresh Token 로직이 아닌 신규 로직(`AdminAuthService.refreshAdminToken()`)을 생성했습니다.
  - 로그인 시 발급한 Refresh Token을 해싱하여 Redis에 저장합니다.
  - 재발급 시 Redis에 Refresh Token 정보가 없으면 DB fallback 없이 재로그인을 유도합니다.

## 💬리뷰 요구사항
- 관리자 Refresh Token에 대한 관리는 Backup 테이블 없이 Redis만 사용하는 방법으로 구현했습니다. 실제 운영 환경에서 Redis에 있는 Refresh Token이 유실되었을 시 관리자가 재로그인을 시도하도록 강제하는 것이 적절한지 리뷰 부탁드립니다.
- 기존에 있던 UserAuthDto에 admin 전용 데이터를 추가하여 설계하는것이 적절한지 리뷰 부탁드립니다.