### PR TITLE
🐛 Fix: Diary 재작성 시 보상 중복 지급 버그 수정

### DIFF
--- a/src/main/java/com/example/egobook_be/domain/diary/service/DiaryService.java
+++ b/src/main/java/com/example/egobook_be/domain/diary/service/DiaryService.java
@@ -67,21 +67,22 @@ public class DiaryService {
         LocalDateTime endOfToday = LocalDate.now().atTime(LocalTime.MAX);
 
         // 오늘 첫 일기 작성 여부
-        boolean isFirstDiaryToday = !diaryRepository.existsByUserAndCreatedAtBetween(user, startOfToday, endOfToday);
+        boolean isFirstDiaryToday = !inkLogRepository.existsByUserAndReasonAndCreatedAtBetween(
+                user, InkLogType.FIRST_EMOTION_DIARY, startOfToday, endOfToday
+        );
 
         // 오늘 첫 고민(CONCERN) 일기 작성 여부
         boolean isFirstConcernToday =
                 dto.type().contains(DiaryType.CONCERN) &&
-                        !diaryRepository.existsByUserAndTypeContainingAndCreatedAtBetween(
-                                user, DiaryType.CONCERN, startOfToday, endOfToday
+                        !inkLogRepository.existsByUserAndReasonAndCreatedAtBetween(
+                                user, InkLogType.FIRST_CONCERN_DIARY, startOfToday, endOfToday
                         );
 
         // 오늘 첫 칭찬(PRAISE) 또는 감사(GRATITUDE) 작성 여부
         boolean isFirstPositiveToday =
                 (dto.type().contains(DiaryType.PRAISE) || dto.type().contains(DiaryType.GRATITUDE)) &&
-                        !diaryRepository.existsByUserAndTypeInAndCreatedAtBetween(
-                                user, Set.of(DiaryType.PRAISE, DiaryType.GRATITUDE),
-                                startOfToday, endOfToday
+                        !inkLogRepository.existsByUserAndReasonAndCreatedAtBetween(
+                                user, InkLogType.FIRST_POSITIVE_DIARY, startOfToday, endOfToday
                         );
 
         LocalDateTime writtenAt = LocalDateTime.now();
@@ -147,6 +148,7 @@ public class DiaryService {
          * - 감정조절 레벨이 올랐으면 잉크 +1
          */
         if (isFirstConcernToday) {
+            inkLogUtil.addInkLogToList(inkLogs, user, 0, InkLogType.FIRST_CONCERN_DIARY);
             int earnedInk = ability.addEmotionRegulation(1); // 감정 조절 Score를 증가시켰을 때, 사용자가 레벨업한 경우 earnedInk의 값은 1이다
             rewards.add(new DiaryCreateResDto.RewardResDto(
                     RewardType.EMOTION_REGULATION, 1, "고민 일기를 작성하여 감정조절 스코어가 상승했어요"
@@ -167,6 +169,7 @@ public class DiaryService {
          * - 긍정 사고의 레벨이 올랐으면 잉크 +1
          */
         if (isFirstPositiveToday) {
+            inkLogUtil.addInkLogToList(inkLogs, user, 0, InkLogType.FIRST_POSITIVE_DIARY);
             int amount = 1;
             int earnedInk = ability.addPositiveThinking(amount);
             if (diaryTypes.contains(DiaryType.PRAISE)) {

--- a/src/main/java/com/example/egobook_be/domain/user/entity/InkLogType.java
+++ b/src/main/java/com/example/egobook_be/domain/user/entity/InkLogType.java
@@ -12,5 +12,8 @@ public enum InkLogType {
     WEEKLY_MISSION_REWARD,
     WATCH_AD,
     WEEKLY_UNLOCK,
-    LETTER_COLOR_PURCHASE
+    LETTER_COLOR_PURCHASE,
+    // 능력치 보상 확인을 위한 기록
+    FIRST_CONCERN_DIARY,
+    FIRST_POSITIVE_DIARY
 }

--- a/src/main/java/com/example/egobook_be/domain/user/repository/InkLogRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/user/repository/InkLogRepository.java
@@ -53,6 +53,8 @@ public interface InkLogRepository extends JpaRepository<InkLog, Long> {
             @Param("format") String format
     );
 
+    boolean existsByUserAndReasonAndCreatedAtBetween(User user, InkLogType reason, LocalDateTime createdAtAfter, LocalDateTime createdAtBefore);
+
     interface InkStatAmount {
         String getPeriod();
         Long getAmount();

--- a/src/main/java/com/example/egobook_be/global/security/JwtAuthFilter.java
+++ b/src/main/java/com/example/egobook_be/global/security/JwtAuthFilter.java
@@ -147,6 +147,10 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         String subject = jwtUtil.getSubjectFromToken(accessToken);
         String roleString = jwtUtil.getRoleFromToken(accessToken);
 
+        if (subject == null) {
+            throw new CustomException(AuthErrorCode.INVALID_TYPE_TOKEN);
+        }
+
         // 2. Admin 분기: subject가 "ADMIN:"으로 시작
         if (subject.startsWith("ADMIN:")) {
             UserAuthDto userAuthDto = UserAuthDto.builder()
@@ -171,6 +175,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                 .authAccountId(authAccountId)
                 .hashedDeviceUid(hashedDeviceUid)
                 .provider(provider)
+                .subject(subject)
                 .role(RoleType.valueOf(roleString))
                 .build();
         CustomUserDetails customUserDetails = new CustomUserDetails(userAuthDto);


### PR DESCRIPTION
## 📝작업 내용

**1. 작성한 일기 삭제하고 다시 작성 시, 잉크 및 능력치 보상이 무한으로 중복 지급**

- 보상 지급 조건 : 일기 존재 여부 → InkLog 지급 이력 으로 변경

**2. 유저 JWT 인증 시 NullPointerException 발생**

- UserAuthDto 빌더에 subject 필드 누락 추가

> 테스트 결과
> 

<img width="39%" alt="Image" src="https://github.com/user-attachments/assets/4cefecc2-001b-460c-ae53-62c9344575f4" />