### PR TITLE
:bug: Fix: 편지 삭제 후 재작성 시 무한 잉크 획득 버그 수정

### DIFF
--- a/src/main/java/com/example/egobook_be/domain/letters/enums/PlazaLetterColor.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/enums/PlazaLetterColor.java
@@ -2,10 +2,10 @@ package com.example.egobook_be.domain.letters.enums;
 
 public enum PlazaLetterColor {
     WHITE(0),  // 기본 하얀색, 가격 0원
-    PINK(150),  // 핑크색, 가격 150원
-    GREEN(200),  // 초록색, 가격 200원
-    BLUE(300),  // 파란색, 가격 300원
-    PURPLE(400);  // 보라색, 가격 400원
+    PINK(75),  // 핑크색, 가격 75원
+    GREEN(100),  // 초록색, 가격 100원
+    BLUE(150),  // 파란색, 가격 150원
+    PURPLE(175);  // 보라색, 가격 175원
 
     private final int price;
 

--- a/src/main/java/com/example/egobook_be/domain/letters/service/PlazaLetterService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/PlazaLetterService.java
@@ -17,10 +17,14 @@ import com.example.egobook_be.domain.letters.repository.*;
 import com.example.egobook_be.domain.notification.enums.NotificationType;
 import com.example.egobook_be.domain.notification.service.NotificationService;
 import com.example.egobook_be.domain.user.entity.Ability;
+import com.example.egobook_be.domain.user.entity.AbilityLog;
+import com.example.egobook_be.domain.user.entity.AbilityLogReason;
+import com.example.egobook_be.domain.user.entity.AbilityLogType;
 import com.example.egobook_be.domain.user.entity.InkLog;
 import com.example.egobook_be.domain.user.entity.InkLogType;
 import com.example.egobook_be.domain.user.entity.User;
 import com.example.egobook_be.domain.user.exception.UserErrorCode;
+import com.example.egobook_be.domain.user.repository.AbilityLogRepository;
 import com.example.egobook_be.domain.user.repository.AbilityRepository;
 import com.example.egobook_be.domain.user.repository.InkLogRepository;
 import com.example.egobook_be.domain.user.repository.UserRepository;
@@ -55,6 +59,7 @@ public class PlazaLetterService {
 
     private static final int REPLY_TEXT_LIMIT = 350;
     private static final int LETTER_TEXT_LIMIT = 360;
+    private static final ZoneId ASIA_SEOUL_ZONE_ID = ZoneId.of("Asia/Seoul");
 
     private final PlazaLetterRepository plazaLetterRepository;
     private final PlazaLetterReplyRepository plazaLetterReplyRepository;
@@ -64,6 +69,7 @@ public class PlazaLetterService {
     private final UserRepository userRepository;
     private final MissionRepository missionRepository;
     private final AbilityRepository abilityRepository;
+    private final AbilityLogRepository abilityLogRepository;
     private final WordClientService wordClient;
     private final BadWordBlockLogRepository badWordBlockLogRepo;
     private final InkLogUtil inkLogUtil;
@@ -206,8 +212,19 @@ public class PlazaLetterService {
         PlazaLetter saved = plazaLetterRepository.save(letter);
 
 
+        // [AI-MOD] 편지 첫 작성 잉크 보상 중복 방지
         List<InkLog> inkLogs = new ArrayList<>();
-        inkLogUtil.addInkLogToList(inkLogs, user, 1, InkLogType.FIRST_LETTER_WRITE);
+        LocalDateTime startOfDay = getStartOfDay();
+        LocalDateTime endOfDay = getEndOfDay();
+        boolean alreadyRewardedFirstLetterWrite = inkLogRepository.existsByUserAndReasonAndCreatedAtBetween(
+                user,
+                InkLogType.FIRST_LETTER_WRITE,
+                startOfDay,
+                endOfDay
+        );
+        if (!alreadyRewardedFirstLetterWrite) {
+            inkLogUtil.addInkLogToList(inkLogs, user, 1, InkLogType.FIRST_LETTER_WRITE);
+        }
         if (userMission.updateDailyLetterMissionStatus(true)) {
             inkLogUtil.addInkLogToList(inkLogs, user, 1, InkLogType.DAILY_MISSION_REWARD);
             if (userMission.isWeeklyMissionCompleted()) {
@@ -336,14 +353,25 @@ public class PlazaLetterService {
 
 
     private void enforceDailyLimit(Long userId, LocalDateTime now) {
-        ZoneId zoneId = ZoneId.of("Asia/Seoul");
-        LocalDate today = LocalDate.now(zoneId);
-        LocalDateTime start = today.atStartOfDay(zoneId).toLocalDateTime();
-        LocalDateTime end = today.plusDays(1).atStartOfDay(zoneId).toLocalDateTime();
+        LocalDate today = now.atZone(ASIA_SEOUL_ZONE_ID).toLocalDate();
+        LocalDateTime start = today.atStartOfDay(ASIA_SEOUL_ZONE_ID).toLocalDateTime();
+        LocalDateTime end = today.plusDays(1).atStartOfDay(ASIA_SEOUL_ZONE_ID).toLocalDateTime();
 
         if (plazaLetterRepository.existsBySenderIdAndCreatedAtBetween(userId, start, end)) {
             throw new CustomException(LettersErrorCode.DAILY_LETTER_LIMIT);
         }
+    }
+
+    // [AI-GEN] 서울 기준 시작 시각 계산
+    private LocalDateTime getStartOfDay() {
+        LocalDate today = LocalDate.now(ASIA_SEOUL_ZONE_ID);
+        return today.atStartOfDay(ASIA_SEOUL_ZONE_ID).toLocalDateTime();
+    }
+
+    // [AI-GEN] 서울 기준 종료 시각 계산
+    private LocalDateTime getEndOfDay() {
+        LocalDate today = LocalDate.now(ASIA_SEOUL_ZONE_ID);
+        return today.plusDays(1).atStartOfDay(ASIA_SEOUL_ZONE_ID).toLocalDateTime();
     }
 
     private Long resolveReceiverId(Long userId, CreateLetterRequest request) {
@@ -463,10 +491,8 @@ public class PlazaLetterService {
         enforceWordAiOrThrow(content, userId, BlockType.REPLY);
 
         // 6. plazaLetterReplyRepository로 PlazaLetterReply를 저장하기 전, 해당 사용자가 답장한 편지가 오늘 처음 답장한 편지인지 확인한다.
-        ZoneId zoneId = ZoneId.of("Asia/Seoul");
-        LocalDate today = LocalDate.now(zoneId);
-        LocalDateTime startOfDay = today.atStartOfDay(zoneId).toLocalDateTime();
-        LocalDateTime endOfDay = today.plusDays(1).atStartOfDay(zoneId).toLocalDateTime();
+        LocalDateTime startOfDay = getStartOfDay();
+        LocalDateTime endOfDay = getEndOfDay();
         boolean isFirstReplyToday = !plazaLetterReplyRepository.existsByReplierIdAndCreatedAtBetween(userId, startOfDay, endOfDay);
 
         PlazaLetterReply reply = plazaLetterReplyRepository.save(PlazaLetterReply.builder()
@@ -501,44 +527,59 @@ public class PlazaLetterService {
                     letter.getSenderId(), reply.getReplyId(), e);
         }
 
-        // =============================================
-        // [ 보상 로직 ]
-        // =============================================
-        /*
-         * 1. 해당 사용자가 오늘 처음 편지 답장을 한 경우
-         * - 잉크 +1
-         * - 잉크 로그 작성
-         * - 공감성 +1
-         * + 레벨업 시 잉크 +1
-         */
+        // 답장 보상 로그 중복 지급 방지
         List<ReplyResponse.RewardDto> rewards = new ArrayList<>();
         List<InkLog> inkLogs = new ArrayList<>();
+        List<AbilityLog> abilityLogs = new ArrayList<>();
         if(isFirstReplyToday){
-            inkLogUtil.addInkLogToList(inkLogs, user, 1, InkLogType.FIRST_LETTER_REPLY); // 잉크 +1
-            rewards.add(ReplyResponse.RewardDto.builder()
-                    .kind(ReplyResponse.RewardKind.INK)
-                    .amount(1)
-                    .toastMessage("첫 답장 보상으로 잉크를 획득했어요!")
-                    .build());
+            boolean alreadyRewardedFirstReplyInk = inkLogRepository.existsByUserAndReasonAndCreatedAtBetween(
+                    user,
+                    InkLogType.FIRST_LETTER_REPLY,
+                    startOfDay,
+                    endOfDay
+            );
+            boolean alreadyRewardedFirstReplyEmpathy = abilityLogRepository.existsByUserAndReasonAndCreatedAtBetween(
+                    user,
+                    AbilityLogReason.FIRST_LETTER_REPLY,
+                    startOfDay,
+                    endOfDay
+            );
 
-            int earnedInk = userAbility.addEmpathy(1); // 공감성 +1
-            rewards.add(ReplyResponse.RewardDto.builder()
-                    .kind(ReplyResponse.RewardKind.EMPATHY) // [수정] SINCERITY -> EMPATHY
-                    .amount(1)
-                    .toastMessage("공감성 점수가 1 상승했어요.")
-                    .build());
-            // 1-1. 레벨업했는지 여부 확인
-            if(earnedInk == 1){
-                inkLogUtil.addInkLogToList(inkLogs, user, earnedInk, InkLogType.LEVEL_UP);
-                user.levelUp();
+            if (!alreadyRewardedFirstReplyInk) {
+                inkLogUtil.addInkLogToList(inkLogs, user, 1, InkLogType.FIRST_LETTER_REPLY);
                 rewards.add(ReplyResponse.RewardDto.builder()
-                        .kind(ReplyResponse.RewardKind.EMPATHY) // [수정] SINCERITY -> EMPATHY
+                        .kind(ReplyResponse.RewardKind.INK)
                         .amount(1)
-                        .toastMessage("공감성 레벨이 1 상승했어요.")
+                        .toastMessage("첫 답장 보상으로 잉크를 획득했어요!")
                         .build());
+            }
+
+            if (!alreadyRewardedFirstReplyEmpathy) {
+                int earnedInk = userAbility.addEmpathy(1);
+                abilityLogs.add(AbilityLog.builder()
+                        .user(user)
+                        .abilityType(AbilityLogType.EMPATHY)
+                        .amount(1)
+                        .reason(AbilityLogReason.FIRST_LETTER_REPLY)
+                        .build());
+                rewards.add(ReplyResponse.RewardDto.builder()
+                        .kind(ReplyResponse.RewardKind.EMPATHY)
+                        .amount(1)
+                        .toastMessage("공감성 점수가 1 상승했어요.")
+                        .build());
+                if(earnedInk == 1){
+                    inkLogUtil.addInkLogToList(inkLogs, user, earnedInk, InkLogType.LEVEL_UP);
+                    user.levelUp();
+                    rewards.add(ReplyResponse.RewardDto.builder()
+                            .kind(ReplyResponse.RewardKind.EMPATHY)
+                            .amount(1)
+                            .toastMessage("공감성 레벨이 1 상승했어요.")
+                            .build());
+                }
             }
         }
         inkLogRepository.saveAll(inkLogs);
+        abilityLogRepository.saveAll(abilityLogs);
 
         log.info("[PlazaLetterService] replyToLetter End - userId: {}, letterId: {}", userId, letterId);
         return ReplyResponse.builder()

--- a/src/main/java/com/example/egobook_be/domain/user/entity/AbilityLog.java
+++ b/src/main/java/com/example/egobook_be/domain/user/entity/AbilityLog.java
@@ -1,0 +1,38 @@
+package com.example.egobook_be.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "ability_log")
+public class AbilityLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AbilityLogType abilityType;
+
+    @Column(nullable = false)
+    private Integer amount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AbilityLogReason reason;
+
+    @Column(name = "created_at", nullable = false)
+    @Builder.Default
+    private LocalDateTime createdAt = LocalDateTime.now();
+}

--- a/src/main/java/com/example/egobook_be/domain/user/entity/AbilityLogReason.java
+++ b/src/main/java/com/example/egobook_be/domain/user/entity/AbilityLogReason.java
@@ -1,0 +1,11 @@
+package com.example.egobook_be.domain.user.entity;
+
+// [AI-GEN] AbilityLog 보상 사유 정의
+public enum AbilityLogReason {
+    FIRST_CONCERN_DIARY,
+    FIRST_GRATITUDE_DIARY,
+    FIRST_PRAISE_DIARY,
+    FIRST_LETTER_REPLY,
+    FIRST_QUESTION_ANSWER,
+    FIRST_PSYCHOLOGY_VIEW
+}

--- a/src/main/java/com/example/egobook_be/domain/user/entity/AbilityLogType.java
+++ b/src/main/java/com/example/egobook_be/domain/user/entity/AbilityLogType.java
@@ -1,0 +1,10 @@
+package com.example.egobook_be.domain.user.entity;
+
+// [AI-GEN] AbilityLog 능력치 타입 정의
+public enum AbilityLogType {
+    EMPATHY,
+    SELF_ESTEEM,
+    EMOTION_REGULATION,
+    POSITIVE_THINKING,
+    DILIGENCE
+}

--- a/src/main/java/com/example/egobook_be/domain/user/repository/AbilityLogRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/user/repository/AbilityLogRepository.java
@@ -1,0 +1,28 @@
+package com.example.egobook_be.domain.user.repository;
+
+import com.example.egobook_be.domain.user.entity.AbilityLog;
+import com.example.egobook_be.domain.user.entity.AbilityLogReason;
+import com.example.egobook_be.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+
+@Repository
+public interface AbilityLogRepository extends JpaRepository<AbilityLog, Long> {
+
+    /**
+     * 사용자가 특정 능력치 보상을 오늘 이미 획득했는지 확인한다.
+     * @param user : 보상 획득 여부를 확인할 사용자
+     * @param reason : 능력치 보상 사유
+     * @param start : 조회 시작 시각
+     * @param end : 조회 종료 시각
+     * @return : 오늘 능력치 보상 획득 여부
+     */
+    boolean existsByUserAndReasonAndCreatedAtBetween(
+            User user,
+            AbilityLogReason reason,
+            LocalDateTime start,
+            LocalDateTime end
+    );
+}

--- a/src/main/java/com/example/egobook_be/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/egobook_be/global/config/SecurityConfig.java
@@ -47,7 +47,8 @@ public class SecurityConfig {
             "/ads/admob/callback", // AdMob의 광고 보상 수령 여부 확인 경로
             "/admin/auth/refresh",
             "/admin/auth/register",
-            "/admin/auth/login"
+            "/admin/auth/login",
+            "/test-google-oauth.html"
     };
 
     /**

--- a/src/test/java/com/example/egobook_be/domain/letter/PlazaLetterServiceTest.java
+++ b/src/test/java/com/example/egobook_be/domain/letter/PlazaLetterServiceTest.java
@@ -5,6 +5,7 @@ import com.example.egobook_be.domain.home.entity.Mission;
 import com.example.egobook_be.domain.home.repository.MissionRepository;
 import com.example.egobook_be.domain.letters.dto.request.CreateLetterRequest;
 import com.example.egobook_be.domain.letters.dto.response.CreateLetterResponse;
+import com.example.egobook_be.domain.letters.dto.response.ReplyResponse;
 import com.example.egobook_be.domain.letters.entity.PlazaLetter;
 import com.example.egobook_be.domain.letters.entity.PlazaLetterMode;
 import com.example.egobook_be.domain.letters.entity.PlazaLetterStatus;
@@ -12,6 +13,8 @@ import com.example.egobook_be.domain.letters.entity.PlazaLetterThread;
 import com.example.egobook_be.domain.letters.enums.LettersErrorCode;
 import com.example.egobook_be.domain.letters.enums.PlazaLetterColor;
 import com.example.egobook_be.domain.letters.mapper.PlazaLetterMapper;
+import com.example.egobook_be.domain.letters.repository.AiRequestCountLogRepository;
+import com.example.egobook_be.domain.letters.repository.BadWordBlockLogRepository;
 import com.example.egobook_be.domain.letters.repository.PlazaLetterReplyRepository;
 import com.example.egobook_be.domain.letters.repository.PlazaLetterRepository;
 import com.example.egobook_be.domain.letters.repository.PlazaLetterThreadRepository;
@@ -19,7 +22,10 @@ import com.example.egobook_be.domain.letters.service.PlazaLetterService;
 import com.example.egobook_be.domain.letters.service.WordClientService;
 import com.example.egobook_be.domain.notification.service.NotificationService;
 import com.example.egobook_be.domain.user.entity.Ability;
+import com.example.egobook_be.domain.user.entity.AbilityLogReason;
+import com.example.egobook_be.domain.user.entity.InkLogType;
 import com.example.egobook_be.domain.user.entity.User;
+import com.example.egobook_be.domain.user.repository.AbilityLogRepository;
 import com.example.egobook_be.domain.user.repository.AbilityRepository;
 import com.example.egobook_be.domain.user.repository.InkLogRepository;
 import com.example.egobook_be.domain.user.repository.UserRepository;
@@ -81,7 +87,16 @@ class PlazaLetterServiceTest {
     private AbilityRepository abilityRepository;
 
     @Mock
+    private AbilityLogRepository abilityLogRepository;
+
+    @Mock
     private WordClientService wordClient;
+
+    @Mock
+    private BadWordBlockLogRepository badWordBlockLogRepo;
+
+    @Mock
+    private AiRequestCountLogRepository aiRequestCountLogRepo;
 
     @Mock
     private InkLogUtil inkLogUtil;
@@ -281,6 +296,122 @@ class PlazaLetterServiceTest {
 
         verify(plazaLetterReplyRepository, never()).save(any());
         verify(notificationService, never()).createNotification(anyLong(), any(), anyLong(), any());
+    }
+
+    // [AI-GEN] 광장 편지 첫 작성 재보상 방지 테스트
+    @Test
+    @DisplayName("createLetter_오늘 첫 작성 잉크 로그가 있으면 보상을 지급하지 않는다")
+    void createLetter_오늘첫작성잉크로그가있으면_보상을지급하지않는다() {
+        // given
+        Long userId = 1L;
+
+        User sender = User.builder()
+                .id(userId)
+                .accountCode("ACC001")
+                .nickname("효진")
+                .ink(0)
+                .build();
+
+        Mission mission = Mission.builder()
+                .user(sender)
+                .build();
+
+        CreateLetterRequest request = new CreateLetterRequest();
+        ReflectionTestUtils.setField(request, "mode", PlazaLetterMode.RANDOM);
+        ReflectionTestUtils.setField(request, "text", "재보상 방지 편지");
+        ReflectionTestUtils.setField(request, "backgroundColor", PlazaLetterColor.WHITE);
+
+        PlazaLetterThread savedThread = PlazaLetterThread.builder()
+                .threadId(10L)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(sender));
+        given(missionRepository.findByUser(sender)).willReturn(Optional.of(mission));
+        given(plazaLetterRepository.existsBySenderIdAndCreatedAtBetween(eq(userId), any(), any())).willReturn(false);
+        given(inkLogRepository.existsByUserAndReasonAndCreatedAtBetween(eq(sender), eq(InkLogType.FIRST_LETTER_WRITE), any(), any()))
+                .willReturn(true);
+        given(wordClient.detectAsync(anyString())).willReturn(Mono.empty());
+        given(userRepository.findHighReplyRateCandidates(userId, 50)).willReturn(Collections.emptyList());
+        given(plazaLetterThreadRepository.save(any(PlazaLetterThread.class))).willReturn(savedThread);
+        given(plazaLetterRepository.save(any(PlazaLetter.class))).willAnswer(invocation -> {
+            PlazaLetter letter = invocation.getArgument(0);
+            return PlazaLetter.builder()
+                    .letterId(100L)
+                    .threadId(letter.getThreadId())
+                    .senderId(letter.getSenderId())
+                    .receiverId(letter.getReceiverId())
+                    .mode(letter.getMode())
+                    .fromLabel(letter.getFromLabel())
+                    .content(letter.getContent())
+                    .backgroundColor(letter.getBackgroundColor())
+                    .status(letter.getStatus())
+                    .createdAt(letter.getCreatedAt())
+                    .arrivedAt(letter.getArrivedAt())
+                    .replyDeadlineAt(letter.getReplyDeadlineAt())
+                    .build();
+        });
+
+        // when
+        plazaLetterService.createLetter(userId, request);
+
+        // then
+        verify(inkLogUtil, never()).addInkLogToList(anyList(), eq(sender), eq(1), eq(InkLogType.FIRST_LETTER_WRITE));
+    }
+
+    // [AI-GEN] 광장 답장 재보상 방지 테스트
+    @Test
+    @DisplayName("replyToLetter_오늘 첫 답장 보상 로그가 있으면 잉크와 공감성을 지급하지 않는다")
+    void replyToLetter_오늘첫답장보상로그가있으면_잉크와공감성을지급하지않는다() {
+        // given
+        Long userId = 2L;
+        Long letterId = 101L;
+
+        User receiver = User.builder()
+                .id(userId)
+                .accountCode("ACC002")
+                .nickname("민지")
+                .ink(0)
+                .build();
+
+        Ability ability = spy(Ability.builder()
+                .user(receiver)
+                .build());
+
+        PlazaLetter letter = PlazaLetter.builder()
+                .letterId(letterId)
+                .threadId(10L)
+                .senderId(1L)
+                .receiverId(userId)
+                .mode(PlazaLetterMode.RANDOM)
+                .fromLabel("익명")
+                .content("원본 편지")
+                .backgroundColor(PlazaLetterColor.WHITE)
+                .status(PlazaLetterStatus.ARRIVED)
+                .createdAt(LocalDateTime.now().minusHours(1))
+                .arrivedAt(LocalDateTime.now().minusMinutes(30))
+                .replyDeadlineAt(LocalDateTime.now().plusHours(23))
+                .build();
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(receiver));
+        given(abilityRepository.findByUser(receiver)).willReturn(Optional.of(ability));
+        given(plazaLetterRepository.findById(letterId)).willReturn(Optional.of(letter));
+        given(plazaLetterReplyRepository.existsByLetter(letter)).willReturn(false);
+        given(plazaLetterReplyRepository.existsByReplierIdAndCreatedAtBetween(eq(userId), any(), any())).willReturn(false);
+        given(inkLogRepository.existsByUserAndReasonAndCreatedAtBetween(eq(receiver), eq(InkLogType.FIRST_LETTER_REPLY), any(), any()))
+                .willReturn(true);
+        given(abilityLogRepository.existsByUserAndReasonAndCreatedAtBetween(eq(receiver), eq(AbilityLogReason.FIRST_LETTER_REPLY), any(), any()))
+                .willReturn(true);
+        given(plazaLetterReplyRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        ReplyResponse result = plazaLetterService.replyToLetter(userId, letterId, "답장 내용");
+
+        // then
+        assertThat(result.getRewards()).isEmpty();
+        verify(inkLogUtil, never()).addInkLogToList(anyList(), eq(receiver), eq(1), eq(InkLogType.FIRST_LETTER_REPLY));
+        verify(ability, never()).addEmpathy(anyInt());
+        verify(abilityLogRepository).saveAll(anyList());
     }
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈
- #203 

## 📝작업 내용
- AbilityLog를 추가해 능력치 획득 시 AbilityLog의 레코드로 저장되도록 한 뒤, 편지 작성 후 보상을 부여할 때 InkLog와 AbilityLog를 확인해서 오늘 생성한 능력치, 잉크 획득 로그가 있는지 확인하게 함으로써 무한 획득 버그를 해결했음
- 다른 능력치 획득 로직에도 AbilityLog를 향후 추가해야할 것으로 예상 (당장 필요한 것은 아님)
