### PR TITLE
✨ Feat: 유료편지지 영구 구매 구조

### DIFF
--- a/src/main/java/com/example/egobook_be/domain/letters/enums/LettersErrorCode.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/enums/LettersErrorCode.java
@@ -35,6 +35,7 @@ public enum LettersErrorCode implements BaseErrorCode {
     THREAD_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAZA404_THREAD_NOT_FOUND", "스레드를 찾을 수 없어요"),
     NO_RECEIVER_AVAILABLE(HttpStatus.NOT_FOUND,"PLAZA404_NO_RECEIVER_AVAILABLE", "현재 편지를 받을 수 있는 유저가 없습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND,"PLAZA404_USER_NOT_FOUND", "유저를 찾을 수 없어요."),
+    LETTER_PAPER_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAZA404_LETTER_PAPER_NOT_FOUND", "해당 편지지 아이템을 찾을 수 없어요."),
 
 
 

--- a/src/main/java/com/example/egobook_be/domain/letters/service/PlazaLetterService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/PlazaLetterService.java
@@ -16,6 +16,12 @@ import com.example.egobook_be.domain.letters.enums.BlockType;
 import com.example.egobook_be.domain.letters.repository.*;
 import com.example.egobook_be.domain.notification.enums.NotificationType;
 import com.example.egobook_be.domain.notification.service.NotificationService;
+import com.example.egobook_be.domain.shop.entity.Item;
+import com.example.egobook_be.domain.shop.entity.UserItem;
+import com.example.egobook_be.domain.shop.enums.ItemCategory;
+import com.example.egobook_be.domain.shop.enums.ShopErrorCode;
+import com.example.egobook_be.domain.shop.repository.ItemRepository;
+import com.example.egobook_be.domain.shop.repository.UserItemRepository;
 import com.example.egobook_be.domain.user.entity.Ability;
 import com.example.egobook_be.domain.user.entity.AbilityLog;
 import com.example.egobook_be.domain.user.entity.AbilityLogReason;
@@ -73,6 +79,8 @@ public class PlazaLetterService {
     private final WordClientService wordClient;
     private final BadWordBlockLogRepository badWordBlockLogRepo;
     private final InkLogUtil inkLogUtil;
+    private final UserItemRepository userItemRepository;  // 편지지 보유 확인용
+    private final ItemRepository itemRepository;          // 편지지 아이템 조회용
 
     private final PlazaLetterMapper plazaLetterMapper;
 
@@ -153,12 +161,10 @@ public class PlazaLetterService {
 
         PlazaLetterColor color = (request.getBackgroundColor() == null)
                 ? PlazaLetterColor.WHITE : request.getBackgroundColor();
-        int price = color.getPrice();
-        if (price > 0) {
-            user.useInk(price);
-            inkLogRepository.save(InkLog.builder()
-                    .user(user).amount(-price)
-                    .reason(InkLogType.LETTER_COLOR_PURCHASE).build());
+
+        // 유료 편지지면 보유 여부 확인 후 미보유 시 구매 처리
+        if (color != PlazaLetterColor.WHITE) {
+            purchaseLetterPaperIfNotOwned(user, color);
         }
 
         PlazaLetterThread thread = plazaLetterThreadRepository.save(PlazaLetterThread.createNow());
@@ -391,6 +397,31 @@ public class PlazaLetterService {
         return candidates.get(pick);
     }
 
+
+    /**
+     * 유료 편지지 영구 구매 처리
+     * - 이미 보유 중이면 아무것도 안 함 (영구 보유 → 재사용 가능)
+     * - 미보유 시 잉크 차감 후 UserItem에 저장
+     */
+    private void purchaseLetterPaperIfNotOwned(User user, PlazaLetterColor color) {
+        // 편지지 색상명으로 Item 조회 (name = "PINK" / "GREEN" / "BLUE" / "PURPLE")
+        Item item = itemRepository.findByCategoryAndName(ItemCategory.LETTER_PAPER, color.name())
+                .orElseThrow(() -> new CustomException(LettersErrorCode.LETTER_PAPER_NOT_FOUND));
+
+        // 이미 보유 중이면 바로 리턴 (영구 보유 → 무료 재사용)
+        if (userItemRepository.existsByUserIdAndItemId(user.getId(), item.getId())) {
+            return;
+        }
+
+        // 미보유 → 잉크 차감 후 UserItem 저장
+        user.useInk(color.getPrice());
+        inkLogRepository.save(InkLog.builder()
+                .user(user)
+                .amount(-color.getPrice())
+                .reason(InkLogType.LETTER_COLOR_PURCHASE)
+                .build());
+        userItemRepository.save(UserItem.create(user, item));
+    }
 
     private PlazaLetterColor resolveBackgroundColor(String requested) {
         if (requested == null || requested.isBlank()) {

--- a/src/main/java/com/example/egobook_be/domain/shop/enums/ItemCategory.java
+++ b/src/main/java/com/example/egobook_be/domain/shop/enums/ItemCategory.java
@@ -8,5 +8,6 @@ public enum ItemCategory {
     SKIN,    // 거북이 스킨
     DECOR_ONE,  // 데코레이션 1
     DECOR_TWO,  // 데코레이션 2
-    BACKGROUND // 배경
+    BACKGROUND, // 배경
+    LETTER_PAPER  // 편지지 (유료 배경색)
 }

--- a/src/main/java/com/example/egobook_be/domain/shop/repository/ItemRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/shop/repository/ItemRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 
 public interface ItemRepository extends JpaRepository<Item, Long> {
@@ -16,5 +17,8 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
     List<Item> findAllByName(String name);
 
     boolean existsByNameAndPath(String name, String path);
+
+    // 편지지 아이템 조회 (카테고리 + 색상명으로 조회)
+    Optional<Item> findByCategoryAndName(ItemCategory category, String name);
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
- #122 

## 📝작업 내용

기존에 편지 작성 시 매번 잉크를 차감하던 방식을 UserItem 기반 영구 보유 구조로 변경

**편지지 구매 흐름**
1. 편지 작성 요청 시 `backgroundColor` 값 확인
2. WHITE면 무료로 바로 사용
3. 유료 색상이면 `UserItem` 보유 여부 확인
   - 보유 중 → 무료 재사용
   - 미보유 → 잉크 차감 + `UserItem` 저장 후 사용

**DB 작업 필요**
아래 SQL 실행 후 배포해주세요.
\```sql
-- 1. item 테이블 category ENUM 확장
ALTER TABLE item 
MODIFY category ENUM(
  'BACK', 'SKIN', 'DECOR_ONE', 'DECOR_TWO', 'BACKGROUND', 'LETTER_PAPER'
) NOT NULL;

-- 2. 편지지 아이템 4종 INSERT
INSERT INTO item (path, category, name, price, created_at, updated_at) VALUES
('letter', 'LETTER_PAPER', 'PINK',   75,  NOW(), NOW()),
('letter', 'LETTER_PAPER', 'GREEN',  100, NOW(), NOW()),
('letter', 'LETTER_PAPER', 'BLUE',   150, NOW(), NOW()),
('letter', 'LETTER_PAPER', 'PURPLE', 175, NOW(), NOW());
\```

## 💬리뷰 요구사항
