### PR TITLE
✨ Feat: 오늘의 질문 답변 조회 정보 추가

### DIFF
--- a/src/main/java/com/example/egobook_be/domain/question/data/TodayQuestionInitializer.java
+++ b/src/main/java/com/example/egobook_be/domain/question/data/TodayQuestionInitializer.java
@@ -23,8 +23,8 @@ public class TodayQuestionInitializer {
             return;
         }
 
-        //26.01.27 부터 1번 질문 시작
-        LocalDate startDate = LocalDate.of(2026, 1, 27);
+        //26.05.10 부터 1번 질문 시작
+        LocalDate startDate = LocalDate.of(2026, 5, 5);
 
         List<TodayQuestion> questions = new ArrayList<>();
 

--- a/src/main/java/com/example/egobook_be/domain/question/dto/FriendAnswerResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/question/dto/FriendAnswerResDto.java
@@ -11,7 +11,11 @@ public record FriendAnswerResDto(
         String nickname,
         Integer level,
         String content,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        String topAbilityName
 ) {
+    public FriendAnswerResDto(Long answerId, Long userId, String nickname, Integer level, String content, LocalDateTime createdAt) {
+        this(answerId, userId, nickname, level, content, createdAt, null);
+    }
 }
 

--- a/src/main/java/com/example/egobook_be/domain/question/dto/FriendAnswerResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/question/dto/FriendAnswerResDto.java
@@ -9,6 +9,7 @@ public record FriendAnswerResDto(
         Long answerId,
         Long userId,
         String nickname,
+        Integer level,
         String content,
         LocalDateTime createdAt
 ) {

--- a/src/main/java/com/example/egobook_be/domain/question/dto/PublicAnswerResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/question/dto/PublicAnswerResDto.java
@@ -9,6 +9,7 @@ public record PublicAnswerResDto(
         Long answerId,
         Long userId,
         String nickname,
+        Integer level,
         String content,
         LocalDateTime createdAt
 ) {

--- a/src/main/java/com/example/egobook_be/domain/question/dto/PublicAnswerResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/question/dto/PublicAnswerResDto.java
@@ -10,6 +10,7 @@ public record PublicAnswerResDto(
         Long userId,
         String nickname,
         Integer level,
+        String topAbilityName,
         String content,
         LocalDateTime createdAt
 ) {

--- a/src/main/java/com/example/egobook_be/domain/question/mapper/PublicAnswerMapper.java
+++ b/src/main/java/com/example/egobook_be/domain/question/mapper/PublicAnswerMapper.java
@@ -10,6 +10,7 @@ public class PublicAnswerMapper {
                 .answerId(answer.getId())
                 .userId(answer.getUser().getId())
                 .nickname(answer.getUser().getNickname())
+                .level(answer.getUser().getLevel())
                 .content(answer.getContent())
                 .createdAt(answer.getCreatedAt())
                 .build();

--- a/src/main/java/com/example/egobook_be/domain/question/mapper/PublicAnswerMapper.java
+++ b/src/main/java/com/example/egobook_be/domain/question/mapper/PublicAnswerMapper.java
@@ -2,15 +2,17 @@ package com.example.egobook_be.domain.question.mapper;
 
 import com.example.egobook_be.domain.question.dto.PublicAnswerResDto;
 import com.example.egobook_be.domain.question.entity.QuestionAnswer;
+import com.example.egobook_be.domain.user.entity.Ability;
 
 public class PublicAnswerMapper {
 
-    public static PublicAnswerResDto toDto(QuestionAnswer answer) {
+    public static PublicAnswerResDto toDto(QuestionAnswer answer, Ability ability) {
         return PublicAnswerResDto.builder()
                 .answerId(answer.getId())
                 .userId(answer.getUser().getId())
                 .nickname(answer.getUser().getNickname())
                 .level(answer.getUser().getLevel())
+                .topAbilityName(ability.getTopAbilityName())
                 .content(answer.getContent())
                 .createdAt(answer.getCreatedAt())
                 .build();

--- a/src/main/java/com/example/egobook_be/domain/question/repository/QuestionAnswerRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/question/repository/QuestionAnswerRepository.java
@@ -1,6 +1,7 @@
 package com.example.egobook_be.domain.question.repository;
 
 import com.example.egobook_be.domain.question.dto.FriendAnswerResDto;
+import com.example.egobook_be.domain.question.dto.PublicAnswerResDto;
 import com.example.egobook_be.domain.question.entity.QuestionAnswer;
 import com.example.egobook_be.domain.question.entity.TodayQuestion;
 import com.example.egobook_be.domain.question.enums.AnswerVisibility;
@@ -34,6 +35,7 @@ public interface QuestionAnswerRepository extends JpaRepository<QuestionAnswer, 
             qa.id,
             u.id,
             u.nickname,
+            u.level,
             qa.content,
             qa.createdAt
         )
@@ -50,7 +52,6 @@ public interface QuestionAnswerRepository extends JpaRepository<QuestionAnswer, 
             @Param("friendIds") List<Long> friendIds,
             Pageable pageable
     );
-
     List<QuestionAnswer> findByUserOrderByCreatedAtDesc(User user);
 
     Optional<QuestionAnswer> findByIdAndUser(Long id, User user);

--- a/src/main/java/com/example/egobook_be/domain/question/service/TodayQuestionService.java
+++ b/src/main/java/com/example/egobook_be/domain/question/service/TodayQuestionService.java
@@ -35,7 +35,9 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -179,25 +181,31 @@ public class TodayQuestionService {
 
         TodayQuestion todayQuestion = todayQuestionRepository
                 .findByQuestionDate(LocalDate.now())
-                .orElseThrow(() ->
-                        new CustomException(QuestionErrorCode.TODAY_QUESTION_NOT_FOUND)
-                );
+                .orElseThrow(() -> new CustomException(QuestionErrorCode.TODAY_QUESTION_NOT_FOUND));
 
         PageRequest pageable = PageRequest.of(
-                page -1,
+                page - 1,
                 size,
                 Sort.by(Sort.Direction.DESC, "createdAt")
         );
 
-        Slice<QuestionAnswer> slice =
-                questionAnswerRepository.findPublicAnswersWithUser(
-                        todayQuestion,
-                        AnswerVisibility.PUBLIC,
-                        pageable
-                );
+        Slice<QuestionAnswer> slice = questionAnswerRepository.findPublicAnswersWithUser(
+                todayQuestion,
+                AnswerVisibility.PUBLIC,
+                pageable
+        );
+
+        List<Long> userIds = slice.getContent().stream()
+                .map(qa -> qa.getUser().getId())
+                .toList();
+
+        Map<Long, Ability> abilityMap = abilityRepository.findByUserIdIn(userIds).stream()
+                .collect(Collectors.toMap(a -> a.getUser().getId(), a -> a));
 
         log.info("[TodayQuestionService] getPublicAnswers End");
-        return SliceResponse.of(slice, PublicAnswerMapper::toDto);
+        return SliceResponse.of(slice, qa ->
+                PublicAnswerMapper.toDto(qa, abilityMap.get(qa.getUser().getId()))
+        );
     }
 
     /** 답변 수정 **/
@@ -277,8 +285,32 @@ public class TodayQuestionService {
                         pageable
                 );
 
+        // ability 조회 후 topAbilityName 세팅
+        List<Long> userIds = slice.getContent().stream()
+                .map(FriendAnswerResDto::userId)
+                .toList();
+
+        Map<Long, Ability> abilityMap = abilityRepository.findByUserIdIn(userIds).stream()
+                .collect(Collectors.toMap(a -> a.getUser().getId(), a -> a));
+
+        Slice<FriendAnswerResDto> enrichedSlice = new SliceImpl<>(
+                slice.getContent().stream()
+                        .map(dto -> FriendAnswerResDto.builder()
+                                .answerId(dto.answerId())
+                                .userId(dto.userId())
+                                .nickname(dto.nickname())
+                                .level(dto.level())
+                                .topAbilityName(abilityMap.get(dto.userId()).getTopAbilityName())
+                                .content(dto.content())
+                                .createdAt(dto.createdAt())
+                                .build())
+                        .toList(),
+                pageable,
+                slice.hasNext()
+        );
+
         log.info("[TodayQuestionService] getFriendsAnswers End - userId: {}", userId);
-        return SliceResponse.of(slice);
+        return SliceResponse.of(enrichedSlice);
     }
 
     /** 내가 지금까지 작성한 모든 답변 조회 **/

--- a/src/main/java/com/example/egobook_be/domain/user/entity/Ability.java
+++ b/src/main/java/com/example/egobook_be/domain/user/entity/Ability.java
@@ -3,6 +3,9 @@ package com.example.egobook_be.domain.user.entity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.Comparator;
+import java.util.Map;
+
 @Entity
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -86,4 +89,17 @@ public class Ability {
 
     public Integer addSelfEsteem(int amount) { return this.selfEsteem.addScore(amount); }
 
+    public String getTopAbilityName() {
+        Map<String, AbilityStat> map = Map.of(
+                "공감성", empathy,
+                "자존감", selfEsteem,
+                "성실함", diligence,
+                "긍정사고", positiveThinking,
+                "감정조절", emotionRegulation
+        );
+        return map.entrySet().stream()
+                .max(Comparator.comparingInt(e -> e.getValue().getScore()))
+                .map(Map.Entry::getKey)
+                .orElse("공감성");
+    }
 }

--- a/src/main/java/com/example/egobook_be/domain/user/repository/AbilityRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/user/repository/AbilityRepository.java
@@ -3,6 +3,8 @@ package com.example.egobook_be.domain.user.repository;
 import com.example.egobook_be.domain.user.entity.Ability;
 import com.example.egobook_be.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -12,4 +14,7 @@ import java.util.Optional;
 public interface AbilityRepository extends JpaRepository<Ability, Long> {
     Optional<Ability> findByUser(User user);
     void deleteByUserIn(List<User> users);
+
+    @Query("select a from Ability a join fetch a.user where a.user.id in :userIds")
+    List<Ability> findByUserIdIn(@Param("userIds") List<Long> userIds);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈


## 📝작업 내용
오늘의 질문 전체 공개 답변 조회(getPublicAnswers)와 친구 답변 조회(getFriendsAnswers) API에서 답변 작성자의 레벨과 최고 능력치 이름을 함께 반환하도록 수정했습니다.
PublicAnswerResDto와 FriendAnswerResDto에 level과 topAbilityName 필드를 추가했으며, Ability 엔티티에 5가지 능력치(공감성, 자존감, 성실함, 긍정사고, 감정조절) 중 가장 높은 점수의 능력 이름을 반환하는 getTopAbilityName() 메서드를 추가했습니다.

<img width="581" height="617" alt="image" src="https://github.com/user-attachments/assets/673c5e7a-ff2d-4a5d-a3e4-1805afc45aa2" />

<img width="612" height="621" alt="image" src="https://github.com/user-attachments/assets/ee8d759b-5d50-4c0d-8912-79104fa92c99" />


## 💬리뷰 요구사항
