### PR TITLE
🐛  Fix: 아이템 목록 조회시 편지 응답값 필드 오류 수정

### DIFF
--- a/src/main/java/com/example/egobook_be/domain/shop/service/AdminShopService.java
+++ b/src/main/java/com/example/egobook_be/domain/shop/service/AdminShopService.java
@@ -78,8 +78,8 @@ public class AdminShopService {
                         item.getCategory(),
                         item.getName(),
                         item.getPrice(),
-                        item.getStatus(),
                         item.getFullUrl(cloudfrontDomain + "/shop"),
+                        item.getStatus(),
                         item.getCreatedAt()
                 )).toList();
 


### PR DESCRIPTION
## #️⃣연관된 이슈
- #212

## 📝작업 내용

**1.** 아이템 목록 조회시 편지 응답값 필드 오류(imageurl과 status의 내용이 바뀜) 수정

-

> 테스트 결과
> 

<img width="557" height="353" alt="image" src="https://github.com/user-attachments/assets/95ef6bfa-e160-4ece-80e7-3f691357f8fd" />