### PR TITLE
🐛 Fix: 편지지 아이템 구매/착용 URL 경로 수정 및 letter_paper path 예외처리 추가

### DIFF
--- a/src/main/java/com/example/egobook_be/domain/shop/service/AdminShopService.java
+++ b/src/main/java/com/example/egobook_be/domain/shop/service/AdminShopService.java
@@ -40,6 +40,8 @@ public class AdminShopService {
         path = path.equals("decor_two") ? "decor2" : path;
         path = path.equals("decor_one") ? "decor1" : path;
 
+        path = path.equals("letter_paper") ? "letter" : path;
+
         // 이미지 s3에 업로드
         String imageUrl = s3ImageService.upload(reqDto.file(),path);
 

--- a/src/main/java/com/example/egobook_be/domain/shop/service/ShopService.java
+++ b/src/main/java/com/example/egobook_be/domain/shop/service/ShopService.java
@@ -93,7 +93,7 @@ public class ShopService {
          */
         return SliceResponse.of(sliceEntity, item -> {
             Boolean isPurchased = userItemMap.containsKey(item.getId());
-            return itemMapper.toShopItemInfoResDto(item, getShopCloudFrontDomain(), getMyCloudFrontDomain(), isPurchased, userItemMap.getOrDefault(item.getId(), false));
+            return itemMapper.toShopItemInfoResDto(item, getCloudFrontDomainByCategory(item.getCategory()), getMyCloudFrontDomain(), isPurchased, userItemMap.getOrDefault(item.getId(), false));
         });
     }
 
@@ -131,7 +131,7 @@ public class ShopService {
 
         log.info("[ShopService] purchaseItem End - userId: {}", userId);
         // 4. 아이템 구매 후, 해당 아이템에 대한 정보를 반환한다.
-        return userItemMapper.toItemInfoResDto(userItem, item, getShopCloudFrontDomain());
+        return userItemMapper.toItemInfoResDto(userItem, item, getCloudFrontDomainByCategory(item.getCategory()));
     }
 
     /**
@@ -157,7 +157,8 @@ public class ShopService {
 
         // 2. 멱등성 체크: 이미 원하는 상태라면 DB 변경 없이 바로 반환 (불필요한 쿼리 방지)
         if (targetUserItem.getIsEquipped() == targetStatus) {
-            return userItemMapper.toItemInfoResDto(targetUserItem, targetUserItem.getItem(), cloudfrontDomain);
+            return userItemMapper.toItemInfoResDto(targetUserItem, targetUserItem.getItem(),
+                    getCloudFrontDomainByCategory(targetUserItem.getItem().getCategory()));
         }
 
         /*
@@ -187,7 +188,8 @@ public class ShopService {
 
         log.info("[ShopService] equipItem End - userId: {}", userId);
         // 4. 변경된 정보 반환
-        return userItemMapper.toItemInfoResDto(targetUserItem, targetUserItem.getItem(), getMyCloudFrontDomain());
+        return userItemMapper.toItemInfoResDto(targetUserItem, targetUserItem.getItem(),
+                getCloudFrontDomainByCategory(targetUserItem.getItem().getCategory()));
     }
 
     /**
@@ -202,7 +204,8 @@ public class ShopService {
         log.info("[ShopService] getEquippedItems End - userId: {}", userId);
         // 2. 조회해온 각 아이템을 dto로 변환 (Fetch Join 썼으므로 N+1 발생 안함)
         return equippedItems.stream()
-                .map(userItem -> userItemMapper.toItemInfoResDto(userItem, userItem.getItem(), getMyCloudFrontDomain()))
+                .map(userItem -> userItemMapper.toItemInfoResDto(userItem, userItem.getItem(),
+                        getCloudFrontDomainByCategory(userItem.getItem().getCategory())))
                 .toList();
     }
 
@@ -211,5 +214,12 @@ public class ShopService {
     }
     private String getMyCloudFrontDomain(){
         return cloudfrontDomain+"/my";
+    }
+
+    private String getCloudFrontDomainByCategory(ItemCategory category) {
+        return switch (category) {
+            case LETTER_PAPER -> cloudfrontDomain + "/letter";
+            default -> cloudfrontDomain + "/shop";
+        };
     }
 }

--- a/src/main/java/com/example/egobook_be/global/loader/ItemInitializer.java
+++ b/src/main/java/com/example/egobook_be/global/loader/ItemInitializer.java
@@ -35,6 +35,7 @@ public class ItemInitializer implements ApplicationRunner {
     String PATH_DECOR_TWO = "decor2";
     String PATH_BACKGROUND = "background";
 
+    String PATH_LETTER_PAPER = "letter";
 
     @Override
     @Transactional
@@ -170,7 +171,20 @@ public class ItemInitializer implements ApplicationRunner {
         items.add(buildBackgroundItem("Blossom.png", 750));
         items.add(buildBackgroundItem("Beach.png", 1000));
 
+
+
+        items.add(buildLetterPaperItem("Blue.png", 150));
+        items.add(buildLetterPaperItem("Green.png", 100));
+        items.add(buildLetterPaperItem("Pink.png", 75));
+        items.add(buildLetterPaperItem("Purple.png", 175));
+
+
         return items;
+    }
+
+
+    private Item buildLetterPaperItem(String name, Integer price) {
+        return buildItem(PATH_LETTER_PAPER, ItemCategory.LETTER_PAPER, name, price);
     }
 
     /**


### PR DESCRIPTION
## #️⃣연관된 이슈
- ex) #이슈번호, #이슈번호

## 📝작업 내용
 - ShopService: CloudFront URL 생성 시 카테고리별 분기 처리
  (LETTER_PAPER → /letter, 기타 → /shop)
- AdminShopService: letter_paper path 변환 예외처리 추가
  (letter_paper → letter)
- ItemInitializer: 편지지(LETTER_PAPER) 4종 초기 데이터 추가
  (Blue, Green, Pink, Purple)

기존 아이템(BACK, SKIN, DECOR 등) 동작에는 영향 없음
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?