### PR TITLE
✨ Feat: 신고 승인 거절 API 추가

### DIFF
--- a/src/main/java/com/example/egobook_be/domain/letters/entity/PlazaLetter.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/entity/PlazaLetter.java
@@ -111,4 +111,7 @@ public class PlazaLetter {
         this.arrivedAt = arrivedAt;
     }
 
+    public void hide() {
+        this.status = PlazaLetterStatus.HIDDEN;
+    }
 }

--- a/src/main/java/com/example/egobook_be/domain/letters/entity/PlazaLetterReply.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/entity/PlazaLetterReply.java
@@ -53,7 +53,11 @@ public class PlazaLetterReply {
     }
 
     public enum ReplyStatus {
-        AI_REPLIED, ARRIVED, SENT, DELETED
+        AI_REPLIED, ARRIVED, SENT, DELETED, HIDDEN
+    }
+
+    public void hide() {
+        this.status = ReplyStatus.HIDDEN;
     }
 }
 

--- a/src/main/java/com/example/egobook_be/domain/letters/entity/PlazaLetterStatus.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/entity/PlazaLetterStatus.java
@@ -9,6 +9,7 @@ public enum PlazaLetterStatus {
     AI_REPLIED,
     SENT,
     ANALYZING,   //AI 분석 중
-    CANCELLED    //사용자가 취소함
+    CANCELLED,    //사용자가 취소함
+    HIDDEN
 }
 

--- a/src/main/java/com/example/egobook_be/domain/letters/enums/LettersErrorCode.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/enums/LettersErrorCode.java
@@ -21,7 +21,8 @@ public enum LettersErrorCode implements BaseErrorCode {
     ALREADY_REPORTED(HttpStatus.BAD_REQUEST, "PLAZA400_ALREADY_REPORTED", "이미 신고한 답장입니다."),
     NOT_FRIEND(HttpStatus.BAD_REQUEST, "PLAZA400_NOT_FRIEND", "친구 관계가 아닙니다."),
     INSUFFICIENT_INK(HttpStatus.BAD_REQUEST, "PLAZA400_INSUFFICIENT_INK", "잉크가 부족합니다."),
-
+    ALREADY_REPORTED_LETTER(HttpStatus.BAD_REQUEST, "PLAZA400_ALREADY_REPORTED_LETTER", "이미 처리된 편지입니다."),
+    ALREADY_REPORTED_REPLY(HttpStatus.BAD_REQUEST, "PLAZA400_ALREADY_REPORTED_REPLY", "이미 처리된 답장입니다."),
 
 
 

--- a/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterReplyReportRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterReplyReportRepository.java
@@ -2,6 +2,7 @@ package com.example.egobook_be.domain.letters.repository;
 
 import com.example.egobook_be.domain.letters.entity.PlazaLetterReply;
 import com.example.egobook_be.domain.letters.entity.PlazaLetterReplyReport;
+import com.example.egobook_be.global.enums.ReportStatus;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -65,4 +66,8 @@ public interface PlazaLetterReplyReportRepository extends JpaRepository<PlazaLet
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM PlazaLetterReplyReport r WHERE r.reply.replyId = :replyId")
     void deleteAllByReplyId(@Param("replyId") Long replyId);
+
+    @Query("SELECT COUNT(r) FROM PlazaLetterReplyReport r WHERE r.reply.replyId = :replyId AND r.status = :status")
+    long countByReplyIdAndStatus(@Param("replyId") Long replyId, @Param("status") ReportStatus status);
+
 }

--- a/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterReportRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterReportRepository.java
@@ -1,6 +1,7 @@
 package com.example.egobook_be.domain.letters.repository;
 
 import com.example.egobook_be.domain.letters.entity.PlazaLetterReport;
+import com.example.egobook_be.global.enums.ReportStatus;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -48,5 +49,8 @@ public interface PlazaLetterReportRepository extends JpaRepository<PlazaLetterRe
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM PlazaLetterReport r WHERE r.letter.letterId = :letterId")
     void deleteAllByLetterId(@Param("letterId") Long letterId);
+
+    @Query("SELECT COUNT(r) FROM PlazaLetterReport r WHERE r.letter.letterId = :letterId AND r.status = :status")
+    long countByLetterIdAndStatus(@Param("letterId") Long letterId, @Param("status") ReportStatus status);
 }
 

--- a/src/main/java/com/example/egobook_be/domain/letters/service/LetterReportAdminService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/LetterReportAdminService.java
@@ -9,6 +9,7 @@ import com.example.egobook_be.domain.letters.repository.PlazaLetterReplyReposito
 import com.example.egobook_be.domain.letters.repository.PlazaLetterReportRepository;
 import com.example.egobook_be.domain.letters.repository.PlazaLetterReplyReportRepository;
 import com.example.egobook_be.domain.letters.repository.PlazaLetterRepository;
+import com.example.egobook_be.global.enums.ReportStatus;
 import com.example.egobook_be.global.exception.CustomException;
 import com.example.egobook_be.global.response.SliceResponse;
 import lombok.RequiredArgsConstructor;
@@ -132,5 +133,67 @@ public class LetterReportAdminService {
         }
         replyReportRepository.deleteAllByReplyId(replyId);      // 신고 내역 먼저 삭제
         replyRepository.deleteById(replyId);
+    }
+
+    @Transactional
+    public void approveLetterReport(Long reportId) {
+        PlazaLetterReport report = letterReportRepository.findByIdWithLetter(reportId)
+                .orElseThrow(() -> new CustomException(LettersErrorCode.LETTER_NOT_FOUND));
+
+        if (report.getStatus() != ReportStatus.PENDING) {
+            throw new CustomException(LettersErrorCode.ALREADY_REPORTED_LETTER);
+        }
+
+        report.approve();
+
+        long approvedCount = letterReportRepository
+                .countByLetterIdAndStatus(report.getLetter().getLetterId(), ReportStatus.RESOLVED);
+
+        if (approvedCount >= 3) {
+            report.getLetter().hide();
+        }
+    }
+
+    @Transactional
+    public void rejectLetterReport(Long reportId) {
+        PlazaLetterReport report = letterReportRepository.findByIdWithLetter(reportId)
+                .orElseThrow(() -> new CustomException(LettersErrorCode.LETTER_NOT_FOUND));
+
+        if (report.getStatus() != ReportStatus.PENDING) {
+            throw new CustomException(LettersErrorCode.ALREADY_REPORTED_LETTER);
+        }
+
+        report.reject();
+    }
+
+    @Transactional
+    public void approveReplyReport(Long reportId) {
+        PlazaLetterReplyReport report = replyReportRepository.findByIdWithReply(reportId)
+                .orElseThrow(() -> new CustomException(LettersErrorCode.LETTER_NOT_FOUND));
+
+        if (report.getStatus() != ReportStatus.PENDING) {
+            throw new CustomException(LettersErrorCode.ALREADY_REPORTED_REPLY);
+        }
+
+        report.approve();
+
+        long approvedCount = replyReportRepository
+                .countByReplyIdAndStatus(report.getReply().getReplyId(), ReportStatus.RESOLVED);
+
+        if (approvedCount >= 3) {
+            report.getReply().hide();
+        }
+    }
+
+    @Transactional
+    public void rejectReplyReport(Long reportId) {
+        PlazaLetterReplyReport report = replyReportRepository.findByIdWithReply(reportId)
+                .orElseThrow(() -> new CustomException(LettersErrorCode.LETTER_NOT_FOUND));
+
+        if (report.getStatus() != ReportStatus.PENDING) {
+            throw new CustomException(LettersErrorCode.ALREADY_REPORTED_REPLY);
+        }
+
+        report.reject();
     }
 }

--- a/src/main/java/com/example/egobook_be/domain/question/controller/AdminReportController.java
+++ b/src/main/java/com/example/egobook_be/domain/question/controller/AdminReportController.java
@@ -108,4 +108,46 @@ public class AdminReportController implements AdminReportControllerDocs {
         answerReportAdminService.deleteAnswer(answerId);
         return ResponseEntity.ok(GlobalResponse.success("신고된 오늘의 질문 답변 수동 삭제 성공", null));
     }
+
+    @Override
+    @PatchMapping("/letters/{reportId}/approve")
+    public ResponseEntity<GlobalResponse<Void>> approveLetterReport(@PathVariable Long reportId) {
+        letterReportAdminService.approveLetterReport(reportId);
+        return ResponseEntity.ok(GlobalResponse.success("편지 신고 승인 성공", null));
+    }
+
+    @Override
+    @PatchMapping("/letters/{reportId}/reject")
+    public ResponseEntity<GlobalResponse<Void>> rejectLetterReport(@PathVariable Long reportId) {
+        letterReportAdminService.rejectLetterReport(reportId);
+        return ResponseEntity.ok(GlobalResponse.success("편지 신고 거절 성공", null));
+    }
+
+    @Override
+    @PatchMapping("/replies/{reportId}/approve")
+    public ResponseEntity<GlobalResponse<Void>> approveReplyReport(@PathVariable Long reportId) {
+        letterReportAdminService.approveReplyReport(reportId);
+        return ResponseEntity.ok(GlobalResponse.success("편지 답장 신고 승인 성공", null));
+    }
+
+    @Override
+    @PatchMapping("/replies/{reportId}/reject")
+    public ResponseEntity<GlobalResponse<Void>> rejectReplyReport(@PathVariable Long reportId) {
+        letterReportAdminService.rejectReplyReport(reportId);
+        return ResponseEntity.ok(GlobalResponse.success("편지 답장 신고 거절 성공", null));
+    }
+
+    @Override
+    @PatchMapping("/answers/{reportId}/approve")
+    public ResponseEntity<GlobalResponse<Void>> approveAnswerReport(@PathVariable Long reportId) {
+        answerReportAdminService.approveReport(reportId);
+        return ResponseEntity.ok(GlobalResponse.success("답변 신고 승인 성공", null));
+    }
+
+    @Override
+    @PatchMapping("/answers/{reportId}/reject")
+    public ResponseEntity<GlobalResponse<Void>> rejectAnswerReport(@PathVariable Long reportId) {
+        answerReportAdminService.rejectReport(reportId);
+        return ResponseEntity.ok(GlobalResponse.success("답변 신고 거절 성공", null));
+    }
 }

--- a/src/main/java/com/example/egobook_be/domain/question/controller/AdminReportControllerDocs.java
+++ b/src/main/java/com/example/egobook_be/domain/question/controller/AdminReportControllerDocs.java
@@ -61,4 +61,22 @@ public interface AdminReportControllerDocs {
     ResponseEntity<GlobalResponse<Void>> deleteAnswer(
             @PathVariable Long answerId
     );
+
+    @Operation(summary = "[관리자] 편지 신고 승인", description = "승인 3회 누적 시 편지가 비공개 처리됩니다.")
+    ResponseEntity<GlobalResponse<Void>> approveLetterReport(@PathVariable Long reportId);
+
+    @Operation(summary = "[관리자] 편지 신고 거절")
+    ResponseEntity<GlobalResponse<Void>> rejectLetterReport(@PathVariable Long reportId);
+
+    @Operation(summary = "[관리자] 편지 답장 신고 승인", description = "승인 3회 누적 시 답장이 비공개 처리됩니다.")
+    ResponseEntity<GlobalResponse<Void>> approveReplyReport(@PathVariable Long reportId);
+
+    @Operation(summary = "[관리자] 편지 답장 신고 거절")
+    ResponseEntity<GlobalResponse<Void>> rejectReplyReport(@PathVariable Long reportId);
+
+    @Operation(summary = "[관리자] 오늘의 질문 답변 신고 승인", description = "승인 3회 누적 시 답변이 비공개 처리됩니다.")
+    ResponseEntity<GlobalResponse<Void>> approveAnswerReport(@PathVariable Long reportId);
+
+    @Operation(summary = "[관리자] 오늘의 질문 답변 신고 거절")
+    ResponseEntity<GlobalResponse<Void>> rejectAnswerReport(@PathVariable Long reportId);
 }

--- a/src/main/java/com/example/egobook_be/domain/question/exception/QuestionErrorCode.java
+++ b/src/main/java/com/example/egobook_be/domain/question/exception/QuestionErrorCode.java
@@ -45,6 +45,11 @@ public enum QuestionErrorCode implements BaseErrorCode {
             "해당 id가 존재하지 않습니다."
     ),
 
+    ALREADY_RESOLVED(
+            HttpStatus.CONFLICT,
+            "이미 처리된 신고입니다."
+    ),
+
     DUPLICATE_QUESTION_DATE(
             HttpStatus.CONFLICT,
             "해당 날짜에는 이미 활성화된 질문이 존재합니다."

--- a/src/main/java/com/example/egobook_be/domain/question/repository/AnswerReportRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/question/repository/AnswerReportRepository.java
@@ -3,6 +3,7 @@ package com.example.egobook_be.domain.question.repository;
 import com.example.egobook_be.domain.question.entity.AnswerReport;
 import com.example.egobook_be.domain.question.entity.QuestionAnswer;
 import com.example.egobook_be.domain.user.entity.User;
+import com.example.egobook_be.global.enums.ReportStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -44,4 +45,8 @@ public interface AnswerReportRepository
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM AnswerReport ar WHERE ar.answer.id = :answerId")
     void deleteAllByAnswerId(@Param("answerId") Long answerId);
+
+    //승인 획수 카운트
+    @Query("SELECT COUNT(ar) FROM AnswerReport ar WHERE ar.answer.id = :answerId AND ar.status = :status")
+    long countByAnswerIdAndStatus(@Param("answerId") Long answerId, @Param("status") ReportStatus status);
 }

--- a/src/main/java/com/example/egobook_be/domain/question/service/AnswerReportAdminService.java
+++ b/src/main/java/com/example/egobook_be/domain/question/service/AnswerReportAdminService.java
@@ -2,9 +2,11 @@ package com.example.egobook_be.domain.question.service;
 
 import com.example.egobook_be.domain.question.dto.AnswerReportAdminResDto;
 import com.example.egobook_be.domain.question.entity.AnswerReport;
+import com.example.egobook_be.domain.question.enums.AnswerVisibility;
 import com.example.egobook_be.domain.question.exception.QuestionErrorCode;
 import com.example.egobook_be.domain.question.repository.AnswerReportRepository;
 import com.example.egobook_be.domain.question.repository.QuestionAnswerRepository;
+import com.example.egobook_be.global.enums.ReportStatus;
 import com.example.egobook_be.global.exception.CustomException;
 import com.example.egobook_be.global.response.SliceResponse;
 import lombok.RequiredArgsConstructor;
@@ -73,5 +75,36 @@ public class AnswerReportAdminService {
         answerReportRepository.deleteAllByAnswerId(answerId);   // 신고 내역 먼저 삭제
         questionAnswerRepository.deleteById(answerId);
         log.info("[AnswerReportAdminService] deleteAnswer End - answerId: {}", answerId);
+    }
+
+    @Transactional
+    public void approveReport(Long reportId) {
+        AnswerReport report = answerReportRepository.findByIdWithAnswerAndUser(reportId)
+                .orElseThrow(() -> new CustomException(QuestionErrorCode.ANSWER_NOT_FOUND));
+
+        if (report.getStatus() != ReportStatus.PENDING) {
+            throw new CustomException(QuestionErrorCode.ALREADY_RESOLVED);
+        }
+
+        report.approve();
+
+        long approvedCount = answerReportRepository
+                .countByAnswerIdAndStatus(report.getAnswer().getId(), ReportStatus.RESOLVED);
+
+        if (approvedCount >= 3) {
+            report.getAnswer().update(report.getAnswer().getContent(), AnswerVisibility.PRIVATE);
+        }
+    }
+
+    @Transactional
+    public void rejectReport(Long reportId) {
+        AnswerReport report = answerReportRepository.findByIdWithAnswerAndUser(reportId)
+                .orElseThrow(() -> new CustomException(QuestionErrorCode.ANSWER_NOT_FOUND));
+
+        if (report.getStatus() != ReportStatus.PENDING) {
+            throw new CustomException(QuestionErrorCode.ALREADY_RESOLVED);
+        }
+
+        report.reject();
     }
 }

--- a/src/main/java/com/example/egobook_be/domain/question/service/AnswerReportService.java
+++ b/src/main/java/com/example/egobook_be/domain/question/service/AnswerReportService.java
@@ -49,11 +49,11 @@ public class AnswerReportService {
                         .build()
         );
 
-        // 3회 누적 신고 시 visibility → PRIVATE으로 변경
-        long reportCount = answerReportRepository.countByAnswer(answer);
-        if (reportCount >= 3) {
-            answer.update(answer.getContent(), AnswerVisibility.PRIVATE);
-        }
+//        // 3회 누적 신고 시 visibility → PRIVATE으로 변경
+//        long reportCount = answerReportRepository.countByAnswer(answer);
+//        if (reportCount >= 3) {
+//            answer.update(answer.getContent(), AnswerVisibility.PRIVATE);
+//        }
 
         return new AnswerReportResDto(
                 report.getId(),

--- a/src/main/java/com/example/egobook_be/global/entity/BaseReportEntity.java
+++ b/src/main/java/com/example/egobook_be/global/entity/BaseReportEntity.java
@@ -28,5 +28,13 @@ public abstract class BaseReportEntity {
     @Column(nullable = false)
     private ReportStatus status;        // 공통 신고 상태
 
+    public void approve() {
+        this.status = ReportStatus.RESOLVED;
+    }
+
+    public void reject() {
+        this.status = ReportStatus.REFUSED;
+    }
+
     // reporterId는 도메인마다 타입이 달라서 각 자식에서 선언
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
- ex) #이슈번호, #이슈번호

## 📝작업 내용
- 기존에 신고 누적 3회 시 편지, 답장, 오늘의 질문 답변이 자동으로 삭제 또는 비공개 처리되던 방식을 제거하고, 관리자가 신고 내역을 검토한 후 직접 승인 또는 거절할 수 있는 시스템으로 변경했습니다.

- BaseReportEntity에 approve() / reject() 메서드를 추가하고, 각 Admin 서비스에 승인/거절 메서드를 구현했습니다. 관리자가 승인한 횟수가 3회 누적되면 해당 콘텐츠가 비공개(PRIVATE 또는 HIDDEN) 처리되도록 하였습니다.

- 승인이 3번 된 후에 삭제 되는 것도 확인하였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
