### PR TITLE
🐛 Fix: 콘텐츠관리자 api 오류 수정

### DIFF
--- a/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterRepository.java
@@ -28,6 +28,8 @@ public interface PlazaLetterRepository extends JpaRepository<PlazaLetter, Long> 
 
     List<PlazaLetter> findByLetterIdIn(List<Long> letterIds);
 
+    long countByStatus(PlazaLetterStatus status);
+
     Slice<PlazaLetter> findByReceiverIdOrderByArrivedAtDesc(
             Long receiverId,
             Pageable pageable

--- a/src/main/java/com/example/egobook_be/domain/letters/service/BadWordBlockLogService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/BadWordBlockLogService.java
@@ -1,0 +1,32 @@
+package com.example.egobook_be.domain.letters.service;
+
+import com.example.egobook_be.domain.letters.entity.BadWordBlockLog;
+import com.example.egobook_be.domain.letters.enums.BlockType;
+import com.example.egobook_be.domain.letters.repository.BadWordBlockLogRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BadWordBlockLogService {
+
+    private final BadWordBlockLogRepository badWordBlockLogRepo;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void saveBlockLog(Long userId, BlockType type, String text,
+                             List<String> badWords, double score) {
+        badWordBlockLogRepo.save(BadWordBlockLog.builder()
+                .userId(userId)
+                .type(type)
+                .originalText(text)
+                .badWords(badWords != null ? badWords : List.of())
+                .score(score)
+                .blockedAt(LocalDateTime.now())
+                .build());
+    }
+}

--- a/src/main/java/com/example/egobook_be/domain/letters/service/PlazaLetterDispatchService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/PlazaLetterDispatchService.java
@@ -1,7 +1,9 @@
 package com.example.egobook_be.domain.letters.service;
 
+import com.example.egobook_be.domain.letters.entity.LetterSendFailLog;
 import com.example.egobook_be.domain.letters.entity.PlazaLetter;
 import com.example.egobook_be.domain.letters.entity.PlazaLetterStatus;
+import com.example.egobook_be.domain.letters.repository.LetterSendFailLogRepository;
 import com.example.egobook_be.domain.letters.repository.PlazaLetterRepository;
 import com.example.egobook_be.domain.restriction.enums.RestrictionDomainType;
 import com.example.egobook_be.domain.restriction.service.RestrictionGuardService;
@@ -26,6 +28,7 @@ public class PlazaLetterDispatchService {
     private final PlazaLetterRepository plazaLetterRepository;
     private final UserRepository userRepository;
     private final RestrictionGuardService restrictionGuardService;
+    private final LetterSendFailLogRepository letterFailLogRepo;
 
     private static final int BATCH_SIZE = 20;
     private static final int RECEIVER_POOL_SIZE = 300;
@@ -49,7 +52,16 @@ public class PlazaLetterDispatchService {
                 PageRequest.of(0, RECEIVER_POOL_SIZE)
         );
 
-        if (receiverPool.isEmpty()) return;
+        if (receiverPool.isEmpty()) {
+            for (PlazaLetter letter : waitingLetters) {
+                letterFailLogRepo.save(LetterSendFailLog.builder()
+                        .letterId(letter.getLetterId())
+                        .failedAt(LocalDateTime.now())
+                        .reason("수신 가능한 유저 없음")
+                        .build());
+            }
+            return;
+        }
 
         // LETTER 제재 사용자 수신자 풀에서 제외
         Set<Long> restrictedIds = restrictionGuardService.getActivelyRestrictedUserIds(RestrictionDomainType.LETTER);
@@ -57,15 +69,31 @@ public class PlazaLetterDispatchService {
             receiverPool = receiverPool.stream()
                     .filter(id -> !restrictedIds.contains(id))
                     .collect(Collectors.toList());
-            if (receiverPool.isEmpty()) return;
+            if (receiverPool.isEmpty()) {
+                for (PlazaLetter letter : waitingLetters) {
+                    letterFailLogRepo.save(LetterSendFailLog.builder()
+                            .letterId(letter.getLetterId())
+                            .failedAt(LocalDateTime.now())
+                            .reason("수신 가능한 유저 없음")
+                            .build());
+                }
+                return;
+            }
         }
 
         for (PlazaLetter letter : waitingLetters) {
             Long senderId = letter.getSenderId();
-
             Long receiverId = pickRandomExcluding(receiverPool, senderId);
-            if (receiverId == null) continue;
 
+            if (receiverId == null) {
+                // 기존엔 그냥 continue → 실패 로그 저장 추가
+                letterFailLogRepo.save(LetterSendFailLog.builder()
+                        .letterId(letter.getLetterId())
+                        .failedAt(LocalDateTime.now())
+                        .reason("수신 가능한 유저 없음")
+                        .build());
+                continue;
+            }
             letter.assignReceiver(receiverId, now, now.plusHours(24));
         }
         log.info("[PlazaLetterDispatchService] dispatchWaitingLetters End");

--- a/src/main/java/com/example/egobook_be/domain/letters/service/PlazaLetterService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/PlazaLetterService.java
@@ -90,6 +90,8 @@ public class PlazaLetterService {
 
     private final RestrictionGuardService restrictionGuardService;
 
+    private final BadWordBlockLogService badWordBlockLogService;
+
     @Value("${spring.cloud.aws.cloudfront.domain}")
     private String cloudfrontDomain;
 
@@ -115,14 +117,8 @@ public class PlazaLetterService {
         try {
             WordDetectResponse res = wordClient.detect(text);
             if (wordClient.shouldBlock(res)) {
-                badWordBlockLogRepo.save(BadWordBlockLog.builder()
-                        .userId(userId)
-                        .type(blockType)
-                        .originalText(text)
-                        .badWords(res.getBadWords() != null ? res.getBadWords() : List.of())
-                        .score(res.getPercentage() / 100.0)
-                        .blockedAt(LocalDateTime.now())
-                        .build());
+                badWordBlockLogService.saveBlockLog(userId, blockType, text,
+                        res.getBadWords(), res.getPercentage() / 100.0);
                 throw new CustomException(LettersErrorCode.AI_MODERATION_FAILED);
             }
         } catch (CustomException e) {
@@ -290,14 +286,8 @@ public class PlazaLetterService {
 
         if (wordClient.shouldBlock(result)) {
             // 욕설 감지 → 차단 로그 저장 후 편지 삭제
-            badWordBlockLogRepo.save(BadWordBlockLog.builder()
-                    .userId(letter.getSenderId())
-                    .type(BlockType.LETTER)
-                    .originalText(result.getText())
-                    .badWords(result.getBadWords() != null ? result.getBadWords() : List.of())
-                    .score(result.getPercentage() / 100.0)
-                    .blockedAt(LocalDateTime.now())
-                    .build());
+            badWordBlockLogService.saveBlockLog(letter.getSenderId(), BlockType.LETTER,
+                    result.getText(), result.getBadWords(), result.getPercentage() / 100.0);
             plazaLetterRepository.delete(letter);
             return;
         }

--- a/src/main/java/com/example/egobook_be/domain/user/service/AdminContentService.java
+++ b/src/main/java/com/example/egobook_be/domain/user/service/AdminContentService.java
@@ -244,8 +244,7 @@ public class AdminContentService {
         long sentCount = plazaLetterRepo.countByCreatedAtBetweenAndStatuses(
                 start, end, List.of(PlazaLetterStatus.REPLIED, PlazaLetterStatus.AI_REPLIED));
 
-        long waitingCount = plazaLetterRepo.countByCreatedAtBetweenAndStatus(
-                start, end, PlazaLetterStatus.WAITING);
+        long waitingCount = plazaLetterRepo.countByStatus(PlazaLetterStatus.WAITING);
 
         long aiReplyCount = plazaLetterRepo.countByCreatedAtBetweenAndStatus(
                 start, end, PlazaLetterStatus.AI_REPLIED);


### PR DESCRIPTION
## #️⃣연관된 이슈
- ex) #221 

## 📝작업 내용

- BadWordBlockLogService 생성 (REQUIRES_NEW 트랜잭션 분리)
  기존 @Transactional 롤백 시 차단 로그도 함께 롤백되던 문제 수정
- PlazaLetterService: badWordBlockLogRepo.save → saveBlockLog 교체 
- AdminContentService: waitingCount를 기간 필터 누적합산 → 현재 WAITING 상태 건수로 수정
- PlazaLetterRepository: countByStatus 메서드 추가
- PlazaLetterDispatchService: 수신자 배정 실패 시 LetterSendFailLog 저장 추가 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?