### PR TITLE
♻️ Refactor: 관리자 통계 잔존율 조회 기준 수정 

### DIFF
--- a/src/main/java/com/example/egobook_be/domain/stat/controller/AdminStatControllerDocs.java
+++ b/src/main/java/com/example/egobook_be/domain/stat/controller/AdminStatControllerDocs.java
@@ -45,8 +45,8 @@ public interface AdminStatControllerDocs {
     @Operation(summary = "잔존율 조회", description = """
             7/30일 잔존율을 조회합니다.
             
-            - 7일 잔존율 : 전체 가입 유저 중 가입 후 7일째 되는 날 접속한 유저 비율
-            - 30일 잔존율 : 전체 가입 유저 중 가입 후 30일째 되는 날 접속한 유저 비율
+            - 7일 잔존율 : 전체 가입 유저 중 가입 후 7일 이내 접속한 유저 비율
+            - 30일 잔존율 : 전체 가입 유저 중 가입 후 30일 이내 접속한 유저 비율
             """)
     @SecurityRequirement(name = "bearerAuth")
     @GetMapping("/users/retention")

--- a/src/main/java/com/example/egobook_be/domain/stat/service/AdminStatService.java
+++ b/src/main/java/com/example/egobook_be/domain/stat/service/AdminStatService.java
@@ -17,6 +17,7 @@ import com.example.egobook_be.domain.user.repository.UserRepository;
 import com.example.egobook_be.domain.user.repository.WithdrawReasonRepository;
 import com.example.egobook_be.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,7 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -106,8 +107,10 @@ public class AdminStatService {
         Long total7 = userRepository.countByCreatedAtBefore(today.minusDays(7).atStartOfDay());
         Long total30 = userRepository.countByCreatedAtBefore(today.minusDays(30).atStartOfDay());
 
-        Long active7 = userActivityLogRepository.countRetainedUserOnDay(7);
-        Long active30 = userActivityLogRepository.countRetainedUserOnDay(30);
+        Long active7 = userActivityLogRepository.countRetainedUserWithinDays(7);
+        Long active30 = userActivityLogRepository.countRetainedUserWithinDays(30);
+
+        log.info("total7={}, total30={}, active7={}, active30={}", total7, total30, active7, active30);
 
         return AdminStatMapper.getRetentionResDto(total7, total30, active7, active30);
     }

--- a/src/main/java/com/example/egobook_be/domain/user/repository/UserActivityLogRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/user/repository/UserActivityLogRepository.java
@@ -17,9 +17,10 @@ public interface UserActivityLogRepository extends JpaRepository<UserActivityLog
     SELECT COUNT(DISTINCT a.user_id)
     FROM user_activity_log a
     JOIN user u ON u.id = a.user_id
-    WHERE a.active_date = DATE(DATE_ADD(u.created_at, INTERVAL :days DAY))
+    WHERE a.active_date BETWEEN DATE(u.created_at) 
+      AND DATE(DATE_ADD(u.created_at, INTERVAL :days DAY))
     """, nativeQuery = true)
-    Long countRetainedUserOnDay(@Param("days") int days);
+    Long countRetainedUserWithinDays(@Param("days") int days);
 
     @Query(value = """
     SELECT active_date AS date, COUNT(DISTINCT user_id) AS count


### PR DESCRIPTION
## #️⃣연관된 이슈
- #226 

## 📝작업 내용

**1. 잔존율 조회 기준 수정 (당일 접속 → N일 이내 접속)**

- 기존: 가입 후 정확히 7일째, 30일째 당일 접속한 유저 비율 (%)
- 변경: 가입 후 7일 이내, 30일 이내 접속한 유저 비율 (%)

> 테스트 결과
> 

<img width="39%" alt="Image" src="https://github.com/user-attachments/assets/3262e18c-5cd4-483d-a64d-d66c05f0a4ce" />