### PR TITLE
🐛  Fix: 관리자 통계 잔존율 쿼리 범위 불일치 수정

### DIFF
--- a/src/main/java/com/example/egobook_be/domain/stat/service/AdminStatService.java
+++ b/src/main/java/com/example/egobook_be/domain/stat/service/AdminStatService.java
@@ -110,8 +110,6 @@ public class AdminStatService {
         Long active7 = userActivityLogRepository.countRetainedUserWithinDays(7);
         Long active30 = userActivityLogRepository.countRetainedUserWithinDays(30);
 
-        log.info("total7={}, total30={}, active7={}, active30={}", total7, total30, active7, active30);
-
         return AdminStatMapper.getRetentionResDto(total7, total30, active7, active30);
     }
 

--- a/src/main/java/com/example/egobook_be/domain/user/repository/UserActivityLogRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/user/repository/UserActivityLogRepository.java
@@ -17,7 +17,8 @@ public interface UserActivityLogRepository extends JpaRepository<UserActivityLog
     SELECT COUNT(DISTINCT a.user_id)
     FROM user_activity_log a
     JOIN user u ON u.id = a.user_id
-    WHERE a.active_date BETWEEN DATE(u.created_at) 
+    WHERE u.created_at < NOW() - INTERVAL :days DAY
+      AND a.active_date BETWEEN DATE(u.created_at) 
       AND DATE(DATE_ADD(u.created_at, INTERVAL :days DAY))
     """, nativeQuery = true)
     Long countRetainedUserWithinDays(@Param("days") int days);


### PR DESCRIPTION
## #️⃣연관된 이슈
- #226 

## 📝작업 내용

**1. 잔존율 조회 기준 수정 (당일 접속 → N일 이내 접속)**

- total : 가입한 지 N일 이상 된 유저
- active : 전체 유저 중 가입 후 N일 이내 접속한 유저 -> N일 이상 된 유저만 대상

> 테스트 결과
> 

<img width="39%" alt="Image" src="https://github.com/user-attachments/assets/f795de49-d3a0-4b5e-86c7-460fbcd02ff5" />