### PR TITLE
:bug: Fix: 편지지 이름 .png 설정 오류

### DIFF
--- a/src/main/java/com/example/egobook_be/domain/letters/enums/PlazaLetterColor.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/enums/PlazaLetterColor.java
@@ -1,21 +1,19 @@
 package com.example.egobook_be.domain.letters.enums;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum PlazaLetterColor {
-    WHITE(0),  // 기본 하얀색, 가격 0원
-    PINK(75),  // 핑크색, 가격 75원
-    GREEN(100),  // 초록색, 가격 100원
-    BLUE(150),  // 파란색, 가격 150원
-    PURPLE(175);  // 보라색, 가격 175원
+    WHITE(0, "White.png"),  // 기본 하얀색, 가격 0원
+    PINK(75, "Pink.png"),  // 핑크색, 가격 75원
+    GREEN(100, "Green.png"),  // 초록색, 가격 100원
+    BLUE(150, "Blue.png"),  // 파란색, 가격 150원
+    PURPLE(175, "Purple.png");  // 보라색, 가격 175원
 
     private final int price;
-
-    PlazaLetterColor(int price) {
-        this.price = price;
-    }
-
-    public int getPrice() {
-        return price;
-    }
+    private final String imageName;
 
 }
 

--- a/src/main/java/com/example/egobook_be/domain/letters/service/PlazaLetterService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/PlazaLetterService.java
@@ -395,7 +395,7 @@ public class PlazaLetterService {
      */
     private void purchaseLetterPaperIfNotOwned(User user, PlazaLetterColor color) {
         // 편지지 색상명으로 Item 조회 (name = "PINK" / "GREEN" / "BLUE" / "PURPLE")
-        Item item = itemRepository.findByCategoryAndName(ItemCategory.LETTER_PAPER, color.name())
+        Item item = itemRepository.findByCategoryAndName(ItemCategory.LETTER_PAPER, color.getImageName())
                 .orElseThrow(() -> new CustomException(LettersErrorCode.LETTER_PAPER_NOT_FOUND));
 
         // 이미 보유 중이면 바로 리턴 (영구 보유 → 무료 재사용)


### PR DESCRIPTION
## #️⃣연관된 이슈
- 없음

## 📝작업 내용
- Item Entity의 `name` 컬럼에 각 아이템의 이름들이 .png로 들어가있는 상황 (이미지 cloudfront url을 만들기 위해서임)
- 이때 편지지 구매 함수 `PlazaLetterService.purchaseLetterPaperIfNotOwned()`에서 구매할 편지지를 Enum.name() 함수로 조회하고 있던 상황
- 따라서 `Default.png`가 아닌 `DEFAULT` 식으로 조회가 되어 "LETTER_PAPER_NOT_FOUND" 예외가 났음
- `PlazaLetterColor`에 `imageName` 필드를 추가하여 해당 필드의 Enum 데이터로 조회하도록 수정하였음