### PR TITLE
✨ Feat: AdMob 앱 인증을 위한 app-ads.txt 엔드포인트 구현

### DIFF
--- a/src/main/java/com/example/egobook_be/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/egobook_be/global/config/SecurityConfig.java
@@ -48,7 +48,8 @@ public class SecurityConfig {
             "/admin/auth/refresh",
             "/admin/auth/register",
             "/admin/auth/login",
-            "/test-google-oauth.html"
+            "/test-google-oauth.html",
+            "/app-ads.txt"
     };
 
     /**

--- a/src/main/java/com/example/egobook_be/global/controller/AppAdsTxtController.java
+++ b/src/main/java/com/example/egobook_be/global/controller/AppAdsTxtController.java
@@ -1,0 +1,15 @@
+package com.example.egobook_be.global.controller;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class AppAdsTxtController {
+
+    @GetMapping(value = "/app-ads.txt", produces = MediaType.TEXT_PLAIN_VALUE)
+    public ResponseEntity<String> appAdsTxt() {
+        return ResponseEntity.ok("google.com, pub-7304061200076771, DIRECT, f08c47fec0942fa0");
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
**AdMob 실제 광고 미노출 이슈 대응**

**1. AppAdsTxtController**
- `/app-ads.txt` GET 엔드포인트 추가
- AdMob 앱 인증을 위해 구글 크롤러가 해당 경로에서 publisher 정보를 읽어감

**2. SecurityConfig 화이트리스트 추가**
- `/app-ads.txt` 경로를 JWT 인증 없이 접근 가능하도록 허용
- 구글 크롤러는 JWT 토큰이 없으므로 필수

> 테스트 결과 : 로컬(`localhost:8080/app-ads.txt`) 접속 시 정상 응답 확인
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/28458a4f-af14-4344-8e60-0ab82bd0de93" />
