### PR TITLE
✨ Feat: Google Search Console 소유권 인증 엔드포인트 구현

### DIFF
--- a/src/main/java/com/example/egobook_be/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/egobook_be/global/config/SecurityConfig.java
@@ -49,7 +49,8 @@ public class SecurityConfig {
             "/admin/auth/register",
             "/admin/auth/login",
             "/test-google-oauth.html",
-            "/app-ads.txt"
+            "/app-ads.txt",
+            "/google-site-verification"
     };
 
     /**

--- a/src/main/java/com/example/egobook_be/global/controller/AppAdsTxtController.java
+++ b/src/main/java/com/example/egobook_be/global/controller/AppAdsTxtController.java
@@ -12,4 +12,9 @@ public class AppAdsTxtController {
     public ResponseEntity<String> appAdsTxt() {
         return ResponseEntity.ok("google.com, pub-7304061200076771, DIRECT, f08c47fec0942fa0");
     }
+
+    @GetMapping(value = "/google-site-verification", produces = MediaType.TEXT_PLAIN_VALUE)
+    public ResponseEntity<String> googleSiteVerification() {
+        return ResponseEntity.ok("google-site-verification: Z9OYphMMuoGMhcYamomvVRdiRwxv-Fd9nyNEQQV8hDk");
+    }
 }


### PR DESCRIPTION
## 📝 작업 내용

**1. Google Search Console 소유권 인증 엔드포인트 구현**
- `/google-site-verification` GET 엔드포인트 추가
- Play Store 개발자 웹사이트 등록을 위한 Search Console 소유권 인증용

**2. SecurityConfig 화이트리스트 추가**
- `/google-site-verification` 경로를 JWT 인증 없이 접근 가능하도록 허용