### PR TITLE
♻️  Refactor: 관리자 페이지 버그 수정 

### DIFF
--- a/src/main/java/com/example/egobook_be/domain/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/diary/repository/DiaryRepository.java
@@ -41,6 +41,27 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
     """)
     List<DailyEmotionCount> findDailyEmotions(User user, LocalDate start, LocalDate end);
 
+    //  날짜별 일간 칭찬서 발송 대상자 수 집계 (관리자 API용)
+    /**
+     * 날짜별로 그날 일기를 작성했고 daily_praise=true인 유저 수 집계
+     * - 관리자 API에서 "실제 일간 칭찬서 발송 대상자 수(scheduledCount)"를 계산하기 위해 사용
+     * @param startDate : 조회 시작일
+     * @param endDate : 조회 종료일
+     * @return : [날짜, 발송 대상 유저 수] 리스트
+     */
+    @Query("""
+        SELECT d.date, COUNT(DISTINCT d.user.id)
+        FROM Diary d
+        WHERE d.date BETWEEN :startDate AND :endDate
+          AND d.user.dailyPraise = true
+        GROUP BY d.date
+        ORDER BY d.date ASC
+    """)
+    List<Object[]> countDailyPraiseTargetsByDateRange(
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate
+    );
+
     @Query("""
     SELECT DISTINCT d
     FROM Diary d

--- a/src/main/java/com/example/egobook_be/domain/ego_room/scheduler/EgoStatsScheduler.java
+++ b/src/main/java/com/example/egobook_be/domain/ego_room/scheduler/EgoStatsScheduler.java
@@ -10,7 +10,7 @@ import java.time.LocalDate;
     private final UserRepository userRepository;
 
 
-    @Scheduled(cron = "0 0 3 * * *")
+    @Scheduled(cron = "0 0 2 * * *")
     public void updateDailyUserStats() {
         log.info("매일 새벽 3시마다 스케줄링");
         LocalDate now = LocalDate.now();

--- a/src/main/java/com/example/egobook_be/domain/letters/dto/response/PlazaLetterReplyReportAdminResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/dto/response/PlazaLetterReplyReportAdminResDto.java
@@ -15,5 +15,6 @@ public record PlazaLetterReplyReportAdminResDto(
         ReportStatus status,
         String adminMemo,
         long reportCount,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        String reportedUserAccountCode
 ) {}

--- a/src/main/java/com/example/egobook_be/domain/letters/dto/response/PlazaLetterReplyReportAdminResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/dto/response/PlazaLetterReplyReportAdminResDto.java
@@ -16,5 +16,6 @@ public record PlazaLetterReplyReportAdminResDto(
         String adminMemo,
         long reportCount,
         LocalDateTime createdAt,
+        Long reportedUserId,
         String reportedUserAccountCode
 ) {}

--- a/src/main/java/com/example/egobook_be/domain/letters/dto/response/PlazaLetterReplyReportDetailResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/dto/response/PlazaLetterReplyReportDetailResDto.java
@@ -1,0 +1,14 @@
+package com.example.egobook_be.domain.letters.dto.response;
+
+import com.example.egobook_be.domain.report.dto.ReportEntryResDto;
+
+import java.util.List;
+
+public record PlazaLetterReplyReportDetailResDto(
+        Long replyId,
+        String replyContent,
+        Long reportedUserId,
+        String reportedUserAccountCode,
+        long reportCount,
+        List<ReportEntryResDto> reports
+) {}

--- a/src/main/java/com/example/egobook_be/domain/letters/dto/response/PlazaLetterReportAdminResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/dto/response/PlazaLetterReportAdminResDto.java
@@ -15,5 +15,6 @@ public record PlazaLetterReportAdminResDto(
         ReportStatus status,
         String adminMemo,
         long reportCount,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        String reportedUserAccountCode
 ) {}

--- a/src/main/java/com/example/egobook_be/domain/letters/dto/response/PlazaLetterReportAdminResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/dto/response/PlazaLetterReportAdminResDto.java
@@ -16,5 +16,6 @@ public record PlazaLetterReportAdminResDto(
         String adminMemo,
         long reportCount,
         LocalDateTime createdAt,
+        Long reportedUserId,
         String reportedUserAccountCode
 ) {}

--- a/src/main/java/com/example/egobook_be/domain/letters/dto/response/PlazaLetterReportDetailResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/dto/response/PlazaLetterReportDetailResDto.java
@@ -1,0 +1,14 @@
+package com.example.egobook_be.domain.letters.dto.response;
+
+import com.example.egobook_be.domain.report.dto.ReportEntryResDto;
+
+import java.util.List;
+
+public record PlazaLetterReportDetailResDto(
+        Long letterId,
+        String letterContent,
+        Long reportedUserId,
+        String reportedUserAccountCode,
+        long reportCount,
+        List<ReportEntryResDto> reports
+) {}

--- a/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterReplyReportRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterReplyReportRepository.java
@@ -45,15 +45,17 @@ public interface PlazaLetterReplyReportRepository extends JpaRepository<PlazaLet
     @Query("SELECT COUNT(r) FROM PlazaLetterReplyReport r WHERE r.reply.replyId = :replyId")
     long countByReply_ReplyId(@Param("replyId") Long replyId);
 
+    // 승인 처리된 신고는 관리 목록에서 제외 (PENDING만 노출, 반려는 DB에서도 삭제)
     @Query("""
         SELECT r
         FROM PlazaLetterReplyReport r
         JOIN FETCH r.reply
+        WHERE r.status = com.example.egobook_be.global.enums.ReportStatus.PENDING
         ORDER BY r.createdAt DESC
     """)
     Slice<PlazaLetterReplyReport> findAllWithReply(Pageable pageable);
 
-    //상세 조회
+    //상세 조회 (reportId 단건 - 승인/반려 처리용)
     @Query("""
         SELECT r
         FROM PlazaLetterReplyReport r
@@ -61,6 +63,16 @@ public interface PlazaLetterReplyReportRepository extends JpaRepository<PlazaLet
         WHERE r.reportId = :reportId
     """)
     Optional<PlazaLetterReplyReport> findByIdWithReply(@Param("reportId") Long reportId);
+
+    // 신고 상세보기: 신고된 컨텐츠(replyId) 기준으로 해당 컨텐츠에 달린 모든 신고 내역을 조회
+    @Query("""
+        SELECT r
+        FROM PlazaLetterReplyReport r
+        JOIN FETCH r.reply
+        WHERE r.reply.replyId = :replyId
+        ORDER BY r.createdAt DESC
+    """)
+    List<PlazaLetterReplyReport> findAllByReplyId(@Param("replyId") Long replyId);
 
     //수동 삭제
     @Modifying(clearAutomatically = true)

--- a/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterReportRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterReportRepository.java
@@ -28,15 +28,17 @@ public interface PlazaLetterReportRepository extends JpaRepository<PlazaLetterRe
     @Query("select count(r) from PlazaLetterReport r where r.letter.letterId = :letterId")
     long countByLetter_LetterId(@Param("letterId") Long letterId);
 
+    // 승인 처리된 신고는 관리 목록에서 제외 (PENDING만 노출, 반려는 DB 에서도 삭제)
     @Query("""
         SELECT r
         FROM PlazaLetterReport r
         JOIN FETCH r.letter
+        WHERE r.status = com.example.egobook_be.global.enums.ReportStatus.PENDING
         ORDER BY r.createdAt DESC
     """)
     Slice<PlazaLetterReport> findAllWithLetter(Pageable pageable);
 
-    //상세 조회
+    //상세 조회 (reportId 단건 - 승인/반려 처리용)
     @Query("""
         SELECT r
         FROM PlazaLetterReport r
@@ -44,6 +46,16 @@ public interface PlazaLetterReportRepository extends JpaRepository<PlazaLetterRe
         WHERE r.reportId = :reportId
     """)
     Optional<PlazaLetterReport> findByIdWithLetter(@Param("reportId") Long reportId);
+
+    // 신고 상세보기: 신고된 컨텐츠(letterId) 기준으로 해당 컨텐츠에 달린 모든 신고 내역을 조회
+    @Query("""
+        SELECT r
+        FROM PlazaLetterReport r
+        JOIN FETCH r.letter
+        WHERE r.letter.letterId = :letterId
+        ORDER BY r.createdAt DESC
+    """)
+    List<PlazaLetterReport> findAllByLetterId(@Param("letterId") Long letterId);
 
     //수동 삭제
     @Modifying(clearAutomatically = true)

--- a/src/main/java/com/example/egobook_be/domain/letters/service/LetterReportAdminService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/LetterReportAdminService.java
@@ -9,6 +9,8 @@ import com.example.egobook_be.domain.letters.repository.PlazaLetterReplyReposito
 import com.example.egobook_be.domain.letters.repository.PlazaLetterReportRepository;
 import com.example.egobook_be.domain.letters.repository.PlazaLetterReplyReportRepository;
 import com.example.egobook_be.domain.letters.repository.PlazaLetterRepository;
+import com.example.egobook_be.domain.user.entity.User;
+import com.example.egobook_be.domain.user.repository.UserRepository;
 import com.example.egobook_be.global.enums.ReportStatus;
 import com.example.egobook_be.global.exception.CustomException;
 import com.example.egobook_be.global.response.SliceResponse;
@@ -30,6 +32,13 @@ public class LetterReportAdminService {
     private final PlazaLetterReplyReportRepository replyReportRepository;
     private final PlazaLetterRepository letterRepository;
     private final PlazaLetterReplyRepository replyRepository;
+    private final UserRepository userRepository;
+
+    // 신고당한 유저(letter senderId / reply replierId)의 accountCode 조회, 탈퇴 등으로 id가 null이면 null 반환
+    private String findAccountCode(Long userId) {
+        if (userId == null) return null;
+        return userRepository.findById(userId).map(User::getAccountCode).orElse(null);
+    }
 
     public SliceResponse<PlazaLetterReportAdminResDto> getReportedLetters(int page, int size) {
         int safePage = Math.max(page, 1);
@@ -51,7 +60,8 @@ public class LetterReportAdminService {
                 report.getStatus(),
                 report.getAdminMemo(),
                 reportCount,
-                report.getCreatedAt()
+                report.getCreatedAt(),
+                findAccountCode(report.getSenderId())
             );
         });
     }
@@ -76,7 +86,8 @@ public class LetterReportAdminService {
                 report.getStatus(),
                 report.getAdminMemo(),
                 reportCount,
-                report.getCreatedAt()
+                report.getCreatedAt(),
+                findAccountCode(report.getReplierId())
             );
         });
     }
@@ -98,7 +109,8 @@ public class LetterReportAdminService {
             report.getStatus(),
             report.getAdminMemo(),
             reportCount,
-            report.getCreatedAt()
+            report.getCreatedAt(),
+            findAccountCode(report.getSenderId())
         );
     }
 
@@ -118,7 +130,8 @@ public class LetterReportAdminService {
             report.getStatus(),
             report.getAdminMemo(),
             reportCount,
-            report.getCreatedAt()
+            report.getCreatedAt(),
+            findAccountCode(report.getReplierId())
         );
     }
 

--- a/src/main/java/com/example/egobook_be/domain/letters/service/LetterReportAdminService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/LetterReportAdminService.java
@@ -1,7 +1,9 @@
 package com.example.egobook_be.domain.letters.service;
 
 import com.example.egobook_be.domain.letters.dto.response.PlazaLetterReportAdminResDto;
+import com.example.egobook_be.domain.letters.dto.response.PlazaLetterReportDetailResDto;
 import com.example.egobook_be.domain.letters.dto.response.PlazaLetterReplyReportAdminResDto;
+import com.example.egobook_be.domain.letters.dto.response.PlazaLetterReplyReportDetailResDto;
 import com.example.egobook_be.domain.letters.entity.PlazaLetterReport;
 import com.example.egobook_be.domain.letters.entity.PlazaLetterReplyReport;
 import com.example.egobook_be.domain.letters.enums.LettersErrorCode;
@@ -9,6 +11,7 @@ import com.example.egobook_be.domain.letters.repository.PlazaLetterReplyReposito
 import com.example.egobook_be.domain.letters.repository.PlazaLetterReportRepository;
 import com.example.egobook_be.domain.letters.repository.PlazaLetterReplyReportRepository;
 import com.example.egobook_be.domain.letters.repository.PlazaLetterRepository;
+import com.example.egobook_be.domain.report.dto.ReportEntryResDto;
 import com.example.egobook_be.domain.user.entity.User;
 import com.example.egobook_be.domain.user.repository.UserRepository;
 import com.example.egobook_be.global.enums.ReportStatus;
@@ -21,6 +24,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Slf4j
 @Service
@@ -61,6 +66,7 @@ public class LetterReportAdminService {
                 report.getAdminMemo(),
                 reportCount,
                 report.getCreatedAt(),
+                report.getSenderId(),
                 findAccountCode(report.getSenderId())
             );
         });
@@ -87,51 +93,68 @@ public class LetterReportAdminService {
                 report.getAdminMemo(),
                 reportCount,
                 report.getCreatedAt(),
+                report.getReplierId(),
                 findAccountCode(report.getReplierId())
             );
         });
     }
 
-    //상세 조회
-    public PlazaLetterReportAdminResDto getReportedLetterDetail(Long reportId) {
-        PlazaLetterReport report = letterReportRepository.findByIdWithLetter(reportId)
-                .orElseThrow(() -> new CustomException(LettersErrorCode.LETTER_NOT_FOUND));
+    // 상세 조회 기준을 reportId(개별 신고건)에서 letterId(신고된 컨텐츠)로 변경
+    // - 같은 편지를 여러 명이 신고한 경우, 그 편지에 달린 모든 신고 내역을 리스트로 함께 반환
+    public PlazaLetterReportDetailResDto getReportedLetterDetail(Long letterId) {
+        List<PlazaLetterReport> reports = letterReportRepository.findAllByLetterId(letterId);
+        if (reports.isEmpty()) {
+            throw new CustomException(LettersErrorCode.LETTER_NOT_FOUND);
+        }
+        PlazaLetterReport first = reports.get(0);
 
-        long reportCount = letterReportRepository.countByLetter_LetterId(report.getLetter().getLetterId());
+        List<ReportEntryResDto> entries = reports.stream()
+                .map(r -> ReportEntryResDto.builder()
+                        .reportId(r.getReportId())
+                        .reporterId(r.getReporterId())
+                        .reason(r.getReason())
+                        .description(r.getDescription())
+                        .status(r.getStatus())
+                        .createdAt(r.getCreatedAt())
+                        .build())
+                .toList();
 
-        return new PlazaLetterReportAdminResDto(
-            report.getReportId(),
-            report.getLetter().getLetterId(),
-            report.getLetter().getContent(),
-            report.getReporterId(),
-            report.getReason(),
-            report.getDescription(),
-            report.getStatus(),
-            report.getAdminMemo(),
-            reportCount,
-            report.getCreatedAt(),
-            findAccountCode(report.getSenderId())
+        return new PlazaLetterReportDetailResDto(
+                letterId,
+                first.getLetter().getContent(),
+                first.getSenderId(),
+                findAccountCode(first.getSenderId()),
+                entries.size(),
+                entries
         );
     }
 
-    public PlazaLetterReplyReportAdminResDto getReportedReplyDetail(Long reportId) {
-        PlazaLetterReplyReport report = replyReportRepository.findByIdWithReply(reportId)
-                .orElseThrow(() -> new CustomException(LettersErrorCode.LETTER_NOT_FOUND));
+    // 상세 조회 기준을 reportId(개별 신고건)에서 replyId(신고된 컨텐츠)로 변경
+    public PlazaLetterReplyReportDetailResDto getReportedReplyDetail(Long replyId) {
+        List<PlazaLetterReplyReport> reports = replyReportRepository.findAllByReplyId(replyId);
+        if (reports.isEmpty()) {
+            throw new CustomException(LettersErrorCode.LETTER_NOT_FOUND);
+        }
+        PlazaLetterReplyReport first = reports.get(0);
 
-        long reportCount = replyReportRepository.countByReply_ReplyId(report.getReply().getReplyId());
+        List<ReportEntryResDto> entries = reports.stream()
+                .map(r -> ReportEntryResDto.builder()
+                        .reportId(r.getReportId())
+                        .reporterId(r.getReporterId())
+                        .reason(r.getReason())
+                        .description(r.getDescription())
+                        .status(r.getStatus())
+                        .createdAt(r.getCreatedAt())
+                        .build())
+                .toList();
 
-        return new PlazaLetterReplyReportAdminResDto(
-            report.getReportId(),
-            report.getReply().getReplyId(),
-            report.getReply().getContent(),
-            report.getReporterId(),
-            report.getReason(),
-            report.getDescription(),
-            report.getStatus(),
-            report.getAdminMemo(),
-            reportCount,
-            report.getCreatedAt(),
-            findAccountCode(report.getReplierId())
+        return new PlazaLetterReplyReportDetailResDto(
+                replyId,
+                first.getReply().getContent(),
+                first.getReplierId(),
+                findAccountCode(first.getReplierId()),
+                entries.size(),
+                entries
         );
     }
 
@@ -174,6 +197,7 @@ public class LetterReportAdminService {
     }
 
     @Transactional
+    // 반려 시 상태 변경 대신 신고 이력 자체를 삭제
     public void rejectLetterReport(Long reportId) {
         PlazaLetterReport report = letterReportRepository.findByIdWithLetter(reportId)
                 .orElseThrow(() -> new CustomException(LettersErrorCode.LETTER_NOT_FOUND));
@@ -182,7 +206,7 @@ public class LetterReportAdminService {
             throw new CustomException(LettersErrorCode.REPORT_ALREADY_RESOLVED);
         }
 
-        report.reject();
+        letterReportRepository.delete(report);
     }
 
     @Transactional
@@ -205,6 +229,7 @@ public class LetterReportAdminService {
     }
 
     @Transactional
+    // 반려 시 상태 변경 대신 신고 이력 자체를 삭제
     public void rejectReplyReport(Long reportId) {
         PlazaLetterReplyReport report = replyReportRepository.findByIdWithReply(reportId)
                 .orElseThrow(() -> new CustomException(LettersErrorCode.LETTER_NOT_FOUND));
@@ -213,7 +238,7 @@ public class LetterReportAdminService {
             throw new CustomException(LettersErrorCode.REPORT_ALREADY_RESOLVED);
         }
 
-        report.reject();
+        replyReportRepository.delete(report);
     }
 
     @Transactional

--- a/src/main/java/com/example/egobook_be/domain/question/dto/AnswerReportAdminResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/question/dto/AnswerReportAdminResDto.java
@@ -16,5 +16,6 @@ public record AnswerReportAdminResDto(
         long reportCount,
         ReportStatus status,
         String adminMemo,
-        LocalDateTime reportedAt
+        LocalDateTime reportedAt,
+        String reportedUserAccountCode
 ) {}

--- a/src/main/java/com/example/egobook_be/domain/question/dto/AnswerReportAdminResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/question/dto/AnswerReportAdminResDto.java
@@ -17,5 +17,6 @@ public record AnswerReportAdminResDto(
         ReportStatus status,
         String adminMemo,
         LocalDateTime reportedAt,
+        Long reportedUserId,
         String reportedUserAccountCode
 ) {}

--- a/src/main/java/com/example/egobook_be/domain/question/dto/AnswerReportDetailResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/question/dto/AnswerReportDetailResDto.java
@@ -1,0 +1,14 @@
+package com.example.egobook_be.domain.question.dto;
+
+import com.example.egobook_be.domain.report.dto.ReportEntryResDto;
+
+import java.util.List;
+
+public record AnswerReportDetailResDto(
+        Long answerId,
+        String answerContent,
+        Long reportedUserId,
+        String reportedUserAccountCode,
+        long reportCount,
+        List<ReportEntryResDto> reports
+) {}

--- a/src/main/java/com/example/egobook_be/domain/question/repository/AnswerReportRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/question/repository/AnswerReportRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface AnswerReportRepository
@@ -20,15 +21,17 @@ public interface AnswerReportRepository
 
     long countByAnswer(QuestionAnswer answer);
 
+    //  승인 처리된 신고는 관리 목록에서 제외 (PENDING만 노출)
     @Query("""
         SELECT ar
         FROM AnswerReport ar
         JOIN FETCH ar.answer a
         JOIN FETCH ar.user u
+        WHERE ar.status = com.example.egobook_be.global.enums.ReportStatus.PENDING
     """)
     Page<AnswerReport> findAllWithAnswerAndUser(Pageable pageable);
 
-    //상세 조회
+    //상세 조회 (reportId 단건 - 승인/반려 처리용)
     @Query("""
         SELECT ar
         FROM AnswerReport ar
@@ -37,6 +40,18 @@ public interface AnswerReportRepository
         WHERE ar.id = :reportId
     """)
     Optional<AnswerReport> findByIdWithAnswerAndUser(@Param("reportId") Long reportId);
+
+    // 신고 상세보기: 신고된 컨텐츠(answerId) 기준으로 해당 컨텐츠에 달린 모든 신고 내역을 조회
+    @Query("""
+        SELECT ar
+        FROM AnswerReport ar
+        JOIN FETCH ar.answer a
+        JOIN FETCH a.user
+        JOIN FETCH ar.user u
+        WHERE ar.answer.id = :answerId
+        ORDER BY ar.createdAt DESC
+    """)
+    List<AnswerReport> findAllByAnswerId(@Param("answerId") Long answerId);
 
     @Query("SELECT COUNT(ar) FROM AnswerReport ar WHERE ar.answer.id = :answerId")
     long countByAnswerId(@Param("answerId") Long answerId);

--- a/src/main/java/com/example/egobook_be/domain/question/repository/AnswerReportRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/question/repository/AnswerReportRepository.java
@@ -22,12 +22,13 @@ public interface AnswerReportRepository
     long countByAnswer(QuestionAnswer answer);
 
     //  승인 처리된 신고는 관리 목록에서 제외 (PENDING만 노출)
-    @Query("""
+    `@Query`("""
         SELECT ar
         FROM AnswerReport ar
         JOIN FETCH ar.answer a
         JOIN FETCH ar.user u
         WHERE ar.status = com.example.egobook_be.global.enums.ReportStatus.PENDING
+        ORDER BY ar.createdAt DESC, ar.id DESC
     """)
     Page<AnswerReport> findAllWithAnswerAndUser(Pageable pageable);
 

--- a/src/main/java/com/example/egobook_be/domain/question/service/AnswerReportAdminService.java
+++ b/src/main/java/com/example/egobook_be/domain/question/service/AnswerReportAdminService.java
@@ -3,11 +3,13 @@ package com.example.egobook_be.domain.question.service;
 import com.example.egobook_be.domain.letters.entity.PlazaLetterReport;
 import com.example.egobook_be.domain.letters.enums.LettersErrorCode;
 import com.example.egobook_be.domain.question.dto.AnswerReportAdminResDto;
+import com.example.egobook_be.domain.question.dto.AnswerReportDetailResDto;
 import com.example.egobook_be.domain.question.entity.AnswerReport;
 import com.example.egobook_be.domain.question.enums.AnswerVisibility;
 import com.example.egobook_be.domain.question.exception.QuestionErrorCode;
 import com.example.egobook_be.domain.question.repository.AnswerReportRepository;
 import com.example.egobook_be.domain.question.repository.QuestionAnswerRepository;
+import com.example.egobook_be.domain.report.dto.ReportEntryResDto;
 import com.example.egobook_be.domain.user.entity.User;
 import com.example.egobook_be.domain.user.repository.UserRepository;
 import com.example.egobook_be.global.enums.ReportStatus;
@@ -19,6 +21,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Slf4j
 @Service
@@ -65,18 +69,41 @@ public class AnswerReportAdminService {
                 report.getStatus(),
                 report.getAdminMemo(),
                 report.getCreatedAt(),
+                report.getAnswer().getUser().getId(),
                 findAccountCode(report.getAnswer().getUser().getId())
         );
     }
 
-    @Transactional(readOnly = true)
-    public AnswerReportAdminResDto getReportedAnswerDetail(Long reportId) {
-        log.info("[AnswerReportAdminService] getReportedAnswers Start - reportId: {}", reportId);
-        AnswerReport report = answerReportRepository.findByIdWithAnswerAndUser(reportId)
-                .orElseThrow(() -> new CustomException(QuestionErrorCode.ANSWER_NOT_FOUND));
 
-        log.info("[AnswerReportAdminService] getReportedAnswers End - reportId: {}", reportId);
-        return toDto(report);
+    @Transactional(readOnly = true)
+    public AnswerReportDetailResDto getReportedAnswerDetail(Long answerId) {
+        log.info("[AnswerReportAdminService] getReportedAnswerDetail Start - answerId: {}", answerId);
+        List<AnswerReport> reports = answerReportRepository.findAllByAnswerId(answerId);
+        if (reports.isEmpty()) {
+            throw new CustomException(QuestionErrorCode.ANSWER_NOT_FOUND);
+        }
+        AnswerReport first = reports.get(0);
+
+        List<ReportEntryResDto> entries = reports.stream()
+                .map(r -> ReportEntryResDto.builder()
+                        .reportId(r.getId())
+                        .reporterId(r.getUser().getId())
+                        .reason(r.getReason())
+                        .description(r.getDescription())
+                        .status(r.getStatus())
+                        .createdAt(r.getCreatedAt())
+                        .build())
+                .toList();
+
+        log.info("[AnswerReportAdminService] getReportedAnswerDetail End - answerId: {}", answerId);
+        return new AnswerReportDetailResDto(
+                answerId,
+                first.getAnswer().getContent(),
+                first.getAnswer().getUser().getId(),
+                findAccountCode(first.getAnswer().getUser().getId()),
+                entries.size(),
+                entries
+        );
     }
 
     //수동 삭제
@@ -110,6 +137,7 @@ public class AnswerReportAdminService {
         }
     }
 
+
     @Transactional
     public void rejectAnswerReport(Long reportId) {
         AnswerReport report = answerReportRepository.findByIdWithAnswerAndUser(reportId)
@@ -119,7 +147,7 @@ public class AnswerReportAdminService {
             throw new CustomException(QuestionErrorCode.ALREADY_RESOLVED);
         }
 
-        report.reject();
+        answerReportRepository.delete(report);
     }
 
     @Transactional

--- a/src/main/java/com/example/egobook_be/domain/question/service/AnswerReportAdminService.java
+++ b/src/main/java/com/example/egobook_be/domain/question/service/AnswerReportAdminService.java
@@ -8,6 +8,8 @@ import com.example.egobook_be.domain.question.enums.AnswerVisibility;
 import com.example.egobook_be.domain.question.exception.QuestionErrorCode;
 import com.example.egobook_be.domain.question.repository.AnswerReportRepository;
 import com.example.egobook_be.domain.question.repository.QuestionAnswerRepository;
+import com.example.egobook_be.domain.user.entity.User;
+import com.example.egobook_be.domain.user.repository.UserRepository;
 import com.example.egobook_be.global.enums.ReportStatus;
 import com.example.egobook_be.global.exception.CustomException;
 import com.example.egobook_be.global.response.SliceResponse;
@@ -25,6 +27,13 @@ public class AnswerReportAdminService {
 
     private final AnswerReportRepository answerReportRepository;
     private final QuestionAnswerRepository questionAnswerRepository;
+    private final UserRepository userRepository;
+
+    // 신고당한 유저(답변 작성자)의 accountCode 조회, 탈퇴 등으로 id가 null이면 null 반환
+    private String findAccountCode(Long userId) {
+        if (userId == null) return null;
+        return userRepository.findById(userId).map(User::getAccountCode).orElse(null);
+    }
 
     @Transactional(readOnly = true)
     public SliceResponse<AnswerReportAdminResDto> getReportedAnswers(
@@ -55,7 +64,8 @@ public class AnswerReportAdminService {
                 reportCount,
                 report.getStatus(),
                 report.getAdminMemo(),
-                report.getCreatedAt()
+                report.getCreatedAt(),
+                findAccountCode(report.getAnswer().getUser().getId())
         );
     }
 

--- a/src/main/java/com/example/egobook_be/domain/report/controller/AdminReportController.java
+++ b/src/main/java/com/example/egobook_be/domain/report/controller/AdminReportController.java
@@ -1,7 +1,9 @@
 package com.example.egobook_be.domain.report.controller;
 
 import com.example.egobook_be.domain.letters.dto.response.PlazaLetterReplyReportAdminResDto;
+import com.example.egobook_be.domain.letters.dto.response.PlazaLetterReplyReportDetailResDto;
 import com.example.egobook_be.domain.letters.dto.response.PlazaLetterReportAdminResDto;
+import com.example.egobook_be.domain.letters.dto.response.PlazaLetterReportDetailResDto;
 import com.example.egobook_be.domain.letters.service.LetterReportAdminService;
 import com.example.egobook_be.domain.question.dto.*;
 import com.example.egobook_be.domain.question.service.AnswerReportAdminService;
@@ -53,33 +55,34 @@ public class AdminReportController implements AdminReportControllerDocs {
         );
     }
 
+
     @Override
-    @GetMapping("/letters/{reportId}")
-    public ResponseEntity<GlobalResponse<PlazaLetterReportAdminResDto>> getReportedLetterDetail(
-            @PathVariable Long reportId
+    @GetMapping("/letters/{letterId}")
+    public ResponseEntity<GlobalResponse<PlazaLetterReportDetailResDto>> getReportedLetterDetail(
+            @PathVariable Long letterId
     ) {
         return ResponseEntity.ok(
-                GlobalResponse.success("신고된 편지 상세 조회 성공", adminReportService.getReportedLetterDetail(reportId))
+                GlobalResponse.success("신고된 편지 상세 조회 성공", adminReportService.getReportedLetterDetail(letterId))
         );
     }
 
     @Override
-    @GetMapping("/replies/{reportId}")
-    public ResponseEntity<GlobalResponse<PlazaLetterReplyReportAdminResDto>> getReportedReplyDetail(
-            @PathVariable Long reportId
+    @GetMapping("/replies/{replyId}")
+    public ResponseEntity<GlobalResponse<PlazaLetterReplyReportDetailResDto>> getReportedReplyDetail(
+            @PathVariable Long replyId
     ) {
         return ResponseEntity.ok(
-                GlobalResponse.success("신고된 답장 상세 조회 성공", adminReportService.getReportedReplyDetail(reportId))
+                GlobalResponse.success("신고된 답장 상세 조회 성공", adminReportService.getReportedReplyDetail(replyId))
         );
     }
 
     @Override
-    @GetMapping("/answers/{reportId}")
-    public ResponseEntity<GlobalResponse<AnswerReportAdminResDto>> getReportedAnswerDetail(
-            @PathVariable Long reportId
+    @GetMapping("/answers/{answerId}")
+    public ResponseEntity<GlobalResponse<AnswerReportDetailResDto>> getReportedAnswerDetail(
+            @PathVariable Long answerId
     ) {
         return ResponseEntity.ok(
-                GlobalResponse.success("신고된 답변 상세 조회 성공", adminReportService.getReportedAnswerDetail(reportId))
+                GlobalResponse.success("신고된 답변 상세 조회 성공", adminReportService.getReportedAnswerDetail(answerId))
         );
     }
 

--- a/src/main/java/com/example/egobook_be/domain/report/controller/AdminReportControllerDocs.java
+++ b/src/main/java/com/example/egobook_be/domain/report/controller/AdminReportControllerDocs.java
@@ -1,9 +1,12 @@
 package com.example.egobook_be.domain.report.controller;
 
 import com.example.egobook_be.domain.letters.dto.response.PlazaLetterReplyReportAdminResDto;
+import com.example.egobook_be.domain.letters.dto.response.PlazaLetterReplyReportDetailResDto;
 import com.example.egobook_be.domain.letters.dto.response.PlazaLetterReportAdminResDto;
+import com.example.egobook_be.domain.letters.dto.response.PlazaLetterReportDetailResDto;
 import com.example.egobook_be.domain.report.dto.AdminReportMemoReqDto;
 import com.example.egobook_be.domain.question.dto.AnswerReportAdminResDto;
+import com.example.egobook_be.domain.question.dto.AnswerReportDetailResDto;
 import com.example.egobook_be.global.response.GlobalResponse;
 import com.example.egobook_be.global.response.SliceResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -22,9 +25,12 @@ public interface AdminReportControllerDocs {
             @RequestParam(defaultValue = "20") int size
     );
 
-    @Operation(summary = "[관리자] 신고된 편지 상세 조회", description = "신고된 편지 1건을 상세 조회합니다.")
-    ResponseEntity<GlobalResponse<PlazaLetterReportAdminResDto>> getReportedLetterDetail(
-            @PathVariable Long reportId
+    @Operation(summary = "[관리자] 신고된 편지 상세 조회", description = """
+            신고된 편지 1건(letterId 기준)에 달린 모든 신고 내역을 조회합니다.
+            여러 명이 같은 편지를 신고한 경우, reports 배열에 각 신고 건이 모두 포함됩니다.
+            """)
+    ResponseEntity<GlobalResponse<PlazaLetterReportDetailResDto>> getReportedLetterDetail(
+            @PathVariable Long letterId
     );
 
     @Operation(summary = "[관리자] 신고된 편지 답장 목록 조회", description = "신고된 편지 답장 목록을 최신순으로 조회합니다.")
@@ -33,9 +39,12 @@ public interface AdminReportControllerDocs {
             @RequestParam(defaultValue = "20") int size
     );
 
-    @Operation(summary = "[관리자] 신고된 편지 답장 상세 조회", description = "신고된 편지 답장 1건을 상세 조회합니다.")
-    ResponseEntity<GlobalResponse<PlazaLetterReplyReportAdminResDto>> getReportedReplyDetail(
-            @PathVariable Long reportId
+    @Operation(summary = "[관리자] 신고된 편지 답장 상세 조회", description = """
+            신고된 편지 답장 1건(replyId 기준)에 달린 모든 신고 내역을 조회합니다.
+            여러 명이 같은 답장을 신고한 경우, reports 배열에 각 신고 건이 모두 포함됩니다.
+            """)
+    ResponseEntity<GlobalResponse<PlazaLetterReplyReportDetailResDto>> getReportedReplyDetail(
+            @PathVariable Long replyId
     );
 
     @Operation(summary = "[관리자] 신고된 오늘의 질문 답변 목록 조회", description = "신고된 오늘의 질문 답변 목록을 최신순으로 조회합니다.")
@@ -44,9 +53,12 @@ public interface AdminReportControllerDocs {
             @RequestParam(defaultValue = "20") int size
     );
 
-    @Operation(summary = "[관리자] 오늘의 질문 답변 상세 조회", description = "신고된 오늘의 질문 답변 1건을 상세 조회합니다.")
-    ResponseEntity<GlobalResponse<AnswerReportAdminResDto>> getReportedAnswerDetail(
-            @PathVariable Long reportId
+    @Operation(summary = "[관리자] 오늘의 질문 답변 상세 조회", description = """
+            신고된 오늘의 질문 답변 1건(answerId 기준)에 달린 모든 신고 내역을 조회합니다.
+            여러 명이 같은 답변을 신고한 경우, reports 배열에 각 신고 건이 모두 포함됩니다.
+            """)
+    ResponseEntity<GlobalResponse<AnswerReportDetailResDto>> getReportedAnswerDetail(
+            @PathVariable Long answerId
     );
 
     @Operation(summary = "[관리자] 편지 수동 삭제", description = "편지를 수동으로 삭제합니다.")

--- a/src/main/java/com/example/egobook_be/domain/report/dto/ReportEntryResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/report/dto/ReportEntryResDto.java
@@ -1,0 +1,17 @@
+package com.example.egobook_be.domain.report.dto;
+
+import com.example.egobook_be.global.enums.ReportReason;
+import com.example.egobook_be.global.enums.ReportStatus;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record ReportEntryResDto(
+        Long reportId,
+        Long reporterId,
+        ReportReason reason,
+        String description,
+        ReportStatus status,
+        LocalDateTime createdAt
+) {}

--- a/src/main/java/com/example/egobook_be/domain/report/service/AdminReportService.java
+++ b/src/main/java/com/example/egobook_be/domain/report/service/AdminReportService.java
@@ -1,9 +1,12 @@
 package com.example.egobook_be.domain.report.service;
 
 import com.example.egobook_be.domain.letters.dto.response.PlazaLetterReplyReportAdminResDto;
+import com.example.egobook_be.domain.letters.dto.response.PlazaLetterReplyReportDetailResDto;
 import com.example.egobook_be.domain.letters.dto.response.PlazaLetterReportAdminResDto;
+import com.example.egobook_be.domain.letters.dto.response.PlazaLetterReportDetailResDto;
 import com.example.egobook_be.domain.letters.service.LetterReportAdminService;
 import com.example.egobook_be.domain.question.dto.AnswerReportAdminResDto;
+import com.example.egobook_be.domain.question.dto.AnswerReportDetailResDto;
 import com.example.egobook_be.domain.question.service.AnswerReportAdminService;
 import com.example.egobook_be.domain.report.dto.AdminReportMemoReqDto;
 import com.example.egobook_be.domain.report.enums.ReportErrorCode;
@@ -36,16 +39,17 @@ public class AdminReportService {
         return answerReportAdminService.getReportedAnswers(page, size);
     }
 
-    public PlazaLetterReportAdminResDto getReportedLetterDetail(Long reportId) {
-        return letterReportAdminService.getReportedLetterDetail(reportId);
+
+    public PlazaLetterReportDetailResDto getReportedLetterDetail(Long letterId) {
+        return letterReportAdminService.getReportedLetterDetail(letterId);
     }
 
-    public PlazaLetterReplyReportAdminResDto getReportedReplyDetail(Long reportId) {
-        return letterReportAdminService.getReportedReplyDetail(reportId);
+    public PlazaLetterReplyReportDetailResDto getReportedReplyDetail(Long replyId) {
+        return letterReportAdminService.getReportedReplyDetail(replyId);
     }
 
-    public AnswerReportAdminResDto getReportedAnswerDetail(Long reportId) {
-        return answerReportAdminService.getReportedAnswerDetail(reportId);
+    public AnswerReportDetailResDto getReportedAnswerDetail(Long answerId) {
+        return answerReportAdminService.getReportedAnswerDetail(answerId);
     }
 
     public void deleteLetter(Long letterId) {

--- a/src/main/java/com/example/egobook_be/domain/user/service/AdminContentService.java
+++ b/src/main/java/com/example/egobook_be/domain/user/service/AdminContentService.java
@@ -67,7 +67,7 @@ public class AdminContentService {
 
         Map<LocalDate, Long> successMap = toDateCountMap(successByDate);
         Map<LocalDate, Long> failMap = toDateCountMap(failByDate);
-        
+
         List<Object[]> scheduledByDate = diaryRepository.countDailyPraiseTargetsByDateRange(startDate, endDate);
         Map<LocalDate, Long> scheduledMap = toDateCountMap(scheduledByDate);
         List<LocalDate> dateRange = buildDateRange(startDate, endDate);

--- a/src/main/java/com/example/egobook_be/domain/user/service/AdminContentService.java
+++ b/src/main/java/com/example/egobook_be/domain/user/service/AdminContentService.java
@@ -7,6 +7,7 @@ import com.example.egobook_be.domain.ego_room.repository.DailyPraiseRepository;
 import com.example.egobook_be.domain.ego_room.repository.WeeklyCounselRepository;
 import com.example.egobook_be.domain.ego_room.repository.WeeklyReportSendFailLogRepository;
 import com.example.egobook_be.domain.ego_room.service.EgoRoomService;
+import com.example.egobook_be.domain.diary.repository.DiaryRepository;
 import com.example.egobook_be.domain.letters.entity.BadWordBlockLog;
 import com.example.egobook_be.domain.letters.entity.LetterSendFailLog;
 import com.example.egobook_be.domain.letters.entity.PlazaLetterStatus;
@@ -45,6 +46,7 @@ public class AdminContentService {
     private final UserRepository userRepository;
     private final EgoRoomService egoRoomService;
     private final AiRequestCountLogRepository aiRequestCountLogRepo;
+    private final DiaryRepository diaryRepository;
 
     // ─────────────────────────────────────────────────────────────────────────
     // B1. AI 일간 칭찬서
@@ -65,24 +67,25 @@ public class AdminContentService {
 
         Map<LocalDate, Long> successMap = toDateCountMap(successByDate);
         Map<LocalDate, Long> failMap = toDateCountMap(failByDate);
-
-        // scheduledCount = dailyPraise=true 유저 수 (현재 기준)
-        long scheduledPerDay = userRepository.findByDailyPraiseTrue().size();
+        
+        List<Object[]> scheduledByDate = diaryRepository.countDailyPraiseTargetsByDateRange(startDate, endDate);
+        Map<LocalDate, Long> scheduledMap = toDateCountMap(scheduledByDate);
         List<LocalDate> dateRange = buildDateRange(startDate, endDate);
 
         List<DailyStat> dailyStats = dateRange.stream()
                 .map(date -> DailyStat.builder()
                         .date(date)
-                        .scheduledCount(scheduledPerDay)
+                        .scheduledCount(scheduledMap.getOrDefault(date, 0L))
                         .successCount(successMap.getOrDefault(date, 0L))
                         .failCount(failMap.getOrDefault(date, 0L))
                         .build())
                 .collect(Collectors.toList());
 
         long totalSuccess = successMap.values().stream().mapToLong(Long::longValue).sum();
+        long totalScheduled = scheduledMap.values().stream().mapToLong(Long::longValue).sum();
 
         SummaryWithDaily summary = SummaryWithDaily.builder()
-                .scheduledCount(scheduledPerDay * dateRange.size())
+                .scheduledCount(totalScheduled)
                 .successCount(totalSuccess)
                 .failCount(failLogs.size())
                 .build();


### PR DESCRIPTION
## 📝 작업 내용

**1. 관리자페이지 발송예정 건수 로직 수정**
- 기존: 전체유저수
- 변경: 전체유저 중 일기를 작성한 유저 중 일간칭찬서 수신 설정한 유저 수

**2. 신고 관리**
- 반려시 DB에서 삭제
- 신고 반려시 누적 횟수 차감
- 신고 목록/상세 응답에 신고당한 유저 정보 추가
- 신고 상세 조회 API 파라미터 변경
 GET /admin/reports/letters/{id} / replies/{id} / answers/{id}
id의 의미가 신고 건 PK(reportId) → 신고당한 컨텐츠 ID(letterId/replyId/answerId) 로 바뀜


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 관리자 일간 칭찬서 현황에서 날짜별 실제 발송 대상자 수와 전체 합계를 확인할 수 있습니다.
  * 편지, 답장, 답변 신고 상세 화면에서 콘텐츠별 전체 신고 내역과 신고자·대상자 정보를 확인할 수 있습니다.
* **개선**
  * 관리자 신고 목록에는 처리 대기 중인 신고만 표시됩니다.
  * 신고 반려 시 해당 신고 내역이 삭제됩니다.
  * 사용자 통계 갱신 시간이 매일 오전 3시에서 오전 2시로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->