### PR TITLE
✨ Feat: Reddot 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,10 @@ dependencies {
 
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // ShedLock (스케줄러 분산 락 - 서버 여러 대에서 동일 스케줄러 동시 실행 방지)
+    implementation 'net.javacrumbs.shedlock:shedlock-spring:5.16.0'
+    implementation 'net.javacrumbs.shedlock:shedlock-provider-redis-spring:5.16.0'
     // Google Auth Library
     implementation 'com.google.api-client:google-api-client:2.2.0'
     implementation 'com.google.oauth-client:google-oauth-client-jetty:1.34.1'

--- a/src/main/java/com/example/egobook_be/domain/home/dto/HomeResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/home/dto/HomeResDto.java
@@ -13,7 +13,7 @@ public record HomeResDto(
         Integer level,
         @Schema(description = "사용자 보유 잉크", example = "100")
         Integer ink,
-        @Schema(description = "사용자가 아직 읽지 않은 알림 개수", example = "10")
+        @Schema(description = "레드닷 판단용 - 마지막으로 알림을 확인(목록 조회/개별 확인)한 시점 이후 새로 도착한 알림 개수. 0이면 레드닷 미노출", example = "10")
         Integer unreadNotifications,
         @Schema(description = "사용자가 아직 열지 않은 오늘의 심리 지식 여부", example = "true")
         Boolean hasUnopenedPsychology,

--- a/src/main/java/com/example/egobook_be/domain/home/service/HomeService.java
+++ b/src/main/java/com/example/egobook_be/domain/home/service/HomeService.java
@@ -62,8 +62,12 @@ public class HomeService {
          */
         User user = userRepository.findByIdWithLock(userId).orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
 
-        // 2. 사용자가 아직 읽지 않은 알림 개수 확인
-        Integer unReadNotificationCount = notificationRepository.countByUserAndIsReadIsFalse(user);
+        // 레드닷 판단 기준을 isRead 여부 대신 "마지막으로 알림을 확인한 시각 이후 새로 생긴 알림이 있는가"로 변경
+        // - 개별 알림의 읽음(isRead) 상태와는 무관하게, 목록을 열거나 푸시로 확인한 시점 이후 새 알림 존재 여부만 확인
+        LocalDateTime lastCheckedAt = user.getLastNotificationCheckedAt() != null
+                ? user.getLastNotificationCheckedAt()
+                : LocalDateTime.MIN;
+        Integer unReadNotificationCount = notificationRepository.countByUserAndCreatedAtAfter(user, lastCheckedAt);
 
         // 3. 사용자가 열지 않은 오늘의 심리 지식 여부
         Boolean hasUnopenedPsychology = hasUnopenedPsychologyKnowledge(user);

--- a/src/main/java/com/example/egobook_be/domain/home/service/HomeService.java
+++ b/src/main/java/com/example/egobook_be/domain/home/service/HomeService.java
@@ -66,7 +66,7 @@ public class HomeService {
         // - 개별 알림의 읽음(isRead) 상태와는 무관하게, 목록을 열거나 푸시로 확인한 시점 이후 새 알림 존재 여부만 확인
         LocalDateTime lastCheckedAt = user.getLastNotificationCheckedAt() != null
                 ? user.getLastNotificationCheckedAt()
-                : LocalDateTime.MIN;
+                : LocalDateTime.of(1970, 1, 1, 0, 0);
         Integer unReadNotificationCount = notificationRepository.countByUserAndCreatedAtAfter(user, lastCheckedAt);
 
         // 3. 사용자가 열지 않은 오늘의 심리 지식 여부

--- a/src/main/java/com/example/egobook_be/domain/notice/controller/AdminNoticeController.java
+++ b/src/main/java/com/example/egobook_be/domain/notice/controller/AdminNoticeController.java
@@ -6,6 +6,7 @@ import com.example.egobook_be.domain.notice.dto.NoticeUpdateReqDto;
 import com.example.egobook_be.domain.notice.service.AdminNoticeService;
 import com.example.egobook_be.global.response.GlobalResponse;
 import com.example.egobook_be.global.response.SliceResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,7 +21,7 @@ public class AdminNoticeController implements AdminNoticeControllerDocs {
 
     @Override
     @PostMapping
-    public ResponseEntity<GlobalResponse<NoticeAdminResDto>> createNotice(@RequestBody NoticeCreateReqDto reqDto) {
+    public ResponseEntity<GlobalResponse<NoticeAdminResDto>> createNotice(@Valid @RequestBody NoticeCreateReqDto reqDto) {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(GlobalResponse.success(201, "공지사항 등록 성공", adminNoticeService.createNotice(reqDto)));
     }
@@ -40,7 +41,7 @@ public class AdminNoticeController implements AdminNoticeControllerDocs {
     @PatchMapping("/{noticeId}")
     public ResponseEntity<GlobalResponse<NoticeAdminResDto>> updateNotice(
             @PathVariable Long noticeId,
-            @RequestBody NoticeUpdateReqDto reqDto
+            @Valid @RequestBody NoticeUpdateReqDto reqDto
     ) {
         return ResponseEntity.ok(
                 GlobalResponse.success("공지사항 수정 성공", adminNoticeService.updateNotice(noticeId, reqDto))

--- a/src/main/java/com/example/egobook_be/domain/notice/controller/AdminNoticeController.java
+++ b/src/main/java/com/example/egobook_be/domain/notice/controller/AdminNoticeController.java
@@ -1,0 +1,56 @@
+package com.example.egobook_be.domain.notice.controller;
+
+import com.example.egobook_be.domain.notice.dto.NoticeAdminResDto;
+import com.example.egobook_be.domain.notice.dto.NoticeCreateReqDto;
+import com.example.egobook_be.domain.notice.dto.NoticeUpdateReqDto;
+import com.example.egobook_be.domain.notice.service.AdminNoticeService;
+import com.example.egobook_be.global.response.GlobalResponse;
+import com.example.egobook_be.global.response.SliceResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/notices")
+public class AdminNoticeController implements AdminNoticeControllerDocs {
+
+    private final AdminNoticeService adminNoticeService;
+
+    @Override
+    @PostMapping
+    public ResponseEntity<GlobalResponse<NoticeAdminResDto>> createNotice(@RequestBody NoticeCreateReqDto reqDto) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(GlobalResponse.success(201, "공지사항 등록 성공", adminNoticeService.createNotice(reqDto)));
+    }
+
+    @Override
+    @GetMapping
+    public ResponseEntity<GlobalResponse<SliceResponse<NoticeAdminResDto>>> getNotices(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        return ResponseEntity.ok(
+                GlobalResponse.success("공지사항 목록 조회 성공", adminNoticeService.getNotices(page, size))
+        );
+    }
+
+    @Override
+    @PatchMapping("/{noticeId}")
+    public ResponseEntity<GlobalResponse<NoticeAdminResDto>> updateNotice(
+            @PathVariable Long noticeId,
+            @RequestBody NoticeUpdateReqDto reqDto
+    ) {
+        return ResponseEntity.ok(
+                GlobalResponse.success("공지사항 수정 성공", adminNoticeService.updateNotice(noticeId, reqDto))
+        );
+    }
+
+    @Override
+    @DeleteMapping("/{noticeId}")
+    public ResponseEntity<GlobalResponse<Void>> deleteNotice(@PathVariable Long noticeId) {
+        adminNoticeService.deleteNotice(noticeId);
+        return ResponseEntity.ok(GlobalResponse.success("공지사항 삭제 성공", null));
+    }
+}

--- a/src/main/java/com/example/egobook_be/domain/notice/controller/AdminNoticeControllerDocs.java
+++ b/src/main/java/com/example/egobook_be/domain/notice/controller/AdminNoticeControllerDocs.java
@@ -1,0 +1,52 @@
+package com.example.egobook_be.domain.notice.controller;
+
+import com.example.egobook_be.domain.notice.dto.NoticeAdminResDto;
+import com.example.egobook_be.domain.notice.dto.NoticeCreateReqDto;
+import com.example.egobook_be.domain.notice.dto.NoticeUpdateReqDto;
+import com.example.egobook_be.global.response.GlobalResponse;
+import com.example.egobook_be.global.response.SliceResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Admin Notice", description = "공지사항 관리자 API")
+@RequestMapping("/admin/notices")
+public interface AdminNoticeControllerDocs {
+
+    @Operation(summary = "[관리자] 공지사항 등록", description = """
+            공지사항을 등록합니다. 노션 링크를 등록하면 앱에서는 웹뷰로 해당 페이지를 띄웁니다.
+
+            [Request Body]
+            - title: 공지 제목
+            - notionUrl: 공지 노션 페이지 링크
+            - publishedAt: 발행(노출 시작) 일시. 이 시각이 지나야 유저에게 노출/레드닷이 뜹니다.
+            """)
+    @SecurityRequirement(name = "bearerAuth")
+    ResponseEntity<GlobalResponse<NoticeAdminResDto>> createNotice(@RequestBody NoticeCreateReqDto reqDto);
+
+    @Operation(summary = "[관리자] 공지사항 목록 조회", description = "공지사항 목록을 발행일시 최신순으로 조회합니다.")
+    @SecurityRequirement(name = "bearerAuth")
+    ResponseEntity<GlobalResponse<SliceResponse<NoticeAdminResDto>>> getNotices(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "20") int size
+    );
+
+    @Operation(summary = "[관리자] 공지사항 수정", description = """
+            공지사항을 수정합니다.
+            삭제 후 재등록하면 이미 확인한 유저들에게 레드닷이 다시 뜨므로, 오탈자 등을 고칠 때는 이 API를 사용하세요.
+            """)
+    @SecurityRequirement(name = "bearerAuth")
+    ResponseEntity<GlobalResponse<NoticeAdminResDto>> updateNotice(
+            @PathVariable Long noticeId,
+            @RequestBody NoticeUpdateReqDto reqDto
+    );
+
+    @Operation(summary = "[관리자] 공지사항 삭제")
+    @SecurityRequirement(name = "bearerAuth")
+    ResponseEntity<GlobalResponse<Void>> deleteNotice(@PathVariable Long noticeId);
+}

--- a/src/main/java/com/example/egobook_be/domain/notice/dto/NoticeAdminResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/notice/dto/NoticeAdminResDto.java
@@ -1,0 +1,16 @@
+package com.example.egobook_be.domain.notice.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Schema(description = "공지사항 관리자 응답 DTO")
+public record NoticeAdminResDto(
+        Long noticeId,
+        String title,
+        String notionUrl,
+        LocalDateTime publishedAt,
+        LocalDateTime createdAt
+) {}

--- a/src/main/java/com/example/egobook_be/domain/notice/dto/NoticeCreateReqDto.java
+++ b/src/main/java/com/example/egobook_be/domain/notice/dto/NoticeCreateReqDto.java
@@ -1,15 +1,20 @@
 package com.example.egobook_be.domain.notice.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDateTime;
 
 @Schema(description = "공지사항 등록 요청 DTO")
 public record NoticeCreateReqDto(
         @Schema(description = "공지 제목", example = "5월 업데이트 안내")
+        @NotBlank(message = "제목은 필수입니다.")
         String title,
         @Schema(description = "공지 노션 링크", example = "https://notion.so/...")
+        @NotBlank(message = "노션 링크는 필수입니다.")
         String notionUrl,
         @Schema(description = "발행(노출 시작) 일시", example = "2026-05-11T00:00:00")
+        @NotNull(message = "발행 일시는 필수입니다.")
         LocalDateTime publishedAt
 ) {}

--- a/src/main/java/com/example/egobook_be/domain/notice/dto/NoticeCreateReqDto.java
+++ b/src/main/java/com/example/egobook_be/domain/notice/dto/NoticeCreateReqDto.java
@@ -1,0 +1,15 @@
+package com.example.egobook_be.domain.notice.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "공지사항 등록 요청 DTO")
+public record NoticeCreateReqDto(
+        @Schema(description = "공지 제목", example = "5월 업데이트 안내")
+        String title,
+        @Schema(description = "공지 노션 링크", example = "https://notion.so/...")
+        String notionUrl,
+        @Schema(description = "발행(노출 시작) 일시", example = "2026-05-11T00:00:00")
+        LocalDateTime publishedAt
+) {}

--- a/src/main/java/com/example/egobook_be/domain/notice/dto/NoticeUpdateReqDto.java
+++ b/src/main/java/com/example/egobook_be/domain/notice/dto/NoticeUpdateReqDto.java
@@ -1,15 +1,20 @@
 package com.example.egobook_be.domain.notice.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDateTime;
 
 @Schema(description = "공지사항 수정 요청 DTO")
 public record NoticeUpdateReqDto(
         @Schema(description = "공지 제목", example = "5월 업데이트 안내")
+        @NotBlank(message = "제목은 필수입니다.")
         String title,
         @Schema(description = "공지 노션 링크", example = "https://notion.so/...")
+        @NotBlank(message = "노션 링크는 필수입니다.")
         String notionUrl,
         @Schema(description = "발행(노출 시작) 일시", example = "2026-05-11T00:00:00")
+        @NotNull(message = "발행 일시는 필수입니다.")
         LocalDateTime publishedAt
 ) {}

--- a/src/main/java/com/example/egobook_be/domain/notice/dto/NoticeUpdateReqDto.java
+++ b/src/main/java/com/example/egobook_be/domain/notice/dto/NoticeUpdateReqDto.java
@@ -1,0 +1,15 @@
+package com.example.egobook_be.domain.notice.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "공지사항 수정 요청 DTO")
+public record NoticeUpdateReqDto(
+        @Schema(description = "공지 제목", example = "5월 업데이트 안내")
+        String title,
+        @Schema(description = "공지 노션 링크", example = "https://notion.so/...")
+        String notionUrl,
+        @Schema(description = "발행(노출 시작) 일시", example = "2026-05-11T00:00:00")
+        LocalDateTime publishedAt
+) {}

--- a/src/main/java/com/example/egobook_be/domain/notice/entity/Notice.java
+++ b/src/main/java/com/example/egobook_be/domain/notice/entity/Notice.java
@@ -1,0 +1,48 @@
+package com.example.egobook_be.domain.notice.entity;
+
+import com.example.egobook_be.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "notice")
+public class Notice extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 100)
+    private String title;
+
+    @Column(name = "notion_url", nullable = false, length = 500)
+    private String notionUrl;
+
+    @Column(name = "published_at", nullable = false)
+    private LocalDateTime publishedAt;
+
+    // 발행 시각 도달 후 전체 유저 브로드캐스트가 이미 수행됐는지 여부 (스케줄러 중복 발송 방지)
+    @Column(name = "broadcasted", nullable = false)
+    @Builder.Default
+    private boolean broadcasted = false;
+
+    public void update(String title, String notionUrl, LocalDateTime publishedAt) {
+        this.title = title;
+        this.notionUrl = notionUrl;
+        this.publishedAt = publishedAt;
+    }
+
+    public void markBroadcasted() {
+        this.broadcasted = true;
+    }
+}

--- a/src/main/java/com/example/egobook_be/domain/notice/exception/NoticeErrorCode.java
+++ b/src/main/java/com/example/egobook_be/domain/notice/exception/NoticeErrorCode.java
@@ -1,0 +1,21 @@
+package com.example.egobook_be.domain.notice.exception;
+
+import com.example.egobook_be.global.exception.model.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum NoticeErrorCode implements BaseErrorCode {
+
+    NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "공지사항을 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public HttpStatus getStatus() {
+        return this.httpStatus;
+    }
+}

--- a/src/main/java/com/example/egobook_be/domain/notice/mapper/NoticeMapper.java
+++ b/src/main/java/com/example/egobook_be/domain/notice/mapper/NoticeMapper.java
@@ -1,0 +1,24 @@
+package com.example.egobook_be.domain.notice.mapper;
+
+import com.example.egobook_be.domain.notice.dto.NoticeAdminResDto;
+import com.example.egobook_be.domain.notice.entity.Notice;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NoticeMapper {
+
+    /**
+     * Notice Entity -> NoticeAdminResDto 변환
+     * @param notice : 변환할 Notice Entity
+     * @return : 변환된 NoticeAdminResDto
+     */
+    public NoticeAdminResDto toNoticeAdminResDto(Notice notice) {
+        return NoticeAdminResDto.builder()
+                .noticeId(notice.getId())
+                .title(notice.getTitle())
+                .notionUrl(notice.getNotionUrl())
+                .publishedAt(notice.getPublishedAt())
+                .createdAt(notice.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/egobook_be/domain/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/notice/repository/NoticeRepository.java
@@ -1,0 +1,26 @@
+package com.example.egobook_be.domain.notice.repository;
+
+import com.example.egobook_be.domain.notice.entity.Notice;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+
+    /**
+     * 관리자용 공지 목록을 발행 시각 최신순으로 조회한다.
+     * @param pageable : 페이징 정보
+     * @return : 공지 Slice
+     */
+    Slice<Notice> findAllByOrderByPublishedAtDesc(Pageable pageable);
+
+    /**
+     * 발행 시각이 지났지만 아직 전체 유저에게 브로드캐스트되지 않은 공지 목록을 조회한다.
+     * @param now : 기준 시각
+     * @return : 브로드캐스트 대상 공지 목록
+     */
+    List<Notice> findAllByPublishedAtLessThanEqualAndBroadcastedFalse(LocalDateTime now);
+}

--- a/src/main/java/com/example/egobook_be/domain/notice/scheduler/NoticeBroadcastScheduler.java
+++ b/src/main/java/com/example/egobook_be/domain/notice/scheduler/NoticeBroadcastScheduler.java
@@ -8,6 +8,7 @@ import com.example.egobook_be.domain.user.enums.UserStatus;
 import com.example.egobook_be.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,7 +27,9 @@ public class NoticeBroadcastScheduler {
     private final NotificationService notificationService;
 
     // 매분 정각마다 발행 시각이 지난 미발송 공지를 확인
+    // 서버가 여러 대여도 한 인스턴스만 브로드캐스트를 수행하도록 보장
     @Scheduled(cron = "0 * * * * *")
+    @SchedulerLock(name = "noticeBroadcastScheduler", lockAtMostFor = "PT5M", lockAtLeastFor = "PT10S")
     @Transactional
     public void broadcastDueNotices() {
         List<Notice> dueNotices = noticeRepository.findAllByPublishedAtLessThanEqualAndBroadcastedFalse(LocalDateTime.now());

--- a/src/main/java/com/example/egobook_be/domain/notice/scheduler/NoticeBroadcastScheduler.java
+++ b/src/main/java/com/example/egobook_be/domain/notice/scheduler/NoticeBroadcastScheduler.java
@@ -1,0 +1,47 @@
+package com.example.egobook_be.domain.notice.scheduler;
+
+import com.example.egobook_be.domain.notice.entity.Notice;
+import com.example.egobook_be.domain.notice.repository.NoticeRepository;
+import com.example.egobook_be.domain.notification.service.NotificationService;
+import com.example.egobook_be.domain.user.entity.User;
+import com.example.egobook_be.domain.user.enums.UserStatus;
+import com.example.egobook_be.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+// 공지사항 발행 시각 도달 시 전체 유저에게 NOTICE 타입 알림을 브로드캐스트
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NoticeBroadcastScheduler {
+
+    private final NoticeRepository noticeRepository;
+    private final UserRepository userRepository;
+    private final NotificationService notificationService;
+
+    // 매분 정각마다 발행 시각이 지난 미발송 공지를 확인
+    @Scheduled(cron = "0 * * * * *")
+    @Transactional
+    public void broadcastDueNotices() {
+        List<Notice> dueNotices = noticeRepository.findAllByPublishedAtLessThanEqualAndBroadcastedFalse(LocalDateTime.now());
+        if (dueNotices.isEmpty()) {
+            return;
+        }
+
+        List<User> activeUsers = userRepository.findAllByStatus(UserStatus.ACTIVE);
+        for (Notice notice : dueNotices) {
+            log.info("[NoticeBroadcastScheduler] 공지 브로드캐스트 시작 - noticeId: {}, 대상 유저 수: {}", notice.getId(), activeUsers.size());
+            for (User user : activeUsers) {
+                notificationService.createNoticeNotification(user, notice.getId(), notice.getTitle(), notice.getNotionUrl());
+            }
+            notice.markBroadcasted();
+            log.info("[NoticeBroadcastScheduler] 공지 브로드캐스트 완료 - noticeId: {}", notice.getId());
+        }
+    }
+}

--- a/src/main/java/com/example/egobook_be/domain/notice/service/AdminNoticeService.java
+++ b/src/main/java/com/example/egobook_be/domain/notice/service/AdminNoticeService.java
@@ -1,0 +1,103 @@
+package com.example.egobook_be.domain.notice.service;
+
+import com.example.egobook_be.domain.notice.dto.NoticeAdminResDto;
+import com.example.egobook_be.domain.notice.dto.NoticeCreateReqDto;
+import com.example.egobook_be.domain.notice.dto.NoticeUpdateReqDto;
+import com.example.egobook_be.domain.notice.entity.Notice;
+import com.example.egobook_be.domain.notice.exception.NoticeErrorCode;
+import com.example.egobook_be.domain.notice.mapper.NoticeMapper;
+import com.example.egobook_be.domain.notice.repository.NoticeRepository;
+import com.example.egobook_be.global.exception.CustomException;
+import com.example.egobook_be.global.response.SliceResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdminNoticeService {
+
+    private final NoticeRepository noticeRepository;
+    private final NoticeMapper noticeMapper;
+
+    /**
+     * 공지사항을 등록한다.
+     * @param reqDto : 제목, 노션 링크, 발행 일시
+     * @return : 등록된 공지 정보
+     */
+    @Transactional
+    public NoticeAdminResDto createNotice(NoticeCreateReqDto reqDto) {
+        log.info("[AdminNoticeService] createNotice() - START | title: {}", reqDto.title());
+
+        Notice notice = Notice.builder()
+                .title(reqDto.title())
+                .notionUrl(reqDto.notionUrl())
+                .publishedAt(reqDto.publishedAt())
+                .build();
+        Notice saved = noticeRepository.save(notice);
+        NoticeAdminResDto result = noticeMapper.toNoticeAdminResDto(saved);
+
+        log.info("[AdminNoticeService] createNotice() - END | noticeId: {}", saved.getId());
+        return result;
+    }
+
+    /**
+     * 공지사항 목록을 발행 시각 최신순으로 조회한다.
+     * @param page : 페이지 번호 (1 ~ N, 프론트 기준)
+     * @param size : 페이지 크기
+     * @return : SliceResponse<NoticeAdminResDto>
+     */
+    @Transactional(readOnly = true)
+    public SliceResponse<NoticeAdminResDto> getNotices(int page, int size) {
+        log.info("[AdminNoticeService] getNotices() - START | page: {}, size: {}", page, size);
+
+        Pageable pageable = PageRequest.of(page - 1, size);
+        SliceResponse<NoticeAdminResDto> result = SliceResponse.of(
+                noticeRepository.findAllByOrderByPublishedAtDesc(pageable),
+                noticeMapper::toNoticeAdminResDto
+        );
+
+        log.info("[AdminNoticeService] getNotices() - END | resultSize: {}", result.size());
+        return result;
+    }
+
+    /**
+     * 공지사항을 수정한다.
+     * - 삭제 후 재등록 시 유저의 읽음 상태가 초기화되어 레드닷이 재노출되는 부작용을 막기 위해 별도 제공
+     * @param noticeId : 수정할 공지 PK
+     * @param reqDto : 수정할 제목, 노션 링크, 발행 일시
+     * @return : 수정된 공지 정보
+     */
+    @Transactional
+    public NoticeAdminResDto updateNotice(Long noticeId, NoticeUpdateReqDto reqDto) {
+        log.info("[AdminNoticeService] updateNotice() - START | noticeId: {}", noticeId);
+
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new CustomException(NoticeErrorCode.NOTICE_NOT_FOUND));
+        notice.update(reqDto.title(), reqDto.notionUrl(), reqDto.publishedAt());
+        NoticeAdminResDto result = noticeMapper.toNoticeAdminResDto(notice);
+
+        log.info("[AdminNoticeService] updateNotice() - END | noticeId: {}", noticeId);
+        return result;
+    }
+
+    /**
+     * 공지사항을 삭제한다.
+     * @param noticeId : 삭제할 공지 PK
+     */
+    @Transactional
+    public void deleteNotice(Long noticeId) {
+        log.info("[AdminNoticeService] deleteNotice() - START | noticeId: {}", noticeId);
+
+        if (!noticeRepository.existsById(noticeId)) {
+            throw new CustomException(NoticeErrorCode.NOTICE_NOT_FOUND);
+        }
+        noticeRepository.deleteById(noticeId);
+
+        log.info("[AdminNoticeService] deleteNotice() - END | noticeId: {}", noticeId);
+    }
+}

--- a/src/main/java/com/example/egobook_be/domain/notification/controller/NotificationControllerDocs.java
+++ b/src/main/java/com/example/egobook_be/domain/notification/controller/NotificationControllerDocs.java
@@ -17,11 +17,12 @@ public interface NotificationControllerDocs {
 
     @Operation(summary = "알림 목록 조회", description = """
             알림은 최신순으로 확인 가능합니다.
-            
+
             - 편지 답장
             - 친구에게 온 편지
             - AI 칭찬서
             - AI 상담서
+            - 공지사항 (NOTICE 타입 - 발행 시점에 브로드캐스트됨, linkUrl에 노션 링크 포함)
             """)
     @GetMapping
     ResponseEntity<GlobalResponse<SliceResponse<NotificationResDto>>> getNotifications(

--- a/src/main/java/com/example/egobook_be/domain/notification/dto/NotificationResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/notification/dto/NotificationResDto.java
@@ -13,5 +13,6 @@ public record NotificationResDto(
         String content,
         Boolean isRead,
         Long targetId,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        String linkUrl
 ) {}

--- a/src/main/java/com/example/egobook_be/domain/notification/entity/Notification.java
+++ b/src/main/java/com/example/egobook_be/domain/notification/entity/Notification.java
@@ -34,6 +34,9 @@ public class Notification extends BaseTimeEntity {
     @Column(nullable = false)
     private Long targetId;
 
+    @Column(name = "link_url", length = 500)
+    private String linkUrl;
+
     @Column(nullable = false)
     @Builder.Default
     private boolean isRead = false;

--- a/src/main/java/com/example/egobook_be/domain/notification/entity/Notification.java
+++ b/src/main/java/com/example/egobook_be/domain/notification/entity/Notification.java
@@ -21,7 +21,8 @@ public class Notification extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
+    
+    @Column(nullable = false, columnDefinition = "VARCHAR(30)")
     @Enumerated(EnumType.STRING)
     private NotificationType type;
 

--- a/src/main/java/com/example/egobook_be/domain/notification/entity/Notification.java
+++ b/src/main/java/com/example/egobook_be/domain/notification/entity/Notification.java
@@ -14,7 +14,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
-@Table(name = "notification")
+@Table(name = "notification", indexes = @Index(name = "idx_notification_user_created", columnList = "user_id, created_at"))
 public class Notification extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/example/egobook_be/domain/notification/enums/NotificationType.java
+++ b/src/main/java/com/example/egobook_be/domain/notification/enums/NotificationType.java
@@ -11,7 +11,8 @@ public enum NotificationType {
     LETTER_NEW("새로운 편지가 도착했어요!"),
     LETTER_NEW_FRIEND("새로운 %s님 편지가 도착했어요!"),
     PRAISE("%s 일간 칭찬서가 도착했어요!"),
-    REPORT("지난주 주간 리포트가 도착했어요!");
+    REPORT("지난주 주간 리포트가 도착했어요!"),
+    NOTICE("%s");
 
     private final String title;
 

--- a/src/main/java/com/example/egobook_be/domain/notification/mapper/NotificationMapper.java
+++ b/src/main/java/com/example/egobook_be/domain/notification/mapper/NotificationMapper.java
@@ -16,6 +16,7 @@ public class NotificationMapper {
                 .isRead(notification.isRead())
                 .targetId(notification.getTargetId())
                 .createdAt(notification.getCreatedAt())
+                .linkUrl(notification.getLinkUrl())
                 .build();
     }
 

--- a/src/main/java/com/example/egobook_be/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/notification/repository/NotificationRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -19,6 +20,15 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     /** 해당 사용자가 아직 읽지 않은 알림의 개수를 반환하는 함수 */
     Integer countByUserAndIsReadIsFalse(User user);
+
+    // 마지막 알림 확인 시각 이후 새로 생성된 알림 개수 (레드닷 판단 기준, isRead와 무관)
+    /**
+     * 마지막으로 알림을 확인한 시각(checkedAt) 이후 생성된 알림 개수를 반환한다.
+     * @param user : 조회 대상 유저
+     * @param checkedAt : 마지막 알림 확인 시각
+     * @return : checkedAt 이후 생성된 알림 개수
+     */
+    Integer countByUserAndCreatedAtAfter(User user, LocalDateTime checkedAt);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("DELETE FROM Notification n WHERE n.user IN :users")

--- a/src/main/java/com/example/egobook_be/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/example/egobook_be/domain/notification/service/NotificationService.java
@@ -75,8 +75,34 @@ public class NotificationService {
         log.info("[NotificationService] createNotification End - userId: {}, targetId: {}", userId, targetId);
     }
 
-    /** 알림 목록 */
-    @Transactional(readOnly = true)
+    /**
+     * 공지사항을 특정 유저에게 NOTICE 타입 알림으로 생성한다 
+     * - 일반 알림 생성(createNotification)과 달리 content 미리보기가 없고, 노션 링크(linkUrl)를 직접 싣는다.
+     * @param user : 알림을 받을 유저 (알림 설정 꺼져있으면 생성하지 않음)
+     * @param noticeId : 대상 공지 PK
+     * @param title : 공지 제목
+     * @param notionUrl : 공지 노션 링크
+     */
+    @Transactional
+    public void createNoticeNotification(User user, Long noticeId, String title, String notionUrl) {
+        if (!user.isNotificationEnabled()) {
+            return;
+        }
+
+        Notification notification = Notification.builder()
+                .user(user)
+                .type(NotificationType.NOTICE)
+                .title(NotificationType.NOTICE.format(title))
+                .targetId(noticeId)
+                .linkUrl(notionUrl)
+                .build();
+
+        notificationRepository.save(notification);
+        fcmService.sendPushNotification(user, notification);
+    }
+
+    /** 알림 목록 (공지사항은 발행 시 일반 알림으로 브로드캐스트되어 이 목록에 함께 포함됨) */
+    @Transactional
     public SliceResponse<NotificationResDto> getNotifications(Long userId, int page, int size) {
         log.info("[NotificationService] getNotifications Start - userId: {}", userId);
         User user = userRepository.findById(userId)
@@ -96,7 +122,11 @@ public class NotificationService {
                 Sort.by(Sort.Direction.DESC, "createdAt")
         );
 
+        // 응답에 담길 스냅샷은 갱신 전 상태를 기준으로 조회 (목록 내 개별 읽음 표시는 isRead로 그대로 유지)
         Slice<Notification> slice = notificationRepository.findAllByUser(user, pageable);
+
+        // 알림 목록을 연 시점을 기록 - 레드닷은 이 시각 이후 새 알림이 있는지로 판단 (isRead와 무관)
+        user.updateLastNotificationCheckedAt();
 
         log.info("[NotificationService] getNotifications End - userId: {}", userId);
         return SliceResponse.of(slice, NotificationMapper::toNotificationDto);
@@ -116,6 +146,9 @@ public class NotificationService {
 
         notification.markAsRead();
         notificationRepository.save(notification);
+
+        // 목록 화면을 거치지 않고 푸시로 직접 확인한 경우에도 레드닷 기준 시각 갱신
+        notification.getUser().updateLastNotificationCheckedAt();
 
         log.info("[NotificationService] readNotification End - userId: {}, notificationId: {}", userId, notificationId);
         return NotificationMapper.toNotificationReadDto(notification);

--- a/src/main/java/com/example/egobook_be/domain/user/entity/User.java
+++ b/src/main/java/com/example/egobook_be/domain/user/entity/User.java
@@ -25,6 +25,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.DynamicUpdate;
 
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
@@ -32,11 +33,13 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 
+
 @Entity
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@DynamicUpdate
 @Table(name = "User")
 public class User extends BaseTimeEntity {
 

--- a/src/main/java/com/example/egobook_be/domain/user/entity/User.java
+++ b/src/main/java/com/example/egobook_be/domain/user/entity/User.java
@@ -66,6 +66,9 @@ public class User extends BaseTimeEntity {
     @Column(name = "last_login_at")
     private LocalDateTime lastLoginAt;
 
+    @Column(name = "last_notification_checked_at")
+    private LocalDateTime lastNotificationCheckedAt;
+
     @Column(name = "level", nullable = false)
     @Builder.Default
     private Integer level = 1;
@@ -128,6 +131,13 @@ public class User extends BaseTimeEntity {
     }
 
     /**
+     * 알림 목록 조회 또는 개별 알림 확인 시 호출되어, 레드닷 판단 기준 시각을 현재로 갱신한다.
+     */
+    public void updateLastNotificationCheckedAt() {
+        this.lastNotificationCheckedAt = LocalDateTime.now();
+    }
+
+    /**
      * 사용자가 login 했을 때 User Entity 스스로 자신의 상태를 최신으로 갱신하는 함수
      * - 접속 시간 갱신
      * - 현재 상태가 DORMANT 이면 ACTIVE 상태로 변경
@@ -171,12 +181,11 @@ public class User extends BaseTimeEntity {
         this.notificationEnabled = true;
     }
 
-    // [AI-GEN] restrict user status
+
     public void suspend() {
         this.status = UserStatus.SUSPENDED;
     }
-
-    // [AI-GEN] restore user status
+    
     public void activate() {
         this.status = UserStatus.ACTIVE;
     }

--- a/src/main/java/com/example/egobook_be/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/user/repository/UserRepository.java
@@ -58,6 +58,9 @@ public interface UserRepository extends JpaRepository<User, Long>,UserRepository
     List<User> findByDailyPraiseTrue();
     List<User> findAllByWeeklyAnalysisEnabledTrue();
 
+    /** 공지사항 브로드캐스트 대상(활성 유저) 조회 */
+    List<User> findAllByStatus(UserStatus status);
+
 
     // 편지 수신 가능으로 변한 유저 찾기
     @Query("""

--- a/src/main/java/com/example/egobook_be/global/config/ShedLockConfig.java
+++ b/src/main/java/com/example/egobook_be/global/config/ShedLockConfig.java
@@ -1,0 +1,19 @@
+package com.example.egobook_be.global.config;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.redis.spring.RedisLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+// 서버가 여러 대여도 동일 스케줄러가 동시에 실행되지 않도록 방지
+@Configuration
+@EnableSchedulerLock(defaultLockAtMostFor = "PT5M")
+public class ShedLockConfig {
+
+    @Bean
+    public LockProvider lockProvider(RedisConnectionFactory connectionFactory) {
+        return new RedisLockProvider(connectionFactory, "egobook");
+    }
+}

--- a/src/test/java/com/example/egobook_be/domain/home/service/HomeServiceUnitTest.java
+++ b/src/test/java/com/example/egobook_be/domain/home/service/HomeServiceUnitTest.java
@@ -72,7 +72,7 @@ class HomeServiceUnitTest {
 
         // 2. Stub
         when(userRepository.findByIdWithLock(anyLong())).thenReturn(Optional.of(mockUser));
-        when(notificationRepository.countByUserAndIsReadIsFalse(any(User.class))).thenReturn(2);
+        when(notificationRepository.countByUserAndCreatedAtAfter(any(User.class), any(LocalDateTime.class))).thenReturn(2);
         when(inkLogRepository.existsByUserAndReasonAndCreatedAtAfter(eq(mockUser), eq(InkLogType.FIRST_PSYCHOLOGY_VIEW), any(LocalDateTime.class)))
                 .thenReturn(false); // 심리 지식을 열람하지 않은 상태 세팅 (exists가 false 반환)
         when(homeMapper.toHomeResDto(any(User.class), anyInt(), anyBoolean(), anyInt())).thenReturn(mockResDto); // Mapper 동작 세팅
@@ -123,7 +123,7 @@ class HomeServiceUnitTest {
 
         // 2. Stub
         when(userRepository.findByIdWithLock(anyLong())).thenReturn(Optional.of(mockUser));
-        when(notificationRepository.countByUserAndIsReadIsFalse(any(User.class))).thenReturn(0);
+        when(notificationRepository.countByUserAndCreatedAtAfter(any(User.class), any(LocalDateTime.class))).thenReturn(0);
         when(inkLogRepository.existsByUserAndReasonAndCreatedAtAfter(eq(mockUser), eq(InkLogType.FIRST_PSYCHOLOGY_VIEW), any(LocalDateTime.class)))
                 .thenReturn(true); // 이미 심리 지식을 열람한 상태 세팅
         when(homeMapper.toHomeResDto(any(User.class), anyInt(), anyBoolean(), anyInt())).thenReturn(mockResDto);


### PR DESCRIPTION
## 📝 작업 내용
알림 레드닷 판단 로직 개선 + 공지사항 관리 기능 추가

1. 알림 레드닷(unreadNotifications) 판단 기준 변경

기존: 개별 알림의 isRead 여부로 카운트
변경: User.lastNotificationCheckedAt(마지막으로 알림 목록을 확인한 시각) 이후 새로 도착한 알림 개수로 판단
GET /notifications(목록 조회), POST /notifications/{id}/read(개별 읽음 처리) 호출 시마다 lastNotificationCheckedAt 갱신
개별 알림 항목의 읽음 표시(isRead)는 기존 로직 그대로 유지 (레드닷 판단 기준과 완전히 분리)

2. 공지사항(Notice) 도메인 신규 추가

Notice 엔티티 + 관리자 CRUD API
POST /admin/notices : 등록 (제목, 노션 링크, 발행 일시)
GET /admin/notices : 목록 조회
PATCH /admin/notices/{noticeId} : 수정
DELETE /admin/notices/{noticeId} : 삭제
NoticeBroadcastScheduler: 매분 발행 시각이 지난 미발송 공지를 확인해 전체 활성 유저에게 자동 브로드캐스트

3. 공지사항을 기존 알림 인프라에 통합

NotificationType에 NOTICE 타입 추가
Notification에 linkUrl 필드 추가 (NOTICE 타입일 때 노션 링크를 바로 실어서, 프론트가 추가 조회 없이 웹뷰를 열 수 있도록 함)
별도의 공지 전용 API/레드닷 로직을 만들지 않고, 공지 발행 시 일반 Notification row를 브로드캐스트하는 방식으로 구현 → 기존 알림 목록(GET /notifications)과 읽음 처리(POST /notifications/{id}/read)를 그대로 재사용


> 테스트 결과: 로컬에서 서버 직접 실행 후 전체 플로우 수동 테스트 완료/ swagger 확인 완료
> (공지 등록 → 스케줄러 브로드캐스트 → 알림 목록 노출 → 레드닷 점등/소등)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 관리자가 공지사항을 생성, 조회, 수정, 삭제할 수 있습니다.
  * 발행된 공지사항이 활성 사용자에게 알림으로 전달됩니다.
  * 공지사항 알림에서 관련 링크를 확인할 수 있습니다.
* **개선**
  * 알림 “레드닷”은 마지막 알림 확인 시점 이후 새로 도착한 알림을 기준으로 표시됩니다.
  * 공지사항 및 알림 API 문서가 갱신되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->