### PR TITLE
🐛  Fix: 관리자 이미지 업로드 S3 버킷 설정 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+*.jar
 
 ### STS ###
 .apt_generated
@@ -55,3 +56,6 @@ CLAUDE.md
 
 ### CODEX ###
 AGENTS.md
+
+### redis ###
+redis/data/

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,7 +17,7 @@ spring:
       region:
         static: ap-northeast-2
       s3:
-        bucket: egobook-${spring.profiles.active} # profiles.active대로 버킷 이름 설정되도록 함
+        bucket: egobook-s3
   # Cloudinary 광고 영상 업로드를 위한 설정
   servlet:
     multipart:


### PR DESCRIPTION
## #️⃣연관된 이슈
- closes #244 

## 📝 작업 내용

* 관리자 이미지 업로드 기능에서 S3 버킷 설정 오류 수정
* 이미지 업로드 시 잘못된 버킷 설정으로 인해 발생할 수 있는 업로드 실패 문제 해결
* S3 관련 설정 값을 환경에 맞게 수정하여 정상적인 이미지 저장이 가능하도록 개선

## 🔧 변경 사항

* `application.yml` 내 S3 관련 설정 수정
* 불필요하게 Git에서 관리되고 있던 파일 정리

  * 빌드 결과물(`egobookServer.jar`) 추적 제거
  * Redis 데이터 파일(`redis/data`) Git 추적 제외 설정 추가

## ✅ 테스트

> 관리자 이미지 업로드 API 호출 및 S3 버킷 이미지 저장 정상 동작 확인

<img width="50%" alt="image" src="https://github.com/user-attachments/assets/c65be966-c2a0-43eb-b91d-127a119159d5" />
<br> 

## 📌 참고 사항

* `.gitignore` 보완을 통해 빌드 파일 및 로컬 실행 환경 파일이 Git에 포함되지 않도록 수정했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * AWS S3 저장소가 환경별 동적 버킷 대신 고정된 버킷을 사용하도록 변경되었습니다.

* **기타**
  * JAR 파일과 Redis 데이터 등 생성·로컬 환경 파일이 버전 관리 대상에서 제외됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->