### PR TITLE
✨ Feat: 오늘의 질문 답변 공개 마케팅 동의 API 구현

### DIFF
--- a/src/main/java/com/example/egobook_be/domain/question/controller/TodayQuestionController.java
+++ b/src/main/java/com/example/egobook_be/domain/question/controller/TodayQuestionController.java
@@ -30,6 +30,15 @@ public class TodayQuestionController implements TodayQuestionControllerDocs {
         return ResponseEntity.ok(GlobalResponse.success("오늘의 질문 조회 성공", todayQuestionService.getTodayQuestion(userId)));
     }
 
+    @PatchMapping("/marketing-consent")
+    public ResponseEntity<GlobalResponse<Void>> updateMarketingEnabled(
+            @AuthenticationPrincipal(expression = "userAuthDto.userId") Long userId,
+            @RequestParam boolean enabled
+    ) {
+        todayQuestionService.updateMarketingEnabled(userId, enabled);
+        return ResponseEntity.ok(GlobalResponse.success("마케팅 동의 상태 변경 완료", null));
+    }
+
     @PostMapping("/answers")
     public ResponseEntity<GlobalResponse<Void>> createAnswer(
             @AuthenticationPrincipal(expression = "userAuthDto.userId") Long userId,

--- a/src/main/java/com/example/egobook_be/domain/question/controller/TodayQuestionControllerDocs.java
+++ b/src/main/java/com/example/egobook_be/domain/question/controller/TodayQuestionControllerDocs.java
@@ -24,6 +24,20 @@ public interface TodayQuestionControllerDocs {
     );
 
     @Operation(
+            summary = "마케팅 동의 상태 변경",
+            description = """
+                오늘의 질문 답변 공개 마케팅 동의 상태를 변경합니다.
+                
+                - enabled=true: 동의 (프론트에서 팝업 후 호출)
+                - enabled=false: 미동의 (팝업 없이 바로 호출)
+                """
+    )
+    ResponseEntity<GlobalResponse<Void>> updateMarketingEnabled(
+            @AuthenticationPrincipal(expression = "userAuthDto.userId") Long userId,
+            @RequestParam boolean enabled
+    );
+
+    @Operation(
             summary = "오늘의 질문 답변 작성",
             description = """
                 오늘의 질문에 대한 답변을 작성합니다.

--- a/src/main/java/com/example/egobook_be/domain/question/dto/TodayQuestionResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/question/dto/TodayQuestionResDto.java
@@ -4,12 +4,12 @@ import lombok.Builder;
 
 import java.time.LocalDate;
 
-
 @Builder
 public record TodayQuestionResDto(
         Long questionId,
         String content,
         LocalDate date,
         boolean answered,
+        boolean marketingEnabled,
         MyTodayAnswerResDto myAnswer
 ) {}

--- a/src/main/java/com/example/egobook_be/domain/question/service/TodayQuestionService.java
+++ b/src/main/java/com/example/egobook_be/domain/question/service/TodayQuestionService.java
@@ -66,9 +66,14 @@ public class TodayQuestionService {
                 );
 
         boolean answered = false;
+        boolean marketingEnabled = false;
         MyTodayAnswerResDto myAnswer = null;
 
         if (userId != null) {
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+            marketingEnabled = Boolean.TRUE.equals(user.getMarketingEnabled());
+
             Optional<QuestionAnswer> answerOpt =
                     questionAnswerRepository.findByUserIdAndQuestionIdWithQuestion(
                             userId,
@@ -94,6 +99,7 @@ public class TodayQuestionService {
                 .content(question.getContent())
                 .date(question.getQuestionDate())
                 .answered(answered)
+                .marketingEnabled(marketingEnabled)
                 .myAnswer(myAnswer)
                 .build();
     }
@@ -367,5 +373,12 @@ public class TodayQuestionService {
 
         questionAnswerRepository.delete(answer);
         log.info("[TodayQuestionService] deleteAnswer End - userId: {}, answerId: {}", userId, answerId);
+    }
+
+    @Transactional
+    public void updateMarketingEnabled(Long userId, boolean enabled) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+        user.updateMarketingEnabled(enabled);
     }
 }

--- a/src/main/java/com/example/egobook_be/domain/user/entity/User.java
+++ b/src/main/java/com/example/egobook_be/domain/user/entity/User.java
@@ -131,6 +131,14 @@ public class User extends BaseTimeEntity {
     @Builder.Default
     private List<UserItem> userItems = new ArrayList<>();
 
+    @Column(name = "marketing_enabled", nullable = false, columnDefinition = "TINYINT(1) DEFAULT 0")
+    @Builder.Default
+    private Boolean marketingEnabled = false;
+
+    public void updateMarketingEnabled(boolean enabled) {
+        this.marketingEnabled = enabled;
+    }
+
     public void updateProfileImages(String turtleImageUrl, String backgroundImageUrl) {
         this.turtleImageUrl = turtleImageUrl;
         this.backgroundImageUrl = backgroundImageUrl;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- closes #248

## 📝 작업 내용
* User 엔티티 marketingEnabled 필드 추가 (기본값 false)
* PATCH /questions/marketing-consent 동의 상태 변경 엔드포인트 추가
* GET /questions/today 응답에 marketingEnabled 필드 추가

## 🔧 변경 사항
* `User.java` marketingEnabled 필드 및 updateMarketingEnabled() 메서드 추가
* `TodayQuestionResDto.java` marketingEnabled 필드 추가
* `TodayQuestionService.java` getTodayQuestion 마케팅 동의 상태 반환 및 updateMarketingEnabled 메서드 추가
* `TodayQuestionController.java` PATCH /questions/marketing-consent 엔드포인트 추가
* `TodayQuestionControllerDocs.java` 마케팅 동의 상태 변경 API 문서 추가

## ✅ 테스트
> PATCH /questions/marketing-consent 호출 후 GET /questions/today에서 marketingEnabled 상태 변경 확인

<img width="39%" alt="image" src="https://github.com/user-attachments/assets/89601855-6936-4e27-90e1-29bda99d9e9f" />
<br>
<img width="39%" alt="image" src="https://github.com/user-attachments/assets/a5cc1302-8c4c-4804-bd6b-ced808c1e20f" />
<br>
<img width="39%" alt="image" src="https://github.com/user-attachments/assets/73b2a6bb-9309-4abe-91ca-1f26b96fe7d6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 오늘의 질문 답변 공개를 위한 마케팅 동의 여부를 설정할 수 있습니다.
  * 오늘의 질문 화면에서 현재 마케팅 동의 상태를 확인할 수 있습니다.
  * 마케팅 동의 및 철회를 지원합니다.
* **문서**
  * 마케팅 동의 상태 변경 API 문서가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->