### PR TITLE
✨ Feat: 쿠폰 코드 입력 API 구현

### DIFF
--- a/src/main/java/com/example/egobook_be/domain/coupon/controller/CouponController.java
+++ b/src/main/java/com/example/egobook_be/domain/coupon/controller/CouponController.java
@@ -1,0 +1,38 @@
+package com.example.egobook_be.domain.coupon.controller;
+
+import com.example.egobook_be.domain.coupon.dto.CouponUseReqDto;
+import com.example.egobook_be.domain.coupon.dto.CouponUseResDto;
+import com.example.egobook_be.domain.coupon.service.CouponService;
+import com.example.egobook_be.global.response.GlobalResponse;
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class CouponController implements CouponControllerDocs {
+
+    private final CouponService couponService;
+
+    /**
+     * [쿠폰 사용]
+     * POST /coupons/use
+     */
+    @Override
+    public ResponseEntity<GlobalResponse<CouponUseResDto>> useCoupon(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal(expression = "userAuthDto.userId") Long userId,
+
+            @RequestBody @Valid CouponUseReqDto reqDto
+    ) {
+        CouponUseResDto resDto = couponService.useCoupon(userId, reqDto);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(GlobalResponse.success("쿠폰 사용 완료", resDto));
+    }
+}

--- a/src/main/java/com/example/egobook_be/domain/coupon/controller/CouponControllerDocs.java
+++ b/src/main/java/com/example/egobook_be/domain/coupon/controller/CouponControllerDocs.java
@@ -1,0 +1,53 @@
+package com.example.egobook_be.domain.coupon.controller;
+
+import com.example.egobook_be.domain.coupon.dto.CouponUseReqDto;
+import com.example.egobook_be.domain.coupon.dto.CouponUseResDto;
+import com.example.egobook_be.global.response.GlobalResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Tag(name = "Coupon Controller", description = "[쿠폰] 관련 API")
+@RequestMapping("/coupons")
+public interface CouponControllerDocs {
+
+    @Operation(summary = "쿠폰 사용 API", description = """
+            쿠폰 코드를 입력하여 보상(잉크/아이템)을 지급받는 API입니다.
+
+            [**Request Body**]
+            - code : 쿠폰 코드 (공백 불가)
+
+            [**기능**]
+            - 쿠폰 코드의 유효성을 검증하고 보상을 지급합니다.
+            - 보상 목록을 `sortOrder` 순서대로 반환하며, 이 순서대로 팝업을 노출하시면 됩니다.
+            - 아이템을 이미 보유 중인 경우 중복 지급은 하지 않지만, 보상 목록에는 포함하여 팝업은 정상 노출되도록 해주세요.
+
+            [**주의사항**]
+            - 만료된 쿠폰, 이미 사용한 쿠폰, 본인 대상이 아닌 쿠폰, 20자를 넘긴 것들은 오류를 반환합니다.
+            """)
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "쿠폰 사용에 성공했습니다.",
+                    content = @Content(schema = @Schema(implementation = CouponUseResDto.class))),
+            @ApiResponse(responseCode = "400", description = "만료된 쿠폰이거나 이미 사용한 쿠폰입니다.", content = @Content),
+            @ApiResponse(responseCode = "401", description = "로그인이 필요합니다.", content = @Content),
+            @ApiResponse(responseCode = "403", description = "해당 쿠폰을 사용할 수 없습니다.", content = @Content),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 쿠폰 코드입니다.", content = @Content)
+    })
+    @PostMapping("/use")
+    ResponseEntity<GlobalResponse<CouponUseResDto>> useCoupon(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal(expression = "userAuthDto.userId") Long userId,
+
+            @RequestBody @Valid CouponUseReqDto reqDto
+    );
+}

--- a/src/main/java/com/example/egobook_be/domain/coupon/dto/CouponRewardResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/coupon/dto/CouponRewardResDto.java
@@ -1,0 +1,13 @@
+package com.example.egobook_be.domain.coupon.dto;
+
+import com.example.egobook_be.domain.coupon.enums.CouponRewardType;
+import lombok.Builder;
+
+@Builder
+public record CouponRewardResDto(
+        CouponRewardType rewardType,
+        Integer inkAmount,
+        Long itemId,
+        String itemName,
+        String itemImageUrl
+) {}

--- a/src/main/java/com/example/egobook_be/domain/coupon/dto/CouponUseReqDto.java
+++ b/src/main/java/com/example/egobook_be/domain/coupon/dto/CouponUseReqDto.java
@@ -1,0 +1,10 @@
+package com.example.egobook_be.domain.coupon.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CouponUseReqDto(
+        @NotBlank(message = "쿠폰 코드를 입력해주세요")
+        @Size(max = 20, message = "쿠폰 코드는 20자 이하여야 합니다")
+        String code
+) {}

--- a/src/main/java/com/example/egobook_be/domain/coupon/dto/CouponUseResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/coupon/dto/CouponUseResDto.java
@@ -1,0 +1,10 @@
+package com.example.egobook_be.domain.coupon.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record CouponUseResDto(
+        List<CouponRewardResDto> rewards
+) {}

--- a/src/main/java/com/example/egobook_be/domain/coupon/entity/Coupon.java
+++ b/src/main/java/com/example/egobook_be/domain/coupon/entity/Coupon.java
@@ -1,0 +1,40 @@
+package com.example.egobook_be.domain.coupon.entity;
+
+import com.example.egobook_be.domain.coupon.enums.CouponTargetType;
+import com.example.egobook_be.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "coupon")
+public class Coupon extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 100)
+    private String code;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "target_type", nullable = false, length = 20)
+    private CouponTargetType targetType;
+
+    @Column(name = "target_account_code", length = 12)
+    private String targetAccountCode;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @OneToMany(mappedBy = "coupon", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<CouponReward> rewards = new ArrayList<>();
+}

--- a/src/main/java/com/example/egobook_be/domain/coupon/entity/CouponReward.java
+++ b/src/main/java/com/example/egobook_be/domain/coupon/entity/CouponReward.java
@@ -1,0 +1,35 @@
+package com.example.egobook_be.domain.coupon.entity;
+
+import com.example.egobook_be.domain.coupon.enums.CouponRewardType;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "coupon_reward")
+public class CouponReward {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "coupon_id", nullable = false)
+    private Coupon coupon;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "reward_type", nullable = false, length = 20)
+    private CouponRewardType rewardType;
+
+    @Column(name = "ink_amount")
+    private Integer inkAmount;
+
+    @Column(name = "item_id")
+    private Long itemId;
+
+    @Column(name = "sort_order", nullable = false)
+    private Integer sortOrder;
+}

--- a/src/main/java/com/example/egobook_be/domain/coupon/entity/UserCoupon.java
+++ b/src/main/java/com/example/egobook_be/domain/coupon/entity/UserCoupon.java
@@ -1,0 +1,41 @@
+package com.example.egobook_be.domain.coupon.entity;
+
+import com.example.egobook_be.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "user_coupon",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_user_coupon",
+                        columnNames = {"user_id", "coupon_id"})
+        }
+)
+public class UserCoupon {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "coupon_id", nullable = false)
+    private Coupon coupon;
+
+    @CreatedDate
+    @Column(name = "used_at", nullable = false, updatable = false)
+    private LocalDateTime usedAt;
+}

--- a/src/main/java/com/example/egobook_be/domain/coupon/enums/CouponRewardType.java
+++ b/src/main/java/com/example/egobook_be/domain/coupon/enums/CouponRewardType.java
@@ -1,0 +1,6 @@
+package com.example.egobook_be.domain.coupon.enums;
+
+public enum CouponRewardType {
+    INK,
+    ITEM
+}

--- a/src/main/java/com/example/egobook_be/domain/coupon/enums/CouponTargetType.java
+++ b/src/main/java/com/example/egobook_be/domain/coupon/enums/CouponTargetType.java
@@ -1,0 +1,6 @@
+package com.example.egobook_be.domain.coupon.enums;
+
+public enum CouponTargetType {
+    ALL,
+    INDIVIDUAL
+}

--- a/src/main/java/com/example/egobook_be/domain/coupon/exception/CouponErrorCode.java
+++ b/src/main/java/com/example/egobook_be/domain/coupon/exception/CouponErrorCode.java
@@ -1,0 +1,24 @@
+package com.example.egobook_be.domain.coupon.exception;
+
+import com.example.egobook_be.global.exception.model.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CouponErrorCode implements BaseErrorCode {
+
+    COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 코드입니다"),
+    COUPON_EXPIRED(HttpStatus.BAD_REQUEST, "만료된 쿠폰입니다"),
+    COUPON_ALREADY_USED(HttpStatus.BAD_REQUEST, "이미 사용한 쿠폰입니다"),
+    COUPON_NOT_FOR_USER(HttpStatus.FORBIDDEN, "해당 쿠폰을 사용할 수 없습니다");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public HttpStatus getStatus() {
+        return this.httpStatus;
+    }
+}

--- a/src/main/java/com/example/egobook_be/domain/coupon/repository/CouponRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/coupon/repository/CouponRepository.java
@@ -1,0 +1,17 @@
+package com.example.egobook_be.domain.coupon.repository;
+
+import com.example.egobook_be.domain.coupon.entity.Coupon;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface CouponRepository extends JpaRepository<Coupon, Long> {
+
+    /**
+     * 쿠폰 코드로 쿠폰 조회 (보상 목록 fetch join)
+     */
+    @Query("select c from Coupon c left join fetch c.rewards r where c.code = :code order by r.sortOrder asc")
+    Optional<Coupon> findByCodeWithRewards(@Param("code") String code);
+}

--- a/src/main/java/com/example/egobook_be/domain/coupon/repository/UserCouponRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/coupon/repository/UserCouponRepository.java
@@ -1,0 +1,12 @@
+package com.example.egobook_be.domain.coupon.repository;
+
+import com.example.egobook_be.domain.coupon.entity.UserCoupon;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserCouponRepository extends JpaRepository<UserCoupon, Long> {
+
+    /**
+     * 해당 유저가 해당 쿠폰을 이미 사용했는지 확인
+     */
+    boolean existsByUserIdAndCouponId(Long userId, Long couponId);
+}

--- a/src/main/java/com/example/egobook_be/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/example/egobook_be/domain/coupon/service/CouponService.java
@@ -1,0 +1,132 @@
+package com.example.egobook_be.domain.coupon.service;
+
+import com.example.egobook_be.domain.coupon.dto.CouponRewardResDto;
+import com.example.egobook_be.domain.coupon.dto.CouponUseReqDto;
+import com.example.egobook_be.domain.coupon.dto.CouponUseResDto;
+import com.example.egobook_be.domain.coupon.entity.Coupon;
+import com.example.egobook_be.domain.coupon.entity.CouponReward;
+import com.example.egobook_be.domain.coupon.entity.UserCoupon;
+import com.example.egobook_be.domain.coupon.enums.CouponRewardType;
+import com.example.egobook_be.domain.coupon.enums.CouponTargetType;
+import com.example.egobook_be.domain.coupon.exception.CouponErrorCode;
+import com.example.egobook_be.domain.coupon.repository.CouponRepository;
+import com.example.egobook_be.domain.coupon.repository.UserCouponRepository;
+import com.example.egobook_be.domain.shop.entity.Item;
+import com.example.egobook_be.domain.shop.entity.UserItem;
+import com.example.egobook_be.domain.shop.repository.ItemRepository;
+import com.example.egobook_be.domain.shop.repository.UserItemRepository;
+import com.example.egobook_be.domain.user.entity.InkLog;
+import com.example.egobook_be.domain.user.entity.InkLogType;
+import com.example.egobook_be.domain.user.entity.User;
+import com.example.egobook_be.domain.user.exception.UserErrorCode;
+import com.example.egobook_be.domain.user.repository.InkLogRepository;
+import com.example.egobook_be.domain.user.repository.UserRepository;
+import com.example.egobook_be.global.exception.CustomException;
+import com.example.egobook_be.global.util.InkLogUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CouponService {
+
+    private final CouponRepository couponRepository;
+    private final UserCouponRepository userCouponRepository;
+    private final UserRepository userRepository;
+    private final ItemRepository itemRepository;
+    private final UserItemRepository userItemRepository;
+    private final InkLogRepository inkLogRepository;
+    private final InkLogUtil inkLogUtil;
+
+    @Value("${spring.cloud.aws.cloudfront.domain}")
+    private String cloudfrontDomain;
+
+    /**
+     * 쿠폰 코드를 입력하여 보상을 지급하는 함수
+     * - 코드 유효성(존재, 만료, 대상, 중복 사용) 검증 후 보상 순서대로 지급
+     * - 잉크: 즉시 지급 및 InkLog 기록
+     * - 아이템: 이미 보유 시 팝업은 노출하되 중복 지급하지 않음
+     * @param userId  현재 로그인한 유저 ID
+     * @param reqDto  쿠폰 코드
+     * @return 지급된 보상 목록 (순서 보장)
+     */
+    @Transactional
+    public CouponUseResDto useCoupon(Long userId, CouponUseReqDto reqDto) {
+        log.info("[CouponService] useCoupon() - START | userId: {}, code: {}", userId, reqDto.code());
+
+        // 1. 유저 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+
+        // 2. 쿠폰 조회 (보상 목록 fetch join)
+        Coupon coupon = couponRepository.findByCodeWithRewards(reqDto.code())
+                .orElseThrow(() -> new CustomException(CouponErrorCode.COUPON_NOT_FOUND));
+
+        // 3. 만료 여부 확인
+        if (LocalDateTime.now().isAfter(coupon.getExpiresAt())) {
+            throw new CustomException(CouponErrorCode.COUPON_EXPIRED);
+        }
+
+        // 4. 개인 쿠폰인 경우 대상 유저 확인
+        if (coupon.getTargetType() == CouponTargetType.INDIVIDUAL) {
+            if (!user.getAccountCode().equals(coupon.getTargetAccountCode())) {
+                throw new CustomException(CouponErrorCode.COUPON_NOT_FOR_USER);
+            }
+        }
+
+        // 5. 이미 사용한 쿠폰인지 확인
+        if (userCouponRepository.existsByUserIdAndCouponId(userId, coupon.getId())) {
+            throw new CustomException(CouponErrorCode.COUPON_ALREADY_USED);
+        }
+
+        // 6. 보상 지급
+        List<InkLog> inkLogs = new ArrayList<>();
+        List<CouponRewardResDto> rewardResults = new ArrayList<>();
+
+        for (CouponReward reward : coupon.getRewards()) {
+            if (reward.getRewardType() == CouponRewardType.INK) {
+                inkLogUtil.addInkLogToList(inkLogs, user, reward.getInkAmount(), InkLogType.COUPON);
+                rewardResults.add(CouponRewardResDto.builder()
+                        .rewardType(CouponRewardType.INK)
+                        .inkAmount(reward.getInkAmount())
+                        .build());
+
+            } else if (reward.getRewardType() == CouponRewardType.ITEM) {
+                Item item = itemRepository.findById(reward.getItemId())
+                        .orElseThrow(() -> new CustomException(CouponErrorCode.COUPON_NOT_FOUND));
+
+                if (!userItemRepository.existsByUserIdAndItemId(userId, item.getId())) {
+                    userItemRepository.save(UserItem.create(user, item));
+                }
+
+                rewardResults.add(CouponRewardResDto.builder()
+                        .rewardType(CouponRewardType.ITEM)
+                        .itemId(item.getId())
+                        .itemName(item.getName())
+                        .itemImageUrl(item.getFullUrl(cloudfrontDomain))
+                        .build());
+            }
+        }
+
+        inkLogRepository.saveAll(inkLogs);
+
+        // 7. 사용 기록 저장
+        userCouponRepository.save(UserCoupon.builder()
+                .user(user)
+                .coupon(coupon)
+                .build());
+
+        log.info("[CouponService] useCoupon() - END | userId: {}, rewardCount: {}", userId, rewardResults.size());
+        return CouponUseResDto.builder()
+                .rewards(rewardResults)
+                .build();
+    }
+}

--- a/src/main/java/com/example/egobook_be/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/example/egobook_be/domain/coupon/service/CouponService.java
@@ -13,6 +13,7 @@ import com.example.egobook_be.domain.coupon.repository.CouponRepository;
 import com.example.egobook_be.domain.coupon.repository.UserCouponRepository;
 import com.example.egobook_be.domain.shop.entity.Item;
 import com.example.egobook_be.domain.shop.entity.UserItem;
+import com.example.egobook_be.domain.shop.exception.ShopErrorCode;
 import com.example.egobook_be.domain.shop.repository.ItemRepository;
 import com.example.egobook_be.domain.shop.repository.UserItemRepository;
 import com.example.egobook_be.domain.user.entity.InkLog;
@@ -26,6 +27,7 @@ import com.example.egobook_be.global.util.InkLogUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -101,7 +103,7 @@ public class CouponService {
 
             } else if (reward.getRewardType() == CouponRewardType.ITEM) {
                 Item item = itemRepository.findById(reward.getItemId())
-                        .orElseThrow(() -> new CustomException(CouponErrorCode.COUPON_NOT_FOUND));
+                        .orElseThrow(() -> new CustomException(ShopErrorCode.ITEM_NOT_FOUND));
 
                 if (!userItemRepository.existsByUserIdAndItemId(userId, item.getId())) {
                     userItemRepository.save(UserItem.create(user, item));
@@ -118,11 +120,15 @@ public class CouponService {
 
         inkLogRepository.saveAll(inkLogs);
 
-        // 7. 사용 기록 저장
-        userCouponRepository.save(UserCoupon.builder()
-                .user(user)
-                .coupon(coupon)
-                .build());
+        // 7. 사용 기록 저장 (유니크 제약 위반 시 동시 중복 요청으로 처리)
+        try {
+            userCouponRepository.saveAndFlush(UserCoupon.builder()
+                    .user(user)
+                    .coupon(coupon)
+                    .build());
+        } catch (DataIntegrityViolationException e) {
+            throw new CustomException(CouponErrorCode.COUPON_ALREADY_USED);
+        }
 
         log.info("[CouponService] useCoupon() - END | userId: {}, rewardCount: {}", userId, rewardResults.size());
         return CouponUseResDto.builder()

--- a/src/main/java/com/example/egobook_be/domain/user/entity/InkLogType.java
+++ b/src/main/java/com/example/egobook_be/domain/user/entity/InkLogType.java
@@ -15,5 +15,6 @@ public enum InkLogType {
     LETTER_COLOR_PURCHASE,
     // 능력치 보상 확인을 위한 기록
     FIRST_CONCERN_DIARY,
-    FIRST_POSITIVE_DIARY
+    FIRST_POSITIVE_DIARY,
+    COUPON
 }

--- a/src/test/java/com/example/egobook_be/domain/coupon/service/CouponServiceUnitTest.java
+++ b/src/test/java/com/example/egobook_be/domain/coupon/service/CouponServiceUnitTest.java
@@ -1,0 +1,340 @@
+package com.example.egobook_be.domain.coupon.service;
+
+import com.example.egobook_be.domain.coupon.dto.CouponUseReqDto;
+import com.example.egobook_be.domain.coupon.dto.CouponUseResDto;
+import com.example.egobook_be.domain.coupon.entity.Coupon;
+import com.example.egobook_be.domain.coupon.entity.CouponReward;
+import com.example.egobook_be.domain.coupon.entity.UserCoupon;
+import com.example.egobook_be.domain.coupon.enums.CouponRewardType;
+import com.example.egobook_be.domain.coupon.enums.CouponTargetType;
+import com.example.egobook_be.domain.coupon.exception.CouponErrorCode;
+import com.example.egobook_be.domain.coupon.repository.CouponRepository;
+import com.example.egobook_be.domain.coupon.repository.UserCouponRepository;
+import com.example.egobook_be.domain.shop.entity.Item;
+import com.example.egobook_be.domain.shop.entity.UserItem;
+import com.example.egobook_be.domain.shop.repository.ItemRepository;
+import com.example.egobook_be.domain.shop.repository.UserItemRepository;
+import com.example.egobook_be.domain.user.entity.User;
+import com.example.egobook_be.domain.user.exception.UserErrorCode;
+import com.example.egobook_be.domain.user.repository.InkLogRepository;
+import com.example.egobook_be.domain.user.repository.UserRepository;
+import com.example.egobook_be.global.exception.CustomException;
+import com.example.egobook_be.global.util.InkLogUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class CouponServiceUnitTest {
+
+    @InjectMocks private CouponService couponService;
+    @Mock private CouponRepository couponRepository;
+    @Mock private UserCouponRepository userCouponRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private ItemRepository itemRepository;
+    @Mock private UserItemRepository userItemRepository;
+    @Mock private InkLogRepository inkLogRepository;
+    @Mock private InkLogUtil inkLogUtil;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(couponService, "cloudfrontDomain", "https://test.cloudfront.net");
+    }
+
+    // ── 픽스처 ────────────────────────────────────────────────────────────────
+
+    private Coupon buildCoupon(CouponTargetType targetType, String targetAccountCode,
+                               LocalDateTime expiresAt, List<CouponReward> rewards) {
+        return Coupon.builder()
+                .targetType(targetType)
+                .targetAccountCode(targetAccountCode)
+                .expiresAt(expiresAt)
+                .rewards(rewards)
+                .build();
+    }
+
+    private CouponReward inkReward(int amount) {
+        return CouponReward.builder()
+                .rewardType(CouponRewardType.INK)
+                .inkAmount(amount)
+                .sortOrder(1)
+                .build();
+    }
+
+    private CouponReward itemReward(Long itemId) {
+        return CouponReward.builder()
+                .rewardType(CouponRewardType.ITEM)
+                .itemId(itemId)
+                .sortOrder(2)
+                .build();
+    }
+
+    // ── 성공 케이스 ───────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("useCoupon() 성공 케이스")
+    class SuccessCases {
+
+        @Test
+        @DisplayName("[성공 1] 잉크 보상 쿠폰 사용")
+        void success_inkReward() {
+            // ========= Given =========
+            Long userId = 1L;
+            User mockUser = mock(User.class);
+            Coupon coupon = buildCoupon(CouponTargetType.ALL, null,
+                    LocalDateTime.now().plusDays(7), List.of(inkReward(100)));
+
+            given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
+            given(couponRepository.findByCodeWithRewards("TEST-CODE")).willReturn(Optional.of(coupon));
+            given(userCouponRepository.existsByUserIdAndCouponId(userId, coupon.getId())).willReturn(false);
+
+            // ========= When =========
+            CouponUseResDto result = couponService.useCoupon(userId, new CouponUseReqDto("TEST-CODE"));
+
+            // ========= Then =========
+            assertThat(result.rewards()).hasSize(1);
+            assertThat(result.rewards().get(0).rewardType()).isEqualTo(CouponRewardType.INK);
+            assertThat(result.rewards().get(0).inkAmount()).isEqualTo(100);
+            verify(inkLogUtil, times(1)).addInkLogToList(any(), eq(mockUser), eq(100), any());
+            verify(inkLogRepository, times(1)).saveAll(any());
+            verify(userCouponRepository, times(1)).save(any(UserCoupon.class));
+        }
+
+        @Test
+        @DisplayName("[성공 2] 아이템 보상 쿠폰 사용 - 신규 아이템")
+        void success_newItemReward() {
+            // ========= Given =========
+            Long userId = 1L;
+            Long itemId = 10L;
+            User mockUser = mock(User.class);
+            Item mockItem = mock(Item.class);
+
+            given(mockItem.getId()).willReturn(itemId);
+            given(mockItem.getName()).willReturn("거북이 스킨");
+            given(mockItem.getFullUrl("https://test.cloudfront.net")).willReturn("https://test.cloudfront.net/items/skin.png");
+
+            Coupon coupon = buildCoupon(CouponTargetType.ALL, null,
+                    LocalDateTime.now().plusDays(7), List.of(itemReward(itemId)));
+
+            given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
+            given(couponRepository.findByCodeWithRewards("TEST-CODE")).willReturn(Optional.of(coupon));
+            given(userCouponRepository.existsByUserIdAndCouponId(userId, coupon.getId())).willReturn(false);
+            given(itemRepository.findById(itemId)).willReturn(Optional.of(mockItem));
+            given(userItemRepository.existsByUserIdAndItemId(userId, itemId)).willReturn(false);
+
+            // ========= When =========
+            CouponUseResDto result = couponService.useCoupon(userId, new CouponUseReqDto("TEST-CODE"));
+
+            // ========= Then =========
+            assertThat(result.rewards()).hasSize(1);
+            assertThat(result.rewards().get(0).rewardType()).isEqualTo(CouponRewardType.ITEM);
+            assertThat(result.rewards().get(0).itemName()).isEqualTo("거북이 스킨");
+            verify(userItemRepository, times(1)).save(any(UserItem.class));
+        }
+
+        @Test
+        @DisplayName("[성공 3] 아이템 보상 쿠폰 - 이미 보유 시 팝업은 노출, DB 저장 생략")
+        void success_duplicateItem_popupShownNotSaved() {
+            // ========= Given =========
+            Long userId = 1L;
+            Long itemId = 10L;
+            User mockUser = mock(User.class);
+            Item mockItem = mock(Item.class);
+
+            given(mockItem.getId()).willReturn(itemId);
+            given(mockItem.getName()).willReturn("거북이 스킨");
+            given(mockItem.getFullUrl("https://test.cloudfront.net")).willReturn("https://test.cloudfront.net/items/skin.png");
+
+            Coupon coupon = buildCoupon(CouponTargetType.ALL, null,
+                    LocalDateTime.now().plusDays(7), List.of(itemReward(itemId)));
+
+            given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
+            given(couponRepository.findByCodeWithRewards("TEST-CODE")).willReturn(Optional.of(coupon));
+            given(userCouponRepository.existsByUserIdAndCouponId(userId, coupon.getId())).willReturn(false);
+            given(itemRepository.findById(itemId)).willReturn(Optional.of(mockItem));
+            given(userItemRepository.existsByUserIdAndItemId(userId, itemId)).willReturn(true); // 이미 보유
+
+            // ========= When =========
+            CouponUseResDto result = couponService.useCoupon(userId, new CouponUseReqDto("TEST-CODE"));
+
+            // ========= Then =========
+            assertThat(result.rewards()).hasSize(1); // 팝업 응답 포함
+            assertThat(result.rewards().get(0).itemName()).isEqualTo("거북이 스킨");
+            verify(userItemRepository, never()).save(any()); // DB 저장 생략
+        }
+
+        @Test
+        @DisplayName("[성공 4] 혼합 보상 쿠폰 (잉크 + 아이템) - sortOrder 순서대로 반환")
+        void success_mixedRewards() {
+            // ========= Given =========
+            Long userId = 1L;
+            Long itemId = 10L;
+            User mockUser = mock(User.class);
+            Item mockItem = mock(Item.class);
+
+            given(mockItem.getId()).willReturn(itemId);
+            given(mockItem.getName()).willReturn("배경 아이템");
+            given(mockItem.getFullUrl("https://test.cloudfront.net")).willReturn("https://test.cloudfront.net/items/bg.png");
+
+            Coupon coupon = buildCoupon(CouponTargetType.ALL, null,
+                    LocalDateTime.now().plusDays(7),
+                    List.of(inkReward(50), itemReward(itemId)));
+
+            given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
+            given(couponRepository.findByCodeWithRewards("TEST-CODE")).willReturn(Optional.of(coupon));
+            given(userCouponRepository.existsByUserIdAndCouponId(userId, coupon.getId())).willReturn(false);
+            given(itemRepository.findById(itemId)).willReturn(Optional.of(mockItem));
+            given(userItemRepository.existsByUserIdAndItemId(userId, itemId)).willReturn(false);
+
+            // ========= When =========
+            CouponUseResDto result = couponService.useCoupon(userId, new CouponUseReqDto("TEST-CODE"));
+
+            // ========= Then =========
+            assertThat(result.rewards()).hasSize(2);
+            assertThat(result.rewards().get(0).rewardType()).isEqualTo(CouponRewardType.INK);
+            assertThat(result.rewards().get(1).rewardType()).isEqualTo(CouponRewardType.ITEM);
+            verify(inkLogUtil, times(1)).addInkLogToList(any(), eq(mockUser), eq(50), any());
+            verify(userItemRepository, times(1)).save(any(UserItem.class));
+        }
+
+        @Test
+        @DisplayName("[성공 5] INDIVIDUAL 타입 쿠폰 - 대상 유저 본인이 사용")
+        void success_individualCoupon() {
+            // ========= Given =========
+            Long userId = 1L;
+            User mockUser = mock(User.class);
+            given(mockUser.getAccountCode()).willReturn("USER01");
+
+            Coupon coupon = buildCoupon(CouponTargetType.INDIVIDUAL, "USER01",
+                    LocalDateTime.now().plusDays(7), List.of(inkReward(200)));
+
+            given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
+            given(couponRepository.findByCodeWithRewards("PRIVATE-CODE")).willReturn(Optional.of(coupon));
+            given(userCouponRepository.existsByUserIdAndCouponId(userId, coupon.getId())).willReturn(false);
+
+            // ========= When =========
+            CouponUseResDto result = couponService.useCoupon(userId, new CouponUseReqDto("PRIVATE-CODE"));
+
+            // ========= Then =========
+            assertThat(result.rewards()).hasSize(1);
+            assertThat(result.rewards().get(0).inkAmount()).isEqualTo(200);
+        }
+    }
+
+    // ── 실패 케이스 ───────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("useCoupon() 실패 케이스")
+    class FailCases {
+
+        @Test
+        @DisplayName("[실패 1] 유저를 찾을 수 없음")
+        void fail_userNotFound() {
+            // ========= Given =========
+            Long userId = 999L;
+            given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+            // ========= When & Then =========
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> couponService.useCoupon(userId, new CouponUseReqDto("ANY")));
+
+            assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
+            verify(couponRepository, never()).findByCodeWithRewards(any());
+        }
+
+        @Test
+        @DisplayName("[실패 2] 존재하지 않는 쿠폰 코드")
+        void fail_couponNotFound() {
+            // ========= Given =========
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(mock(User.class)));
+            given(couponRepository.findByCodeWithRewards("INVALID")).willReturn(Optional.empty());
+
+            // ========= When & Then =========
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> couponService.useCoupon(userId, new CouponUseReqDto("INVALID")));
+
+            assertThat(exception.getErrorCode()).isEqualTo(CouponErrorCode.COUPON_NOT_FOUND);
+            verify(userCouponRepository, never()).existsByUserIdAndCouponId(any(), any());
+        }
+
+        @Test
+        @DisplayName("[실패 3] 만료된 쿠폰")
+        void fail_couponExpired() {
+            // ========= Given =========
+            Long userId = 1L;
+            Coupon expiredCoupon = buildCoupon(CouponTargetType.ALL, null,
+                    LocalDateTime.now().minusDays(1), List.of(inkReward(100)));
+
+            given(userRepository.findById(userId)).willReturn(Optional.of(mock(User.class)));
+            given(couponRepository.findByCodeWithRewards("EXPIRED")).willReturn(Optional.of(expiredCoupon));
+
+            // ========= When & Then =========
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> couponService.useCoupon(userId, new CouponUseReqDto("EXPIRED")));
+
+            assertThat(exception.getErrorCode()).isEqualTo(CouponErrorCode.COUPON_EXPIRED);
+            verify(userCouponRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("[실패 4] INDIVIDUAL 쿠폰 - 대상이 아닌 유저 사용 시도")
+        void fail_couponNotForUser() {
+            // ========= Given =========
+            Long userId = 1L;
+            User mockUser = mock(User.class);
+            given(mockUser.getAccountCode()).willReturn("USER01");
+
+            Coupon individualCoupon = buildCoupon(CouponTargetType.INDIVIDUAL, "OTHER99",
+                    LocalDateTime.now().plusDays(7), List.of(inkReward(100)));
+
+            given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
+            given(couponRepository.findByCodeWithRewards("PRIVATE")).willReturn(Optional.of(individualCoupon));
+
+            // ========= When & Then =========
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> couponService.useCoupon(userId, new CouponUseReqDto("PRIVATE")));
+
+            assertThat(exception.getErrorCode()).isEqualTo(CouponErrorCode.COUPON_NOT_FOR_USER);
+            verify(userCouponRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("[실패 5] 이미 사용한 쿠폰")
+        void fail_couponAlreadyUsed() {
+            // ========= Given =========
+            Long userId = 1L;
+            Coupon coupon = buildCoupon(CouponTargetType.ALL, null,
+                    LocalDateTime.now().plusDays(7), List.of(inkReward(100)));
+
+            given(userRepository.findById(userId)).willReturn(Optional.of(mock(User.class)));
+            given(couponRepository.findByCodeWithRewards("USED-CODE")).willReturn(Optional.of(coupon));
+            given(userCouponRepository.existsByUserIdAndCouponId(userId, coupon.getId())).willReturn(true);
+
+            // ========= When & Then =========
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> couponService.useCoupon(userId, new CouponUseReqDto("USED-CODE")));
+
+            assertThat(exception.getErrorCode()).isEqualTo(CouponErrorCode.COUPON_ALREADY_USED);
+            verify(inkLogRepository, never()).saveAll(any());
+            verify(userCouponRepository, never()).save(any());
+        }
+    }
+}

--- a/src/test/java/com/example/egobook_be/domain/coupon/service/CouponServiceUnitTest.java
+++ b/src/test/java/com/example/egobook_be/domain/coupon/service/CouponServiceUnitTest.java
@@ -114,7 +114,7 @@ public class CouponServiceUnitTest {
             assertThat(result.rewards().get(0).inkAmount()).isEqualTo(100);
             verify(inkLogUtil, times(1)).addInkLogToList(any(), eq(mockUser), eq(100), any());
             verify(inkLogRepository, times(1)).saveAll(any());
-            verify(userCouponRepository, times(1)).save(any(UserCoupon.class));
+            verify(userCouponRepository, times(1)).saveAndFlush(any(UserCoupon.class));
         }
 
         @Test
@@ -291,7 +291,7 @@ public class CouponServiceUnitTest {
                     () -> couponService.useCoupon(userId, new CouponUseReqDto("EXPIRED")));
 
             assertThat(exception.getErrorCode()).isEqualTo(CouponErrorCode.COUPON_EXPIRED);
-            verify(userCouponRepository, never()).save(any());
+            verify(userCouponRepository, never()).saveAndFlush(any());
         }
 
         @Test
@@ -313,7 +313,7 @@ public class CouponServiceUnitTest {
                     () -> couponService.useCoupon(userId, new CouponUseReqDto("PRIVATE")));
 
             assertThat(exception.getErrorCode()).isEqualTo(CouponErrorCode.COUPON_NOT_FOR_USER);
-            verify(userCouponRepository, never()).save(any());
+            verify(userCouponRepository, never()).saveAndFlush(any());
         }
 
         @Test
@@ -334,7 +334,7 @@ public class CouponServiceUnitTest {
 
             assertThat(exception.getErrorCode()).isEqualTo(CouponErrorCode.COUPON_ALREADY_USED);
             verify(inkLogRepository, never()).saveAll(any());
-            verify(userCouponRepository, never()).save(any());
+            verify(userCouponRepository, never()).saveAndFlush(any());
         }
     }
 }

--- a/src/test/java/com/example/egobook_be/domain/user/service/AdminUserServiceUnitTest.java
+++ b/src/test/java/com/example/egobook_be/domain/user/service/AdminUserServiceUnitTest.java
@@ -82,7 +82,7 @@ public class AdminUserServiceUnitTest {
             Integer page = 2;
             Integer size = 7;
 
-            SearchUserResDto mockDto = new SearchUserResDto(1L, "CODE123", "test@example.com", "닉네임", UserStatus.ACTIVE);
+            SearchUserResDto mockDto = new SearchUserResDto(1L, "CODE123", "test@example.com", "닉네임", UserStatus.ACTIVE, null, null);
             Slice<SearchUserResDto> mockSlice = new SliceImpl<>(List.of(mockDto));
 
             given(userRepository.findUsersByKeywordAndStatus(eq(keyword), eq(status), any(Pageable.class)))


### PR DESCRIPTION
## #️⃣연관된 이슈
- #250 

## 📝작업 내용
- 쿠폰 코드 입력 시 보상(잉크/아이템)을 지급하는 API 구현
- 쿠폰 유효성 검증 (존재 여부, 만료, 개인 대상 확인, 중복 사용)
- 아이템 중복 보유 시 DB 저장 생략, 팝업 응답에는 포함
- 쿠폰 코드 최대 20자 제한

### 작업 API
  | Method | URI | 설명 |
  |--------|-----|------|
  | POST | /coupons/use | 쿠폰 사용 |

### 스크린샷 (선택)
[![kupon-sayong.jpg](https://i.postimg.cc/k4mzPctp/kupon-sayong.jpg)](https://postimg.cc/06Vcp7nY)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 쿠폰 코드를 입력해 쿠폰을 사용할 수 있습니다.
  * 잉크 및 아이템 보상을 확인할 수 있습니다.
  * 전체 대상 및 개인 대상 쿠폰을 지원합니다.
  * 만료, 권한 불일치, 중복 사용 등 쿠폰 상태를 검증합니다.
  * 이미 보유한 아이템은 중복 지급되지 않습니다.

* **테스트**
  * 쿠폰 사용 성공 및 주요 예외 상황에 대한 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->