### PR TITLE
🐛 Fix: 편지 횟수 차감 버그와 탈퇴 사유 기타 null 허용 버그

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,3 @@
+[github_app]
+pr_commands = []
+handle_push_trigger = false

--- a/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterRepository.java
@@ -82,7 +82,7 @@ public interface PlazaLetterRepository extends JpaRepository<PlazaLetter, Long> 
         select l
         from PlazaLetter l
         where l.createdAt <= :cutoff
-          and l.status not in (:replied, :aiReplied)
+          and l.status not in (:replied, :aiReplied, :cancelled)
           and not exists (
               select 1
               from PlazaLetterReply r
@@ -94,6 +94,7 @@ public interface PlazaLetterRepository extends JpaRepository<PlazaLetter, Long> 
             @Param("cutoff") LocalDateTime cutoff,
             @Param("replied") PlazaLetterStatus replied,
             @Param("aiReplied") PlazaLetterStatus aiReplied,
+            @Param("cancelled") PlazaLetterStatus cancelled,
             Pageable pageable
     );
 

--- a/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/repository/PlazaLetterRepository.java
@@ -18,7 +18,7 @@ public interface PlazaLetterRepository extends JpaRepository<PlazaLetter, Long> 
 
     Integer countBySenderId(Long senderId);
 
-    boolean existsBySenderIdAndCreatedAtBetween(Long senderId, LocalDateTime start, LocalDateTime end);
+    boolean existsBySenderIdAndStatusNotAndCreatedAtBetween(Long senderId, PlazaLetterStatus status, LocalDateTime start, LocalDateTime end);
 
     Optional<PlazaLetter> findByThreadId(Long threadId);
 

--- a/src/main/java/com/example/egobook_be/domain/letters/service/PlazaLetterService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/PlazaLetterService.java
@@ -351,7 +351,7 @@ public class PlazaLetterService {
         LocalDateTime start = today.atStartOfDay(ASIA_SEOUL_ZONE_ID).toLocalDateTime();
         LocalDateTime end = today.plusDays(1).atStartOfDay(ASIA_SEOUL_ZONE_ID).toLocalDateTime();
 
-        if (plazaLetterRepository.existsBySenderIdAndCreatedAtBetween(userId, start, end)) {
+        if (plazaLetterRepository.existsBySenderIdAndStatusNotAndCreatedAtBetween(userId, PlazaLetterStatus.CANCELLED, start, end)) {
             throw new CustomException(LettersErrorCode.DAILY_LETTER_LIMIT);
         }
     }

--- a/src/main/java/com/example/egobook_be/domain/letters/service/ai/PlazaLetterAiReplyService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/ai/PlazaLetterAiReplyService.java
@@ -40,6 +40,7 @@ public class PlazaLetterAiReplyService {
                 cutoff,
                 PlazaLetterStatus.REPLIED,
                 PlazaLetterStatus.AI_REPLIED,
+                PlazaLetterStatus.CANCELLED,
                 PageRequest.of(0, batchSize)
         );
 

--- a/src/main/java/com/example/egobook_be/domain/letters/service/ai/PlazaLetterAiReplyService.java
+++ b/src/main/java/com/example/egobook_be/domain/letters/service/ai/PlazaLetterAiReplyService.java
@@ -57,8 +57,10 @@ public class PlazaLetterAiReplyService {
         PlazaLetter letter = plazaLetterRepository.findById(letterId).orElse(null);
         if (letter == null) return false;
 
-        // 상태가 이미 REPLIED 또는 AI_REPLIED인 경우 건너뛰기
-        if (letter.getStatus() == PlazaLetterStatus.REPLIED || letter.getStatus() == PlazaLetterStatus.AI_REPLIED) {
+        // 상태가 이미 REPLIED, AI_REPLIED 또는 CANCELLED인 경우 건너뛰기
+        if (letter.getStatus() == PlazaLetterStatus.REPLIED
+                || letter.getStatus() == PlazaLetterStatus.AI_REPLIED
+                || letter.getStatus() == PlazaLetterStatus.CANCELLED) {
             return false;
         }
 

--- a/src/main/java/com/example/egobook_be/domain/user/service/UserService.java
+++ b/src/main/java/com/example/egobook_be/domain/user/service/UserService.java
@@ -230,7 +230,7 @@ public class UserService {
         }
 
         // 3. 회원 탈퇴 이유가 "기타(Others)"인 경우, text 필드가 비어있다면 예외 발생 (기타인 경우에느 반드시 text 필드가 채워져있어야 함)
-        if(reqDto.reasonType().equals(WithdrawReasonType.OTHER) && reqDto.text() != null && reqDto.text().isBlank()){
+        if(reqDto.reasonType().equals(WithdrawReasonType.OTHER) && !StringUtils.hasText(reqDto.text())){
             throw new CustomException(UserErrorCode.WITHDRAW_REASON_OTHER_TEXT_FIELD_EMPTY);
         }
 

--- a/src/test/java/com/example/egobook_be/domain/letter/PlazaLetterServiceTest.java
+++ b/src/test/java/com/example/egobook_be/domain/letter/PlazaLetterServiceTest.java
@@ -147,7 +147,7 @@ class PlazaLetterServiceTest {
 
         given(userRepository.findById(userId)).willReturn(Optional.of(sender));
         given(missionRepository.findByUser(sender)).willReturn(Optional.of(mission));
-        given(plazaLetterRepository.existsBySenderIdAndCreatedAtBetween(eq(userId), any(), any()))
+        given(plazaLetterRepository.existsBySenderIdAndStatusNotAndCreatedAtBetween(eq(userId), any(), any(), any()))
                 .willReturn(false);
         given(wordClient.detectAsync(anyString())).willReturn(Mono.empty());
 
@@ -231,7 +231,7 @@ class PlazaLetterServiceTest {
 
         given(userRepository.findById(userId)).willReturn(Optional.of(sender));
         given(missionRepository.findByUser(sender)).willReturn(Optional.of(mission));
-        given(plazaLetterRepository.existsBySenderIdAndCreatedAtBetween(eq(userId), any(), any()))
+        given(plazaLetterRepository.existsBySenderIdAndStatusNotAndCreatedAtBetween(eq(userId), any(), any(), any()))
                 .willReturn(false);
         given(userRepository.findById(friendId)).willReturn(Optional.of(receiver));
         given(friendRepository.existsByUserAndFriend(sender, receiver)).willReturn(false);
@@ -328,7 +328,7 @@ class PlazaLetterServiceTest {
 
         given(userRepository.findById(userId)).willReturn(Optional.of(sender));
         given(missionRepository.findByUser(sender)).willReturn(Optional.of(mission));
-        given(plazaLetterRepository.existsBySenderIdAndCreatedAtBetween(eq(userId), any(), any())).willReturn(false);
+        given(plazaLetterRepository.existsBySenderIdAndStatusNotAndCreatedAtBetween(eq(userId), any(), any(), any())).willReturn(false);
         given(inkLogRepository.existsByUserAndReasonAndCreatedAtBetween(eq(sender), eq(InkLogType.FIRST_LETTER_WRITE), any(), any()))
                 .willReturn(true);
         given(wordClient.detectAsync(anyString())).willReturn(Mono.empty());
@@ -515,7 +515,7 @@ class PlazaLetterServiceTest {
 
         given(userRepository.findById(userId)).willReturn(Optional.of(sender));
         given(missionRepository.findByUser(sender)).willReturn(Optional.of(mission));
-        given(plazaLetterRepository.existsBySenderIdAndCreatedAtBetween(eq(userId), any(), any())).willReturn(false);
+        given(plazaLetterRepository.existsBySenderIdAndStatusNotAndCreatedAtBetween(eq(userId), any(), any(), any())).willReturn(false);
         given(wordClient.detectAsync(anyString())).willReturn(Mono.empty());
         given(userRepository.findHighReplyRateCandidates(userId, 50)).willReturn(List.of(restrictedCandidateId));
         given(restrictionGuardService.getActivelyRestrictedUserIds(RestrictionDomainType.LETTER))


### PR DESCRIPTION
## #️⃣연관된 이슈
- #252 

## 📝작업 내용
편지 취소 및 회원탈퇴 관련 버그 3건 수정

### 작업 API
- `POST /plaza-letters`  취소(CANCELLED)된 편지를 일일 발송 한도 집계에서 제외
 - enforceDailyLimit()가 CANCELLED 편지도 발송 기록으로 포함해 취소 후 재발송 시 DAILY_LETTER_LIMIT 에러가 발생하던 버그 수정
- AI 자동 답장 스케줄러  CANCELLED 편지 대상 제외
- 48시간 경과한 CANCELLED 편지에 AI 자동 답장이 생성되고 취소한 유저에게 알림이 전송되던 버그 수정
- `POST /users/withdraw/reason` 기타(OTHER) 선택 시 text=null 허용 버그 수정
- null 체크 조건 누락으로 text를 null로 전송해도 저장되던 버그 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 취소된 편지는 일일 편지 발송 한도 계산에서 제외됩니다.
  * 취소된 편지에는 AI 답변이 생성되지 않습니다.
  * 탈퇴 사유로 ‘기타’를 선택할 때 상세 사유가 비어 있으면 제출할 수 없습니다.
  * 편지 생성 및 중복 발송 제한 검증이 변경된 정책에 맞게 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->