### PR TITLE
🔧 Settings: ALB 제거 및 Nginx 리버스 프록시 전환

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -153,6 +153,8 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           WORD_AI_BASE_URL: ${{ secrets.WORD_AI_BASE_URL }}
           FIREBASE_KEY_BASE64: ${{ secrets.FIREBASE_KEY_BASE64 }}
+          NGINX_CERT_BASE64: ${{ secrets.NGINX_CERT_BASE64 }}
+          NGINX_KEY_BASE64: ${{ secrets.NGINX_KEY_BASE64 }}
           # => github secrets에 설정해놓은 값들 env로 가져오기
 
         run: |
@@ -165,6 +167,8 @@ jobs:
             exit 1
           fi
           cp "$jar_file" ./egobookServer.jar
+          ssh -i private_key.pem -o StrictHostKeyChecking=no "$EC2_USERNAME@$EC2_HOST" \
+            "mkdir -p /home/$EC2_USERNAME/nginx/conf.d"
           scp -i private_key.pem -o StrictHostKeyChecking=no \
             ./egobookServer.jar Dockerfile docker-compose.yml \
             "$EC2_USERNAME@$EC2_HOST:/home/$EC2_USERNAME/"
@@ -182,6 +186,10 @@ jobs:
             mkdir -p /home/$EC2_USERNAME/src/main/resources
             echo '$FIREBASE_KEY_BASE64' | base64 -d > /home/$EC2_USERNAME/src/main/resources/firebase-service-account.json
             chmod 600 /home/$EC2_USERNAME/src/main/resources/firebase-service-account.json
+            mkdir -p /home/$EC2_USERNAME/nginx/certs
+            echo '$NGINX_CERT_BASE64' | base64 -d > /home/$EC2_USERNAME/nginx/certs/egobook.pem
+            echo '$NGINX_KEY_BASE64' | base64 -d > /home/$EC2_USERNAME/nginx/certs/egobook.key
+            chmod 600 /home/$EC2_USERNAME/nginx/certs/egobook.key
             REDIS_PASSWORD=$REDIS_PASSWORD sudo -E docker compose up -d --build --force-recreate
             sudo docker image prune -f || true
           "

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -168,6 +168,9 @@ jobs:
           scp -i private_key.pem -o StrictHostKeyChecking=no \
             ./egobookServer.jar Dockerfile docker-compose.yml \
             "$EC2_USERNAME@$EC2_HOST:/home/$EC2_USERNAME/"
+          scp -i private_key.pem -o StrictHostKeyChecking=no -r \
+            ./nginx/conf.d \
+            "$EC2_USERNAME@$EC2_HOST:/home/$EC2_USERNAME/nginx/"
           ssh -i private_key.pem -o StrictHostKeyChecking=no "$EC2_USERNAME@$EC2_HOST" "
             set -e
             cd /home/$EC2_USERNAME

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ AGENTS.md
 
 ### redis ###
 redis/data/
+
+### nginx ###
+nginx/certs/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,15 @@
-version: '3.8'
-
 services:
   # Spring Boot 애플리케이션
   egobook-api:
-    build: . # 현재 디렉토리의 Dockerfile을 이용해서 이미지를 빌드한 후 바로 사용하겠다는 뜻
+    build: .
     container_name: egobook-server
-    ports:
-      - "8080:8080"
-    restart: always  # 서버 재시작 시 자동 실행
+    restart: always
     depends_on:
       - redis-db
     environment:
-      # 컨테이너 내부에서 파일이 위치할 경로를 지정합니다.
       - GOOGLE_APPLICATION_CREDENTIALS=/app/resources/firebase-service-account.json
       - REDIS_PASSWORD=${REDIS_PASSWORD}
     volumes:
-      # [호스트 경로]:[컨테이너 내부 경로]
-      # EC2에 생성된 실제 파일을 컨테이너 내부의 위 environment에서 설정한 경로로 마운트합니다.
       - ./src/main/resources/firebase-service-account.json:/app/resources/firebase-service-account.json
     networks:
       - egobook-network
@@ -30,14 +23,32 @@ services:
   redis-db:
     image: redis:latest
     container_name: redis-cache
-    ports:
-      - "6379:6379"
     restart: always  # <--- 이 설정이 있으면 EC2가 꺼졌다 켜져도 도커가 알아서 실행해줍니다.
     volumes:
       - ./redis/data:/data  # <--- Redis 데이터가 서버 재시작 후에도 유지되도록 저장소 연결
     command: redis-server --requirepass "${REDIS_PASSWORD}" --appendonly yes
     networks:
       - egobook-network
+
+  # Nginx (리버스 프록시 / TLS 종단)
+  nginx:
+    image: nginx:alpine
+    container_name: egobook-nginx
+    restart: always
+    ports:
+      - "443:443"
+    volumes:
+      - ./nginx/conf.d:/etc/nginx/conf.d:ro
+      - ./nginx/certs:/etc/nginx/certs:ro
+    depends_on:
+      - egobook-api
+    networks:
+      - egobook-network
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
 
 networks:
   egobook-network:

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -1,0 +1,18 @@
+server {
+    listen 443 ssl;                          # 443에서 TLS로 수신
+    server_name dev.egobook.site;
+
+    ssl_certificate     /etc/nginx/certs/egobook.pem;   # 인증서
+    ssl_certificate_key /etc/nginx/certs/egobook.key;   # 개인키
+
+    client_max_body_size 20M;                # 업로드 최대 20MB
+
+    location / {
+        proxy_pass http://egobook-api:8080;  # Spring Boot로 전달
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $http_cf_connecting_ip;
+        proxy_set_header X-Forwarded-For   $http_cf_connecting_ip;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_read_timeout 120s;
+    }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -16,7 +16,7 @@ spring:
       root: INFO
   data:
     redis:
-      host: localhost # 같은 EC2 안에 있으므로 localhost
+      host: redis-db
       port: 6379
       password: ${PROD_REDIS_PW}
   cloud:


### PR DESCRIPTION
## #️⃣연관된 이슈
- closes #254 

## 📝작업 내용
* `docker-compose.yml` nginx 서비스 추가 (nginx:alpine, 443 바인딩, 인증서/설정 read-only 마운트)
* `docker-compose.yml` egobook-api의 8080, redis-db의 6379 호스트 포트 바인딩 제거
* `nginx/conf.d/default.conf` 신규 추가 - 443 TLS 종단 후 egobook-api:8080으로 프록시
* `.github/workflows/*.yml` nginx/conf.d 디렉터리 전송 step 추가
* `.gitignore` nginx/certs/ 추가

## 🖥 인프라 작업 
* Cloudflare Origin Certificate 발급 및 EC2 배치
* SG-EC2 443 인바운드 추가 (Cloudflare IP 대역 15개로 제한), 8080 인바운드 제거
* Cloudflare SSL/TLS 모드 Full (strict) 적용
* DNS `dev.egobook.site` CNAME(ALB) → A 레코드(Elastic IP) 전환
* ALB, 대상 그룹, SG-ALB 삭제

## ✅ 테스트

> Cloudflare 경유 요청 정상 응답 확인

```
$ curl -I https://dev.egobook.site/actuator/health

HTTP/2 401
content-type: application/json;charset=UTF-8
server: cloudflare
cf-cache-status: DYNAMIC
cf-ray: a252e85d99ca018f-ICN
```
> Spring Security의 인증 요구 응답(401)이 정상 반환되며, `server: cloudflare` / `cf-ray` 헤더로 Cloudflare 경유 확인
```
141.101.85.7 - - [03/Aug/2026:03:49:37 +0000] "HEAD /actuator/health HTTP/1.1" 401 0
```
## ⚠️ 참고사항
* 인증서는 서버에만 존재 (리포 미포함), 만료일 2027-08-03
* 클라이언트 IP는 `CF-Connecting-IP` 헤더 기준