### PR TITLE
🔧 Settings: Nginx 인증서 배포에 검증 단계 추가 설정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -187,8 +187,18 @@ jobs:
             echo '$FIREBASE_KEY_BASE64' | base64 -d > /home/$EC2_USERNAME/src/main/resources/firebase-service-account.json
             chmod 600 /home/$EC2_USERNAME/src/main/resources/firebase-service-account.json
             mkdir -p /home/$EC2_USERNAME/nginx/certs
-            echo '$NGINX_CERT_BASE64' | base64 -d > /home/$EC2_USERNAME/nginx/certs/egobook.pem
-            echo '$NGINX_KEY_BASE64' | base64 -d > /home/$EC2_USERNAME/nginx/certs/egobook.key
+            echo '$NGINX_CERT_BASE64' | base64 -d > /tmp/egobook.pem.tmp
+            echo '$NGINX_KEY_BASE64' | base64 -d > /tmp/egobook.key.tmp
+            openssl x509 -in /tmp/egobook.pem.tmp -noout -subject
+            openssl pkey -in /tmp/egobook.key.tmp -noout -check
+            CERT_MD5=\$(openssl x509 -noout -modulus -in /tmp/egobook.pem.tmp | openssl md5)
+            KEY_MD5=\$(openssl rsa -noout -modulus -in /tmp/egobook.key.tmp | openssl md5)
+            if [ \"\$CERT_MD5\" != \"\$KEY_MD5\" ]; then
+              echo '인증서와 개인키가 일치하지 않습니다.'
+              exit 1
+            fi
+            mv /tmp/egobook.pem.tmp /home/$EC2_USERNAME/nginx/certs/egobook.pem
+            mv /tmp/egobook.key.tmp /home/$EC2_USERNAME/nginx/certs/egobook.key
             chmod 600 /home/$EC2_USERNAME/nginx/certs/egobook.key
             REDIS_PASSWORD=$REDIS_PASSWORD sudo -E docker compose up -d --build --force-recreate
             sudo docker image prune -f || true


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- closes #256 

## 📝 작업 내용
* 배포 워크플로의 Nginx 인증서 생성 단계에 검증 로직 추가

기존에는 base64 디코딩 결과를 검증 없이 인증서 경로에 덮어썼습니다.
값이 손상된 경우에도 그대로 적용되어 nginx 기동 실패로 이어졌습니다.

## 🔧 변경 사항
* `.github/workflows/*.yml`
  * 인증서를 `/tmp` 임시 파일에 디코딩
  * `openssl x509`, `openssl pkey`로 형식 검증
  * modulus 비교로 인증서-키 쌍 일치 확인
  * 검증 통과 시에만 `mv`로 실제 경로에 적용

## ✅ 테스트
> $ curl -I https://dev.egobook.site/actuator/health
```
HTTP/2 401
content-type: application/json;charset=UTF-8
server: cloudflare
cf-cache-status: DYNAMIC
cf-ray: a25343c83a55d1e2-ICN
```