### PR TITLE
✨ Feat: 관리자 쿠폰 API 구현

### DIFF
--- a/src/main/java/com/example/egobook_be/domain/coupon/controller/AdminCouponController.java
+++ b/src/main/java/com/example/egobook_be/domain/coupon/controller/AdminCouponController.java
@@ -1,0 +1,97 @@
+package com.example.egobook_be.domain.coupon.controller;
+
+import com.example.egobook_be.domain.coupon.dto.*;
+import com.example.egobook_be.domain.coupon.service.AdminCouponService;
+import com.example.egobook_be.global.response.GlobalResponse;
+import com.example.egobook_be.global.response.SliceResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/coupons")
+public class AdminCouponController implements AdminCouponControllerDocs {
+
+    private final AdminCouponService adminCouponService;
+
+    /**
+     * [쿠폰 등록]
+     * POST /admin/coupons
+     */
+    @Override
+    @PostMapping
+    public ResponseEntity<GlobalResponse<CouponAdminResDto>> createCoupon(
+            @Valid @RequestBody CouponAdminCreateReqDto reqDto
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(GlobalResponse.success(201, "쿠폰 등록 성공", adminCouponService.createCoupon(reqDto)));
+    }
+
+    /**
+     * [전체 쿠폰 조회]
+     * GET /admin/coupons
+     */
+    @Override
+    @GetMapping
+    public ResponseEntity<GlobalResponse<SliceResponse<CouponAdminResDto>>> getCoupons(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        return ResponseEntity.ok(
+                GlobalResponse.success("쿠폰 목록 조회 성공", adminCouponService.getCoupons(page, size))
+        );
+    }
+
+    /**
+     * [쿠폰 단건 조회]
+     * GET /admin/coupons/{couponId}
+     */
+    @Override
+    @GetMapping("/{couponId}")
+    public ResponseEntity<GlobalResponse<CouponAdminResDto>> getCoupon(@PathVariable Long couponId) {
+        return ResponseEntity.ok(
+                GlobalResponse.success("쿠폰 조회 성공", adminCouponService.getCoupon(couponId))
+        );
+    }
+
+    /**
+     * [쿠폰 수정]
+     * PATCH /admin/coupons/{couponId}
+     */
+    @Override
+    @PatchMapping("/{couponId}")
+    public ResponseEntity<GlobalResponse<CouponAdminResDto>> updateCoupon(
+            @PathVariable Long couponId,
+            @Valid @RequestBody CouponAdminUpdateReqDto reqDto
+    ) {
+        return ResponseEntity.ok(
+                GlobalResponse.success("쿠폰 수정 성공", adminCouponService.updateCoupon(couponId, reqDto))
+        );
+    }
+
+    /**
+     * [쿠폰 삭제]
+     * DELETE /admin/coupons/{couponId}
+     */
+    @Override
+    @DeleteMapping("/{couponId}")
+    public ResponseEntity<GlobalResponse<Void>> deleteCoupon(@PathVariable Long couponId) {
+        adminCouponService.deleteCoupon(couponId);
+        return ResponseEntity.ok(GlobalResponse.success("쿠폰 삭제 성공", null));
+    }
+
+    /**
+     * [개인 쿠폰 알림 전송]
+     * POST /admin/coupons/{couponId}/notify
+     */
+    @Override
+    @PostMapping("/{couponId}/notify")
+    public ResponseEntity<GlobalResponse<CouponAdminNotifyResDto>> sendCouponNotification(@PathVariable Long couponId) {
+        return ResponseEntity.ok(
+                GlobalResponse.success("쿠폰 알림 전송 성공", adminCouponService.sendCouponNotification(couponId))
+        );
+    }
+}

--- a/src/main/java/com/example/egobook_be/domain/coupon/controller/AdminCouponControllerDocs.java
+++ b/src/main/java/com/example/egobook_be/domain/coupon/controller/AdminCouponControllerDocs.java
@@ -1,0 +1,129 @@
+package com.example.egobook_be.domain.coupon.controller;
+
+import com.example.egobook_be.domain.coupon.dto.*;
+import com.example.egobook_be.global.response.GlobalResponse;
+import com.example.egobook_be.global.response.SliceResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Admin Coupon Controller", description = "[관리자] 쿠폰 관리 API")
+public interface AdminCouponControllerDocs {
+
+    @Operation(summary = "쿠폰 등록 API", description = """
+            새 쿠폰 코드를 등록합니다.
+
+            [**Request Body**]
+            - code : 영문/숫자/하이픈 20자 이하. 대문자로 정규화되어 저장되며 중복 시 409를 반환합니다.
+            - targetType : ALL(전체) / INDIVIDUAL(개인)
+            - targetAccountCode : INDIVIDUAL일 때 필수, ALL일 때는 지정할 수 없습니다. 실존하는 계정인지 검증합니다.
+            - rewards : 잉크(INK)/아이템(ITEM) 보상을 동시에, 각각 복수로 담을 수 있습니다.
+            - rewards 배열 순서가 그대로 sortOrder로 저장되어 유저 팝업 노출 순서가 됩니다.
+            """)
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "쿠폰 등록에 성공했습니다."),
+            @ApiResponse(responseCode = "400", description = "보상 또는 대상 정보가 올바르지 않습니다.", content = @Content),
+            @ApiResponse(responseCode = "404", description = "계정 또는 아이템을 찾을 수 없습니다.", content = @Content),
+            @ApiResponse(responseCode = "409", description = "중복된 코드입니다.", content = @Content)
+    })
+    @SecurityRequirement(name = "bearerAuth")
+    @PostMapping
+    ResponseEntity<GlobalResponse<CouponAdminResDto>> createCoupon(@Valid @RequestBody CouponAdminCreateReqDto reqDto);
+
+    @Operation(summary = "전체 쿠폰 조회 API", description = """
+            만료되지 않은 쿠폰 목록을 최신 등록순으로 조회합니다.
+
+            [**주의사항**]
+            - 만료일이 지난 쿠폰은 목록에 포함되지 않습니다.
+
+            [**응답 활용**]
+            - targetType이 INDIVIDUAL인 행에만 알림 전송 버튼을 노출해주세요.
+            - notified가 true면 '전송 완료' 비활성 버튼으로 노출해주세요.
+            - rewards는 sortOrder 순으로 정렬되어 반환됩니다.
+            """)
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "쿠폰 목록 조회에 성공했습니다."),
+            @ApiResponse(responseCode = "401", description = "로그인이 필요합니다.", content = @Content),
+            @ApiResponse(responseCode = "403", description = "관리자 권한이 필요합니다.", content = @Content)
+    })
+    @SecurityRequirement(name = "bearerAuth")
+    @GetMapping
+    ResponseEntity<GlobalResponse<SliceResponse<CouponAdminResDto>>> getCoupons(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "20") int size
+    );
+
+    @Operation(summary = "쿠폰 단건 조회 API", description = """
+            수정 팝업에 기존 값을 채우기 위해 쿠폰 1건을 조회합니다.
+
+            [**참고**]
+            - 응답 형태는 목록 조회의 content 원소와 동일합니다.
+            """)
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "쿠폰 조회에 성공했습니다."),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 쿠폰입니다.", content = @Content)
+    })
+    @SecurityRequirement(name = "bearerAuth")
+    @GetMapping("/{couponId}")
+    ResponseEntity<GlobalResponse<CouponAdminResDto>> getCoupon(@PathVariable Long couponId);
+
+    @Operation(summary = "쿠폰 수정 API", description = """
+            등록된 쿠폰 정보를 수정합니다. Request Body는 등록과 동일합니다.
+
+            [**주의사항**]
+            - rewards는 부분 수정이 아니라 전체 교체입니다. '-' 버튼으로 제거한 항목은 배열에서 빼고 전달해주세요.
+            - 보상이 새로 생성되므로 수정 후 sortOrder가 배열 순서대로 재부여됩니다.
+            - 등록과 달리 만료 일시의 과거 날짜 제약은 없습니다.
+            """)
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "쿠폰 수정에 성공했습니다."),
+            @ApiResponse(responseCode = "400", description = "보상 또는 대상 정보가 올바르지 않습니다.", content = @Content),
+            @ApiResponse(responseCode = "404", description = "쿠폰, 계정 또는 아이템을 찾을 수 없습니다.", content = @Content),
+            @ApiResponse(responseCode = "409", description = "중복된 코드입니다.", content = @Content)
+    })
+    @SecurityRequirement(name = "bearerAuth")
+    @PatchMapping("/{couponId}")
+    ResponseEntity<GlobalResponse<CouponAdminResDto>> updateCoupon(
+            @PathVariable Long couponId,
+            @Valid @RequestBody CouponAdminUpdateReqDto reqDto
+    );
+
+    @Operation(summary = "쿠폰 삭제 API", description = """
+            쿠폰과 보상을 함께 삭제합니다. 복구되지 않으므로 삭제 확인 팝업을 띄워주세요.
+
+            [**주의사항**]
+            - 이미 사용된 이력이 있는 쿠폰은 지급 내역 추적이 끊기므로 삭제할 수 없습니다. (409)
+            """)
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "쿠폰 삭제에 성공했습니다."),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 쿠폰입니다.", content = @Content),
+            @ApiResponse(responseCode = "409", description = "이미 사용된 쿠폰은 삭제할 수 없습니다.", content = @Content)
+    })
+    @SecurityRequirement(name = "bearerAuth")
+    @DeleteMapping("/{couponId}")
+    ResponseEntity<GlobalResponse<Void>> deleteCoupon(@PathVariable Long couponId);
+
+    @Operation(summary = "개인 쿠폰 알림 전송 API", description = """
+            개인 대상 쿠폰의 코드가 담긴 알림을 해당 유저에게 전송합니다. (FCM 푸시 포함)
+
+            [**주의사항**]
+            - 전체 대상 쿠폰은 400을 반환합니다. 전체 공지는 레드닷 API를 사용해주세요.
+            - 이미 전송한 쿠폰은 409를 반환하여 재전송을 막습니다.
+            - 전송 성공 시 notified가 true가 되며, 버튼을 '전송 완료' 비활성 상태로 바꿔주세요.
+            """)
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "알림 전송에 성공했습니다."),
+            @ApiResponse(responseCode = "400", description = "개인 대상이 아니거나 만료된 쿠폰입니다.", content = @Content),
+            @ApiResponse(responseCode = "404", description = "쿠폰 또는 대상 유저를 찾을 수 없습니다.", content = @Content),
+            @ApiResponse(responseCode = "409", description = "이미 알림을 전송한 쿠폰입니다.", content = @Content)
+    })
+    @SecurityRequirement(name = "bearerAuth")
+    @PostMapping("/{couponId}/notify")
+    ResponseEntity<GlobalResponse<CouponAdminNotifyResDto>> sendCouponNotification(@PathVariable Long couponId);
+}

--- a/src/main/java/com/example/egobook_be/domain/coupon/controller/AdminCouponControllerDocs.java
+++ b/src/main/java/com/example/egobook_be/domain/coupon/controller/AdminCouponControllerDocs.java
@@ -37,10 +37,7 @@ public interface AdminCouponControllerDocs {
     ResponseEntity<GlobalResponse<CouponAdminResDto>> createCoupon(@Valid @RequestBody CouponAdminCreateReqDto reqDto);
 
     @Operation(summary = "전체 쿠폰 조회 API", description = """
-            만료되지 않은 쿠폰 목록을 최신 등록순으로 조회합니다.
-
-            [**주의사항**]
-            - 만료일이 지난 쿠폰은 목록에 포함되지 않습니다.
+            등록된 전체 쿠폰 목록을 등록 최신순으로 조회합니다.
 
             [**응답 활용**]
             - targetType이 INDIVIDUAL인 행에만 알림 전송 버튼을 노출해주세요.

--- a/src/main/java/com/example/egobook_be/domain/coupon/dto/CouponAdminCreateReqDto.java
+++ b/src/main/java/com/example/egobook_be/domain/coupon/dto/CouponAdminCreateReqDto.java
@@ -1,0 +1,36 @@
+package com.example.egobook_be.domain.coupon.dto;
+
+import com.example.egobook_be.domain.coupon.enums.CouponTargetType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record CouponAdminCreateReqDto(
+
+        @Schema(description = "쿠폰 코드", example = "XK7QPT2A")
+        @NotBlank(message = "쿠폰 코드를 입력해주세요")
+        @Size(max = 20, message = "쿠폰 코드는 20자 이하여야 합니다")
+        @Pattern(regexp = "^[A-Za-z0-9-]+$", message = "쿠폰 코드는 영문/숫자/하이픈만 사용할 수 있습니다")
+        String code,
+
+        @Schema(description = "대상", example = "INDIVIDUAL")
+        @NotNull(message = "대상은 필수입니다")
+        CouponTargetType targetType,
+
+        @Schema(description = "계정 고유 코드 (대상이 INDIVIDUAL일 때 필수)", example = "A1B2C3D4")
+        @Size(max = 12, message = "계정 고유 코드는 12자 이하여야 합니다")
+        String targetAccountCode,
+
+        @Schema(description = "보상 목록 (배열 순서가 sortOrder로 저장됨)")
+        @NotEmpty(message = "보상은 1개 이상 등록해야 합니다")
+        @Valid
+        List<CouponAdminRewardReqDto> rewards,
+
+        @Schema(description = "만료 일시", example = "2026-03-24T14:00:00")
+        @NotNull(message = "만료 일시는 필수입니다")
+        @Future(message = "만료 일시는 현재 이후여야 합니다")
+        LocalDateTime expiresAt
+) {}

--- a/src/main/java/com/example/egobook_be/domain/coupon/dto/CouponAdminNotifyResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/coupon/dto/CouponAdminNotifyResDto.java
@@ -1,0 +1,13 @@
+package com.example.egobook_be.domain.coupon.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record CouponAdminNotifyResDto(
+        Long couponId,
+        boolean notified,
+        LocalDateTime notifiedAt,
+        int sentCount
+) {}

--- a/src/main/java/com/example/egobook_be/domain/coupon/dto/CouponAdminResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/coupon/dto/CouponAdminResDto.java
@@ -1,0 +1,22 @@
+package com.example.egobook_be.domain.coupon.dto;
+
+import com.example.egobook_be.domain.coupon.enums.CouponTargetType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+@Schema(description = "[관리자] 쿠폰 응답 DTO")
+public record CouponAdminResDto(
+        Long couponId,
+        String code,
+        CouponTargetType targetType,
+        String targetAccountCode,
+        List<CouponAdminRewardResDto> rewards,
+        LocalDateTime expiresAt,
+        boolean notified,
+        LocalDateTime notifiedAt,
+        LocalDateTime createdAt
+) {}

--- a/src/main/java/com/example/egobook_be/domain/coupon/dto/CouponAdminRewardReqDto.java
+++ b/src/main/java/com/example/egobook_be/domain/coupon/dto/CouponAdminRewardReqDto.java
@@ -1,0 +1,20 @@
+package com.example.egobook_be.domain.coupon.dto;
+
+import com.example.egobook_be.domain.coupon.enums.CouponRewardType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record CouponAdminRewardReqDto(
+
+        @Schema(description = "보상 타입", example = "INK")
+        @NotNull(message = "보상 타입은 필수입니다")
+        CouponRewardType rewardType,
+
+        @Schema(description = "잉크 수량 (rewardType이 INK일 때 필수)", example = "12")
+        @Positive(message = "잉크 수량은 1 이상이어야 합니다")
+        Integer inkAmount,
+
+        @Schema(description = "아이템 PK (rewardType이 ITEM일 때 필수)", example = "72")
+        Long itemId
+) {}

--- a/src/main/java/com/example/egobook_be/domain/coupon/dto/CouponAdminRewardResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/coupon/dto/CouponAdminRewardResDto.java
@@ -1,0 +1,21 @@
+package com.example.egobook_be.domain.coupon.dto;
+
+import com.example.egobook_be.domain.coupon.enums.CouponRewardType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "[관리자] 쿠폰 보상 응답 DTO")
+public record CouponAdminRewardResDto(
+        @Schema(description = "보상 PK", example = "23")
+        Long rewardId,
+
+        @Schema(description = "보상 타입", example = "INK")
+        CouponRewardType rewardType,
+
+        @Schema(description = "잉크 수량 (INK일 때만)", example = "12")
+        Integer inkAmount,
+
+        @Schema(description = "아이템 PK (ITEM일 때만)", example = "72")
+        Long itemId
+) {}

--- a/src/main/java/com/example/egobook_be/domain/coupon/dto/CouponAdminUpdateReqDto.java
+++ b/src/main/java/com/example/egobook_be/domain/coupon/dto/CouponAdminUpdateReqDto.java
@@ -1,0 +1,35 @@
+package com.example.egobook_be.domain.coupon.dto;
+
+import com.example.egobook_be.domain.coupon.enums.CouponTargetType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record CouponAdminUpdateReqDto(
+
+        @Schema(description = "쿠폰 코드", example = "XK7QPT2A")
+        @NotBlank(message = "쿠폰 코드를 입력해주세요")
+        @Size(max = 20, message = "쿠폰 코드는 20자 이하여야 합니다")
+        @Pattern(regexp = "^[A-Za-z0-9-]+$", message = "쿠폰 코드는 영문/숫자/하이픈만 사용할 수 있습니다")
+        String code,
+
+        @Schema(description = "대상", example = "INDIVIDUAL")
+        @NotNull(message = "대상은 필수입니다")
+        CouponTargetType targetType,
+
+        @Schema(description = "계정 고유 코드 (대상이 INDIVIDUAL일 때 필수)", example = "A1B2C3D4")
+        @Size(max = 12, message = "계정 고유 코드는 12자 이하여야 합니다")
+        String targetAccountCode,
+
+        @Schema(description = "보상 목록 (전달된 목록으로 전체 교체됨)")
+        @NotEmpty(message = "보상은 1개 이상 등록해야 합니다")
+        @Valid
+        List<CouponAdminRewardReqDto> rewards,
+
+        @Schema(description = "만료 일시", example = "2026-03-24T14:00:00")
+        @NotNull(message = "만료 일시는 필수입니다")
+        LocalDateTime expiresAt
+) {}

--- a/src/main/java/com/example/egobook_be/domain/coupon/entity/Coupon.java
+++ b/src/main/java/com/example/egobook_be/domain/coupon/entity/Coupon.java
@@ -34,7 +34,47 @@ public class Coupon extends BaseTimeEntity {
     @Column(name = "expires_at", nullable = false)
     private LocalDateTime expiresAt;
 
+    @Column(name = "notified_at")
+    private LocalDateTime notifiedAt;
+
     @OneToMany(mappedBy = "coupon", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<CouponReward> rewards = new ArrayList<>();
+
+    /**
+     * 쿠폰 기본 정보를 수정한다. (보상은 replaceRewards로 별도 교체)
+     */
+    public void update(String code, CouponTargetType targetType, String targetAccountCode, LocalDateTime expiresAt) {
+        this.code = code;
+        this.targetType = targetType;
+        this.targetAccountCode = targetAccountCode;
+        this.expiresAt = expiresAt;
+    }
+
+    /**
+     * 보상 목록을 통째로 교체한다.
+     * - 수정 팝업에서 '-' 버튼으로 제거된 항목은 요청 배열에서 빠져오므로 orphanRemoval로 삭제된다.
+     */
+    public void replaceRewards(List<CouponReward> newRewards) {
+        this.rewards.clear();
+        newRewards.forEach(this::addReward);
+    }
+
+    public void addReward(CouponReward reward) {
+        this.rewards.add(reward);
+        reward.assignCoupon(this);
+    }
+
+    public void markNotified() {
+        this.notifiedAt = LocalDateTime.now();
+    }
+
+    public boolean isNotified() {
+        return this.notifiedAt != null;
+    }
+
+    /** 만료 여부를 판단한다. 만료 일시 이전까지 유효하다. */
+    public boolean isExpired(LocalDateTime now) {
+        return now.isAfter(this.expiresAt);
+    }
 }

--- a/src/main/java/com/example/egobook_be/domain/coupon/entity/Coupon.java
+++ b/src/main/java/com/example/egobook_be/domain/coupon/entity/Coupon.java
@@ -73,7 +73,7 @@ public class Coupon extends BaseTimeEntity {
         return this.notifiedAt != null;
     }
 
-    /** 만료 여부를 판단한다. 만료 일시 이전까지 유효하다. */
+    /** 만료 여부를 판단한다. 만료 일시까지 유효하며, 그 이후는 만료로 본다. */
     public boolean isExpired(LocalDateTime now) {
         return now.isAfter(this.expiresAt);
     }

--- a/src/main/java/com/example/egobook_be/domain/coupon/entity/CouponReward.java
+++ b/src/main/java/com/example/egobook_be/domain/coupon/entity/CouponReward.java
@@ -32,4 +32,26 @@ public class CouponReward {
 
     @Column(name = "sort_order", nullable = false)
     private Integer sortOrder;
+
+    /** 잉크 보상 생성 (sortOrder는 등록 시 입력 순서) */
+    public static CouponReward ofInk(int inkAmount, int sortOrder) {
+        return CouponReward.builder()
+                .rewardType(CouponRewardType.INK)
+                .inkAmount(inkAmount)
+                .sortOrder(sortOrder)
+                .build();
+    }
+
+    /** 아이템 보상 생성 (sortOrder는 등록 시 입력 순서) */
+    public static CouponReward ofItem(Long itemId, int sortOrder) {
+        return CouponReward.builder()
+                .rewardType(CouponRewardType.ITEM)
+                .itemId(itemId)
+                .sortOrder(sortOrder)
+                .build();
+    }
+
+    void assignCoupon(Coupon coupon) {
+        this.coupon = coupon;
+    }
 }

--- a/src/main/java/com/example/egobook_be/domain/coupon/exception/CouponErrorCode.java
+++ b/src/main/java/com/example/egobook_be/domain/coupon/exception/CouponErrorCode.java
@@ -12,7 +12,21 @@ public enum CouponErrorCode implements BaseErrorCode {
     COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 코드입니다"),
     COUPON_EXPIRED(HttpStatus.BAD_REQUEST, "만료된 쿠폰입니다"),
     COUPON_ALREADY_USED(HttpStatus.BAD_REQUEST, "이미 사용한 쿠폰입니다"),
-    COUPON_NOT_FOR_USER(HttpStatus.FORBIDDEN, "해당 쿠폰을 사용할 수 없습니다");
+    COUPON_NOT_FOR_USER(HttpStatus.FORBIDDEN, "해당 쿠폰을 사용할 수 없습니다"),
+
+    // Admin
+    DUPLICATED_CODE(HttpStatus.CONFLICT, "중복된 코드입니다"),
+    REWARD_REQUIRED(HttpStatus.BAD_REQUEST, "보상은 1개 이상 등록해야 합니다"),
+    INVALID_REWARD(HttpStatus.BAD_REQUEST, "보상 정보가 올바르지 않습니다"),
+    REWARD_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "보상 아이템을 찾을 수 없습니다"),
+    TARGET_ACCOUNT_CODE_REQUIRED(HttpStatus.BAD_REQUEST, "개인 대상 쿠폰은 계정 고유 코드가 필요합니다"),
+    TARGET_ACCOUNT_CODE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "전체 대상 쿠폰에는 계정 고유 코드를 지정할 수 없습니다"),
+    TARGET_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 계정 고유 코드의 사용자를 찾을 수 없습니다"),
+    COUPON_ALREADY_USED_CANNOT_DELETE(HttpStatus.CONFLICT, "이미 사용된 쿠폰은 삭제할 수 없습니다"),
+    USED_COUPON_LIMITED_UPDATE(HttpStatus.CONFLICT, "이미 사용된 쿠폰은 만료일만 수정할 수 있습니다"),
+    NOTIFY_TARGET_NOT_INDIVIDUAL(HttpStatus.BAD_REQUEST, "개인 대상 쿠폰만 알림을 전송할 수 있습니다"),
+    COUPON_ALREADY_NOTIFIED(HttpStatus.CONFLICT, "이미 알림을 전송한 쿠폰입니다"),
+    RECEIVER_NOTIFICATION_DISABLED(HttpStatus.BAD_REQUEST, "대상 유저가 알림을 꺼두어 전송할 수 없습니다");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/egobook_be/domain/coupon/mapper/CouponMapper.java
+++ b/src/main/java/com/example/egobook_be/domain/coupon/mapper/CouponMapper.java
@@ -1,0 +1,53 @@
+package com.example.egobook_be.domain.coupon.mapper;
+
+import com.example.egobook_be.domain.coupon.dto.CouponAdminNotifyResDto;
+import com.example.egobook_be.domain.coupon.dto.CouponAdminResDto;
+import com.example.egobook_be.domain.coupon.dto.CouponAdminRewardResDto;
+import com.example.egobook_be.domain.coupon.entity.Coupon;
+import com.example.egobook_be.domain.coupon.entity.CouponReward;
+import org.springframework.stereotype.Component;
+
+import java.util.Comparator;
+
+@Component
+public class CouponMapper {
+
+    /**
+     * Coupon Entity -> CouponAdminResDto 변환
+     * @param coupon : rewards가 fetch join된 Coupon Entity
+     */
+    public CouponAdminResDto toCouponAdminResDto(Coupon coupon) {
+        return CouponAdminResDto.builder()
+                .couponId(coupon.getId())
+                .code(coupon.getCode())
+                .targetType(coupon.getTargetType())
+                .targetAccountCode(coupon.getTargetAccountCode())
+                .rewards(coupon.getRewards().stream()
+                        .sorted(Comparator.comparing(CouponReward::getSortOrder))
+                        .map(this::toCouponAdminRewardResDto)
+                        .toList())
+                .expiresAt(coupon.getExpiresAt())
+                .notified(coupon.isNotified())
+                .notifiedAt(coupon.getNotifiedAt())
+                .createdAt(coupon.getCreatedAt())
+                .build();
+    }
+
+    private CouponAdminRewardResDto toCouponAdminRewardResDto(CouponReward reward) {
+        return CouponAdminRewardResDto.builder()
+                .rewardId(reward.getId())
+                .rewardType(reward.getRewardType())
+                .inkAmount(reward.getInkAmount())
+                .itemId(reward.getItemId())
+                .build();
+    }
+
+    public CouponAdminNotifyResDto toCouponAdminNotifyResDto(Coupon coupon, int sentCount) {
+        return CouponAdminNotifyResDto.builder()
+                .couponId(coupon.getId())
+                .notified(coupon.isNotified())
+                .notifiedAt(coupon.getNotifiedAt())
+                .sentCount(sentCount)
+                .build();
+    }
+}

--- a/src/main/java/com/example/egobook_be/domain/coupon/repository/CouponRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/coupon/repository/CouponRepository.java
@@ -1,10 +1,13 @@
 package com.example.egobook_be.domain.coupon.repository;
 
 import com.example.egobook_be.domain.coupon.entity.Coupon;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
@@ -14,4 +17,25 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
      */
     @Query("select c from Coupon c left join fetch c.rewards r where c.code = :code order by r.sortOrder asc")
     Optional<Coupon> findByCodeWithRewards(@Param("code") String code);
+
+    // Admin
+
+    boolean existsByCode(String code);
+
+    /** 수정 시 자기 자신을 제외한 코드 중복 검증 */
+    boolean existsByCodeAndIdNot(String code, Long id);
+
+    /**
+     * 전체 쿠폰의 ID를 등록 최신순으로 조회한다. (만료 여부 무관)
+     * - 컬렉션 fetch join과 페이징을 함께 쓰면 Hibernate가 전체 행을 메모리에 적재하므로 ID 조회와 분리한다.
+     */
+    @Query("select c.id from Coupon c order by c.createdAt desc")
+    Slice<Long> findCouponIds(Pageable pageable);
+
+    /** ID 목록으로 쿠폰 + 보상을 한 번에 조회한다. */
+    @Query("select distinct c from Coupon c left join fetch c.rewards r where c.id in :ids")
+    List<Coupon> findAllWithRewardsByIdIn(@Param("ids") List<Long> ids);
+
+    @Query("select c from Coupon c left join fetch c.rewards r where c.id = :couponId")
+    Optional<Coupon> findByIdWithRewards(@Param("couponId") Long couponId);
 }

--- a/src/main/java/com/example/egobook_be/domain/coupon/repository/CouponRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/coupon/repository/CouponRepository.java
@@ -4,9 +4,11 @@ import com.example.egobook_be.domain.coupon.entity.Coupon;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -39,4 +41,13 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
 
     @Query("select c from Coupon c left join fetch c.rewards r where c.id = :couponId")
     Optional<Coupon> findByIdWithRewards(@Param("couponId") Long couponId);
+
+    /**
+     * 아직 알림을 보내지 않은 쿠폰만 전송 완료로 표시한다.
+     * - 동시에 두 요청이 들어와도 UPDATE가 성공한 한쪽만 실제 전송을 진행하도록 선점한다.
+     * @return : 갱신된 행 수 (0이면 이미 다른 요청이 선점함)
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update Coupon c set c.notifiedAt = :now where c.id = :couponId and c.notifiedAt is null")
+    int markNotifiedIfNotYet(@Param("couponId") Long couponId, @Param("now") LocalDateTime now);
 }

--- a/src/main/java/com/example/egobook_be/domain/coupon/repository/CouponRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/coupon/repository/CouponRepository.java
@@ -28,8 +28,9 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
     /**
      * 전체 쿠폰의 ID를 등록 최신순으로 조회한다. (만료 여부 무관)
      * - 컬렉션 fetch join과 페이징을 함께 쓰면 Hibernate가 전체 행을 메모리에 적재하므로 ID 조회와 분리한다.
+     * - createdAt이 같을 때 페이지 간 순서가 흔들리지 않도록 id를 보조 정렬 기준으로 둔다.
      */
-    @Query("select c.id from Coupon c order by c.createdAt desc")
+    @Query("select c.id from Coupon c order by c.createdAt desc, c.id desc")
     Slice<Long> findCouponIds(Pageable pageable);
 
     /** ID 목록으로 쿠폰 + 보상을 한 번에 조회한다. */

--- a/src/main/java/com/example/egobook_be/domain/coupon/repository/UserCouponRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/coupon/repository/UserCouponRepository.java
@@ -9,4 +9,9 @@ public interface UserCouponRepository extends JpaRepository<UserCoupon, Long> {
      * 해당 유저가 해당 쿠폰을 이미 사용했는지 확인
      */
     boolean existsByUserIdAndCouponId(Long userId, Long couponId);
+
+    /**
+     * 해당 쿠폰을 사용한 이력이 있는지 확인 (관리자 삭제 가능 여부 판단)
+     */
+    boolean existsByCouponId(Long couponId);
 }

--- a/src/main/java/com/example/egobook_be/domain/coupon/service/AdminCouponService.java
+++ b/src/main/java/com/example/egobook_be/domain/coupon/service/AdminCouponService.java
@@ -203,25 +203,32 @@ public class AdminCouponService {
         if (coupon.getTargetType() != CouponTargetType.INDIVIDUAL) {
             throw new CustomException(CouponErrorCode.NOTIFY_TARGET_NOT_INDIVIDUAL);
         }
-        if (coupon.isNotified()) {
-            throw new CustomException(CouponErrorCode.COUPON_ALREADY_NOTIFIED);
-        }
-        if (coupon.isExpired(LocalDateTime.now())) {
+        LocalDateTime now = LocalDateTime.now();
+        if (coupon.isExpired(now)) {
             throw new CustomException(CouponErrorCode.COUPON_EXPIRED);
+        }
+
+        // 조건부 UPDATE로 전송 권한을 선점한다. 동시 요청 시 한쪽만 성공해 푸시 중복 발송을 막는다.
+        if (couponRepository.markNotifiedIfNotYet(couponId, now) == 0) {
+            throw new CustomException(CouponErrorCode.COUPON_ALREADY_NOTIFIED);
         }
 
         User receiver = userRepository.findByAccountCode(coupon.getTargetAccountCode())
                 .orElseThrow(() -> new CustomException(CouponErrorCode.TARGET_USER_NOT_FOUND));
 
-        // 알림이 생성되지 않았는데 전송 완료로 표시하면 재전송이 영구히 막히므로 예외로 알린다.
+        // 알림이 생성되지 않았는데 전송 완료로 남으면 재전송이 영구히 막히므로, 예외로 트랜잭션을 롤백시킨다.
         boolean created = notificationService.createCouponNotification(receiver, coupon.getId(), coupon.getCode());
         if (!created) {
             throw new CustomException(CouponErrorCode.RECEIVER_NOTIFICATION_DISABLED);
         }
-        coupon.markNotified();
 
         log.info("[AdminCouponService] sendCouponNotification() - END | couponId: {}", couponId);
-        return couponMapper.toCouponAdminNotifyResDto(coupon, 1);
+        return CouponAdminNotifyResDto.builder()
+                .couponId(couponId)
+                .notified(true)
+                .notifiedAt(now)
+                .sentCount(1)
+                .build();
     }
 
     // ===== private =====

--- a/src/main/java/com/example/egobook_be/domain/coupon/service/AdminCouponService.java
+++ b/src/main/java/com/example/egobook_be/domain/coupon/service/AdminCouponService.java
@@ -1,0 +1,317 @@
+package com.example.egobook_be.domain.coupon.service;
+
+import com.example.egobook_be.domain.coupon.dto.*;
+import com.example.egobook_be.domain.coupon.entity.Coupon;
+import com.example.egobook_be.domain.coupon.entity.CouponReward;
+import com.example.egobook_be.domain.coupon.enums.CouponRewardType;
+import com.example.egobook_be.domain.coupon.enums.CouponTargetType;
+import com.example.egobook_be.domain.coupon.exception.CouponErrorCode;
+import com.example.egobook_be.domain.coupon.mapper.CouponMapper;
+import com.example.egobook_be.domain.coupon.repository.CouponRepository;
+import com.example.egobook_be.domain.coupon.repository.UserCouponRepository;
+import com.example.egobook_be.domain.notification.service.NotificationService;
+import com.example.egobook_be.domain.shop.entity.Item;
+import com.example.egobook_be.domain.shop.repository.ItemRepository;
+import com.example.egobook_be.domain.user.entity.User;
+import com.example.egobook_be.domain.user.repository.UserRepository;
+import com.example.egobook_be.global.exception.CustomException;
+import com.example.egobook_be.global.response.SliceResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdminCouponService {
+
+    private final CouponRepository couponRepository;
+    private final UserCouponRepository userCouponRepository;
+    private final UserRepository userRepository;
+    private final ItemRepository itemRepository;
+    private final NotificationService notificationService;
+    private final CouponMapper couponMapper;
+
+    /**
+     * 쿠폰을 등록한다.
+     * @param reqDto : 코드, 대상, 계정 고유 코드(개인 시), 보상 목록, 만료 일시
+     */
+    @Transactional
+    public CouponAdminResDto createCoupon(CouponAdminCreateReqDto reqDto) {
+        log.info("[AdminCouponService] createCoupon() - START | code: {}", reqDto.code());
+
+        String code = reqDto.code().trim();
+        if (couponRepository.existsByCode(code)) {
+            throw new CustomException(CouponErrorCode.DUPLICATED_CODE);
+        }
+
+        String targetAccountCode = resolveTargetAccountCode(reqDto.targetType(), reqDto.targetAccountCode());
+
+        Coupon coupon = Coupon.builder()
+                .code(code)
+                .targetType(reqDto.targetType())
+                .targetAccountCode(targetAccountCode)
+                .expiresAt(reqDto.expiresAt())
+                .build();
+        buildRewards(reqDto.rewards()).forEach(coupon::addReward);
+
+        Coupon saved = couponRepository.save(coupon);
+        CouponAdminResDto result = couponMapper.toCouponAdminResDto(saved);
+
+        log.info("[AdminCouponService] createCoupon() - END | couponId: {}", saved.getId());
+        return result;
+    }
+
+    /**
+     * 전체 쿠폰 목록을 등록 최신순으로 조회한다. (만료된 쿠폰 포함)
+     * - 만료 여부는 응답의 expiresAt으로 프론트에서 구분해 표시한다.
+     * - 컬렉션 fetch join + 페이징의 메모리 페이징을 피하기 위해 ID 조회 후 일괄 fetch 방식으로 처리한다.
+     * @param page : 페이지 번호 (1 ~ N, 프론트 기준)
+     * @param size : 페이지 크기
+     */
+    @Transactional(readOnly = true)
+    public SliceResponse<CouponAdminResDto> getCoupons(int page, int size) {
+        log.info("[AdminCouponService] getCoupons() - START | page: {}", page);
+
+        Pageable pageable = PageRequest.of(page - 1, size);
+        Slice<Long> idSlice = couponRepository.findCouponIds(pageable);
+
+        List<CouponAdminResDto> content = Collections.emptyList();
+        if (!idSlice.getContent().isEmpty()) {
+            Map<Long, Coupon> couponMap = couponRepository.findAllWithRewardsByIdIn(idSlice.getContent())
+                    .stream()
+                    .collect(Collectors.toMap(Coupon::getId, Function.identity()));
+
+            // 최신순 정렬은 ID 조회 결과를 기준으로 유지한다.
+            content = idSlice.getContent().stream()
+                    .map(couponMap::get)
+                    .filter(Objects::nonNull)
+                    .map(couponMapper::toCouponAdminResDto)
+                    .toList();
+        }
+
+        SliceResponse<CouponAdminResDto> result = SliceResponse.<CouponAdminResDto>builder()
+                .content(content)
+                .page(idSlice.getNumber() + 1)
+                .size(idSlice.getSize())
+                .hasNext(idSlice.hasNext())
+                .build();
+
+        log.info("[AdminCouponService] getCoupons() - END | resultSize: {}", content.size());
+        return result;
+    }
+
+    /** 쿠폰 단건을 조회한다. (수정 팝업 프리필용) */
+    @Transactional(readOnly = true)
+    public CouponAdminResDto getCoupon(Long couponId) {
+        Coupon coupon = couponRepository.findByIdWithRewards(couponId)
+                .orElseThrow(() -> new CustomException(CouponErrorCode.COUPON_NOT_FOUND));
+        return couponMapper.toCouponAdminResDto(coupon);
+    }
+
+    /**
+     * 쿠폰을 수정한다. 보상 목록은 전달받은 값으로 전체 교체된다.
+     */
+    @Transactional
+    public CouponAdminResDto updateCoupon(Long couponId, CouponAdminUpdateReqDto reqDto) {
+        log.info("[AdminCouponService] updateCoupon() - START | couponId: {}", couponId);
+
+        Coupon coupon = couponRepository.findByIdWithRewards(couponId)
+                .orElseThrow(() -> new CustomException(CouponErrorCode.COUPON_NOT_FOUND));
+
+        String code = reqDto.code().trim();
+
+        // 사용 이력이 있으면 지급 내역과 어긋나므로 코드/대상/보상 변경을 막고 만료일만 허용한다.
+        if (userCouponRepository.existsByCouponId(couponId)) {
+            boolean changed = !coupon.getCode().equals(code)
+                    || coupon.getTargetType() != reqDto.targetType()
+                    || !Objects.equals(coupon.getTargetAccountCode(), trimOrNull(reqDto.targetAccountCode()))
+                    || isRewardChanged(coupon, reqDto.rewards());
+
+            if (changed) {
+                throw new CustomException(CouponErrorCode.USED_COUPON_LIMITED_UPDATE);
+            }
+        }
+
+        if (couponRepository.existsByCodeAndIdNot(code, couponId)) {
+            throw new CustomException(CouponErrorCode.DUPLICATED_CODE);
+        }
+
+        String targetAccountCode = resolveTargetAccountCode(reqDto.targetType(), reqDto.targetAccountCode());
+
+        coupon.update(code, reqDto.targetType(), targetAccountCode, reqDto.expiresAt());
+        coupon.replaceRewards(buildRewards(reqDto.rewards()));
+
+        CouponAdminResDto result = couponMapper.toCouponAdminResDto(coupon);
+
+        log.info("[AdminCouponService] updateCoupon() - END | couponId: {}", couponId);
+        return result;
+    }
+
+    /**
+     * 쿠폰을 삭제한다.
+     * - 사용 이력(user_coupon)이 있으면 지급 내역 추적이 끊기고 FK 제약에도 걸리므로 삭제를 막는다.
+     */
+    @Transactional
+    public void deleteCoupon(Long couponId) {
+        log.info("[AdminCouponService] deleteCoupon() - START | couponId: {}", couponId);
+
+        if (!couponRepository.existsById(couponId)) {
+            throw new CustomException(CouponErrorCode.COUPON_NOT_FOUND);
+        }
+        if (userCouponRepository.existsByCouponId(couponId)) {
+            throw new CustomException(CouponErrorCode.COUPON_ALREADY_USED_CANNOT_DELETE);
+        }
+        couponRepository.deleteById(couponId);
+
+        log.info("[AdminCouponService] deleteCoupon() - END | couponId: {}", couponId);
+    }
+
+    /**
+     * 개인 대상 쿠폰의 코드가 담긴 알림을 해당 유저에게 전송한다.
+     * - 전송 성공 시 notifiedAt을 기록하여 '전송 완료' 버튼 상태를 만든다.
+     */
+    @Transactional
+    public CouponAdminNotifyResDto sendCouponNotification(Long couponId) {
+        log.info("[AdminCouponService] sendCouponNotification() - START | couponId: {}", couponId);
+
+        Coupon coupon = couponRepository.findById(couponId)
+                .orElseThrow(() -> new CustomException(CouponErrorCode.COUPON_NOT_FOUND));
+
+        if (coupon.getTargetType() != CouponTargetType.INDIVIDUAL) {
+            throw new CustomException(CouponErrorCode.NOTIFY_TARGET_NOT_INDIVIDUAL);
+        }
+        if (coupon.isNotified()) {
+            throw new CustomException(CouponErrorCode.COUPON_ALREADY_NOTIFIED);
+        }
+        if (coupon.isExpired(LocalDateTime.now())) {
+            throw new CustomException(CouponErrorCode.COUPON_EXPIRED);
+        }
+
+        User receiver = userRepository.findByAccountCode(coupon.getTargetAccountCode())
+                .orElseThrow(() -> new CustomException(CouponErrorCode.TARGET_USER_NOT_FOUND));
+
+        // 알림이 생성되지 않았는데 전송 완료로 표시하면 재전송이 영구히 막히므로 예외로 알린다.
+        boolean created = notificationService.createCouponNotification(receiver, coupon.getId(), coupon.getCode());
+        if (!created) {
+            throw new CustomException(CouponErrorCode.RECEIVER_NOTIFICATION_DISABLED);
+        }
+        coupon.markNotified();
+
+        log.info("[AdminCouponService] sendCouponNotification() - END | couponId: {}", couponId);
+        return couponMapper.toCouponAdminNotifyResDto(coupon, 1);
+    }
+
+    // ===== private =====
+
+    /**
+     * 대상 구분에 따라 계정 고유 코드를 검증하고 저장할 값을 결정한다.
+     * - 존재하지 않는 계정 코드가 저장되면 아무도 쓸 수 없는 쿠폰이 되므로 등록 시점에 검증한다.
+     */
+    private String resolveTargetAccountCode(CouponTargetType targetType, String accountCode) {
+        boolean hasAccountCode = accountCode != null && !accountCode.isBlank();
+
+        if (targetType == CouponTargetType.ALL) {
+            if (hasAccountCode) {
+                throw new CustomException(CouponErrorCode.TARGET_ACCOUNT_CODE_NOT_ALLOWED);
+            }
+            return null;
+        }
+
+        if (!hasAccountCode) {
+            throw new CustomException(CouponErrorCode.TARGET_ACCOUNT_CODE_REQUIRED);
+        }
+        String trimmed = accountCode.trim();
+        if (!userRepository.existsByAccountCode(trimmed)) {
+            throw new CustomException(CouponErrorCode.TARGET_USER_NOT_FOUND);
+        }
+        return trimmed;
+    }
+
+    /**
+     * 요청 DTO를 CouponReward 목록으로 변환한다.
+     * - 배열 인덱스를 sortOrder로 저장하여 유저 팝업 노출 순서를 보장한다.
+     * - 아이템 존재 여부는 IN 절로 한 번에 검증한다.
+     */
+    private List<CouponReward> buildRewards(List<CouponAdminRewardReqDto> reqDtos) {
+        if (reqDtos == null || reqDtos.isEmpty()) {
+            throw new CustomException(CouponErrorCode.REWARD_REQUIRED);
+        }
+
+        Set<Long> existingItemIds = findExistingItemIds(reqDtos);
+
+        List<CouponReward> rewards = new ArrayList<>();
+        for (int i = 0; i < reqDtos.size(); i++) {
+            CouponAdminRewardReqDto reqDto = reqDtos.get(i);
+
+            if (reqDto.rewardType() == CouponRewardType.INK) {
+                if (reqDto.inkAmount() == null || reqDto.inkAmount() <= 0) {
+                    throw new CustomException(CouponErrorCode.INVALID_REWARD);
+                }
+                rewards.add(CouponReward.ofInk(reqDto.inkAmount(), i));
+
+            } else {
+                if (reqDto.itemId() == null) {
+                    throw new CustomException(CouponErrorCode.INVALID_REWARD);
+                }
+                if (!existingItemIds.contains(reqDto.itemId())) {
+                    throw new CustomException(CouponErrorCode.REWARD_ITEM_NOT_FOUND);
+                }
+                rewards.add(CouponReward.ofItem(reqDto.itemId(), i));
+            }
+        }
+        return rewards;
+    }
+
+    /** 요청에 포함된 아이템 ID 중 실제 존재하는 것들을 IN 절로 한 번에 조회한다. */
+    private Set<Long> findExistingItemIds(List<CouponAdminRewardReqDto> reqDtos) {
+        List<Long> itemIds = reqDtos.stream()
+                .filter(r -> r.rewardType() == CouponRewardType.ITEM)
+                .map(CouponAdminRewardReqDto::itemId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+
+        if (itemIds.isEmpty()) {
+            return Collections.emptySet();
+        }
+        return itemRepository.findAllById(itemIds).stream()
+                .map(Item::getId)
+                .collect(Collectors.toSet());
+    }
+
+    private String trimOrNull(String value) {
+        return (value == null || value.isBlank()) ? null : value.trim();
+    }
+
+    /** 보상 구성(타입/수량/아이템/순서)이 달라졌는지 비교한다. */
+    private boolean isRewardChanged(Coupon coupon, List<CouponAdminRewardReqDto> reqDtos) {
+        List<CouponReward> current = coupon.getRewards().stream()
+                .sorted(Comparator.comparing(CouponReward::getSortOrder))
+                .toList();
+
+        if (current.size() != reqDtos.size()) {
+            return true;
+        }
+        for (int i = 0; i < current.size(); i++) {
+            CouponReward now = current.get(i);
+            CouponAdminRewardReqDto req = reqDtos.get(i);
+
+            if (now.getRewardType() != req.rewardType()
+                    || !Objects.equals(now.getInkAmount(), req.inkAmount())
+                    || !Objects.equals(now.getItemId(), req.itemId())) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/example/egobook_be/domain/coupon/service/AdminCouponService.java
+++ b/src/main/java/com/example/egobook_be/domain/coupon/service/AdminCouponService.java
@@ -15,6 +15,7 @@ import com.example.egobook_be.domain.shop.repository.ItemRepository;
 import com.example.egobook_be.domain.user.entity.User;
 import com.example.egobook_be.domain.user.repository.UserRepository;
 import com.example.egobook_be.global.exception.CustomException;
+import com.example.egobook_be.global.exception.GlobalErrorCode;
 import com.example.egobook_be.global.response.SliceResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -81,6 +82,13 @@ public class AdminCouponService {
     @Transactional(readOnly = true)
     public SliceResponse<CouponAdminResDto> getCoupons(int page, int size) {
         log.info("[AdminCouponService] getCoupons() - START | page: {}", page);
+
+        if (page < 1) {
+            throw new CustomException(GlobalErrorCode.INVALID_SLICE_VALUE);
+        }
+        if (size < 1 || size > 100) {
+            throw new CustomException(GlobalErrorCode.INVALID_SIZE_VALUE);
+        }
 
         Pageable pageable = PageRequest.of(page - 1, size);
         Slice<Long> idSlice = couponRepository.findCouponIds(pageable);

--- a/src/main/java/com/example/egobook_be/domain/coupon/service/AdminCouponService.java
+++ b/src/main/java/com/example/egobook_be/domain/coupon/service/AdminCouponService.java
@@ -131,7 +131,8 @@ public class AdminCouponService {
         String code = reqDto.code().trim();
 
         // 사용 이력이 있으면 지급 내역과 어긋나므로 코드/대상/보상 변경을 막고 만료일만 허용한다.
-        if (userCouponRepository.existsByCouponId(couponId)) {
+        boolean used = userCouponRepository.existsByCouponId(couponId);
+        if (used) {
             boolean changed = !coupon.getCode().equals(code)
                     || coupon.getTargetType() != reqDto.targetType()
                     || !Objects.equals(coupon.getTargetAccountCode(), trimOrNull(reqDto.targetAccountCode()))
@@ -149,7 +150,11 @@ public class AdminCouponService {
         String targetAccountCode = resolveTargetAccountCode(reqDto.targetType(), reqDto.targetAccountCode());
 
         coupon.update(code, reqDto.targetType(), targetAccountCode, reqDto.expiresAt());
-        coupon.replaceRewards(buildRewards(reqDto.rewards()));
+
+        // 사용 이력이 있으면 보상이 이미 동일함이 검증됐으므로, 불필요한 삭제/재생성으로 rewardId가 바뀌지 않도록 교체를 건너뛴다.
+        if (!used) {
+            coupon.replaceRewards(buildRewards(reqDto.rewards()));
+        }
 
         CouponAdminResDto result = couponMapper.toCouponAdminResDto(coupon);
 

--- a/src/main/java/com/example/egobook_be/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/example/egobook_be/domain/coupon/service/CouponService.java
@@ -69,7 +69,7 @@ public class CouponService {
                 .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
 
         // 2. 쿠폰 조회 (보상 목록 fetch join)
-        Coupon coupon = couponRepository.findByCodeWithRewards(reqDto.code().trim().toUpperCase())
+        Coupon coupon = couponRepository.findByCodeWithRewards(reqDto.code().trim())
                 .orElseThrow(() -> new CustomException(CouponErrorCode.COUPON_NOT_FOUND));
 
         // 3. 만료 여부 확인

--- a/src/main/java/com/example/egobook_be/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/example/egobook_be/domain/coupon/service/CouponService.java
@@ -69,7 +69,7 @@ public class CouponService {
                 .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
 
         // 2. 쿠폰 조회 (보상 목록 fetch join)
-        Coupon coupon = couponRepository.findByCodeWithRewards(reqDto.code())
+        Coupon coupon = couponRepository.findByCodeWithRewards(reqDto.code().trim().toUpperCase())
                 .orElseThrow(() -> new CustomException(CouponErrorCode.COUPON_NOT_FOUND));
 
         // 3. 만료 여부 확인

--- a/src/main/java/com/example/egobook_be/domain/notice/controller/AdminNoticeController.java
+++ b/src/main/java/com/example/egobook_be/domain/notice/controller/AdminNoticeController.java
@@ -2,6 +2,7 @@ package com.example.egobook_be.domain.notice.controller;
 
 import com.example.egobook_be.domain.notice.dto.NoticeAdminResDto;
 import com.example.egobook_be.domain.notice.dto.NoticeCreateReqDto;
+import com.example.egobook_be.domain.notice.dto.NoticeReadResetResDto;
 import com.example.egobook_be.domain.notice.dto.NoticeUpdateReqDto;
 import com.example.egobook_be.domain.notice.service.AdminNoticeService;
 import com.example.egobook_be.global.response.GlobalResponse;
@@ -53,5 +54,13 @@ public class AdminNoticeController implements AdminNoticeControllerDocs {
     public ResponseEntity<GlobalResponse<Void>> deleteNotice(@PathVariable Long noticeId) {
         adminNoticeService.deleteNotice(noticeId);
         return ResponseEntity.ok(GlobalResponse.success("공지사항 삭제 성공", null));
+    }
+
+    @Override
+    @PostMapping("/reads/reset")
+    public ResponseEntity<GlobalResponse<NoticeReadResetResDto>> resetNoticeReads() {
+        return ResponseEntity.ok(
+                GlobalResponse.success("공지 읽음 기록 초기화 성공", adminNoticeService.resetNoticeReads())
+        );
     }
 }

--- a/src/main/java/com/example/egobook_be/domain/notice/controller/AdminNoticeControllerDocs.java
+++ b/src/main/java/com/example/egobook_be/domain/notice/controller/AdminNoticeControllerDocs.java
@@ -2,6 +2,7 @@ package com.example.egobook_be.domain.notice.controller;
 
 import com.example.egobook_be.domain.notice.dto.NoticeAdminResDto;
 import com.example.egobook_be.domain.notice.dto.NoticeCreateReqDto;
+import com.example.egobook_be.domain.notice.dto.NoticeReadResetResDto;
 import com.example.egobook_be.domain.notice.dto.NoticeUpdateReqDto;
 import com.example.egobook_be.global.response.GlobalResponse;
 import com.example.egobook_be.global.response.SliceResponse;
@@ -49,4 +50,16 @@ public interface AdminNoticeControllerDocs {
     @Operation(summary = "[관리자] 공지사항 삭제")
     @SecurityRequirement(name = "bearerAuth")
     ResponseEntity<GlobalResponse<Void>> deleteNotice(@PathVariable Long noticeId);
+
+    @Operation(summary = "[관리자] 공지 읽음 기록 초기화", description = """
+            현재 노출 중인 최신 공지의 읽음 기록을 전부 삭제합니다.
+            읽음 기록이 없으면 안 읽음으로 간주하는 구조라, 결과적으로 모든 유저의 공지 아이콘에 레드닷이 다시 노출됩니다.
+
+            [주의사항]
+            - 이미 공지를 확인한 유저에게도 레드닷이 다시 뜹니다.
+            - 중복 실행을 서버에서 막지 않으므로, 실행 전 확인 팝업을 띄워주세요.
+            - 발행된 공지가 하나도 없으면 400을 반환합니다.
+            """)
+    @SecurityRequirement(name = "bearerAuth")
+    ResponseEntity<GlobalResponse<NoticeReadResetResDto>> resetNoticeReads();
 }

--- a/src/main/java/com/example/egobook_be/domain/notice/dto/NoticeReadResetResDto.java
+++ b/src/main/java/com/example/egobook_be/domain/notice/dto/NoticeReadResetResDto.java
@@ -1,0 +1,20 @@
+package com.example.egobook_be.domain.notice.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "[관리자] 전체 유저 공지 레드닷 전송 응답 DTO")
+public record NoticeReadResetResDto(
+        @Schema(description = "대상 공지 PK", example = "3")
+        Long noticeId,
+
+        @Schema(description = "대상 공지 제목", example = "8월 업데이트 안내")
+        String title,
+
+        @Schema(description = "읽음 처리가 해제된 유저 수", example = "128")
+        int clearedReadCount,
+
+        @Schema(description = "실행 일시", example = "2026-08-11T14:20:03")
+        LocalDateTime resetAt
+) {}

--- a/src/main/java/com/example/egobook_be/domain/notice/exception/NoticeErrorCode.java
+++ b/src/main/java/com/example/egobook_be/domain/notice/exception/NoticeErrorCode.java
@@ -11,7 +11,9 @@ public enum NoticeErrorCode implements BaseErrorCode {
 
     NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "공지사항을 찾을 수 없습니다."),
 
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다.");
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),
+
+    NO_PUBLISHED_NOTICE(HttpStatus.BAD_REQUEST, "읽음 기록을 초기화할 공지사항이 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/egobook_be/domain/notice/repository/NoticeReadRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/notice/repository/NoticeReadRepository.java
@@ -17,8 +17,18 @@ public interface NoticeReadRepository extends JpaRepository<NoticeRead, Long> {
      * @return : 읽음 여부
      */
     boolean existsByUserAndNotice(User user, Notice notice);
-    
+
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(value = "INSERT IGNORE INTO notice_read (user_id, notice_id, created_at, updated_at) VALUES (:userId, :noticeId, NOW(6), NOW(6))", nativeQuery = true)
     void insertIfNotExists(@Param("userId") Long userId, @Param("noticeId") Long noticeId);
+
+    /**
+     * 해당 공지의 읽음 기록을 모두 삭제한다. (전체 유저 레드닷 재점등)
+     * - 읽음 row가 없으면 안 읽음으로 간주하므로, 삭제만으로 모든 유저에게 레드닷이 다시 뜬다.
+     * @param noticeId : 대상 공지 PK
+     * @return : 삭제된 읽음 기록 수
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from NoticeRead nr where nr.notice.id = :noticeId")
+    int deleteAllByNoticeId(@Param("noticeId") Long noticeId);
 }

--- a/src/main/java/com/example/egobook_be/domain/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/notice/repository/NoticeRepository.java
@@ -19,8 +19,9 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
 
     /**
      * 현재 노출 중인(발행 시각이 지난) 공지 중 가장 최근 것을 조회한다.
+     * - publishedAt이 같은 공지가 있을 때 순서가 흔들리지 않도록 id를 보조 정렬 기준으로 둔다.
      * @param now : 기준 시각
      * @return : 최신 공지 (없으면 Optional.empty())
      */
-    Optional<Notice> findFirstByPublishedAtLessThanEqualOrderByPublishedAtDesc(LocalDateTime now);
+    Optional<Notice> findFirstByPublishedAtLessThanEqualOrderByPublishedAtDescIdDesc(LocalDateTime now);
 }

--- a/src/main/java/com/example/egobook_be/domain/notice/service/AdminNoticeService.java
+++ b/src/main/java/com/example/egobook_be/domain/notice/service/AdminNoticeService.java
@@ -2,10 +2,12 @@ package com.example.egobook_be.domain.notice.service;
 
 import com.example.egobook_be.domain.notice.dto.NoticeAdminResDto;
 import com.example.egobook_be.domain.notice.dto.NoticeCreateReqDto;
+import com.example.egobook_be.domain.notice.dto.NoticeReadResetResDto;
 import com.example.egobook_be.domain.notice.dto.NoticeUpdateReqDto;
 import com.example.egobook_be.domain.notice.entity.Notice;
 import com.example.egobook_be.domain.notice.exception.NoticeErrorCode;
 import com.example.egobook_be.domain.notice.mapper.NoticeMapper;
+import com.example.egobook_be.domain.notice.repository.NoticeReadRepository;
 import com.example.egobook_be.domain.notice.repository.NoticeRepository;
 import com.example.egobook_be.global.exception.CustomException;
 import com.example.egobook_be.global.response.SliceResponse;
@@ -16,12 +18,15 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class AdminNoticeService {
 
     private final NoticeRepository noticeRepository;
+    private final NoticeReadRepository noticeReadRepository;
     private final NoticeMapper noticeMapper;
 
     /**
@@ -99,5 +104,26 @@ public class AdminNoticeService {
         noticeRepository.deleteById(noticeId);
 
         log.info("[AdminNoticeService] deleteNotice() - END | noticeId: {}", noticeId);
+    }
+
+    /**
+     * 현재 노출 중인 최신 공지의 읽음 기록을 전부 지워 모든 유저에게 레드닷을 다시 노출시킨다.
+     * - 읽음 row가 없으면 안 읽음으로 간주하는 구조라, 삭제만으로 전체 레드닷이 켜진다.
+     * @return : 대상 공지 정보와 해제된 읽음 기록 수
+     */
+    @Transactional
+    public NoticeReadResetResDto resetNoticeReads() {
+        log.info("[AdminNoticeService] resetNoticeReads() - START");
+
+        LocalDateTime now = LocalDateTime.now();
+        Notice notice = noticeRepository
+                .findFirstByPublishedAtLessThanEqualOrderByPublishedAtDesc(now)
+                .orElseThrow(() -> new CustomException(NoticeErrorCode.NO_PUBLISHED_NOTICE));
+
+        int clearedReadCount = noticeReadRepository.deleteAllByNoticeId(notice.getId());
+
+        log.info("[AdminNoticeService] resetNoticeReads() - END | noticeId: {}, clearedReadCount: {}",
+                notice.getId(), clearedReadCount);
+        return new NoticeReadResetResDto(notice.getId(), notice.getTitle(), clearedReadCount, now);
     }
 }

--- a/src/main/java/com/example/egobook_be/domain/notice/service/AdminNoticeService.java
+++ b/src/main/java/com/example/egobook_be/domain/notice/service/AdminNoticeService.java
@@ -117,7 +117,7 @@ public class AdminNoticeService {
 
         LocalDateTime now = LocalDateTime.now();
         Notice notice = noticeRepository
-                .findFirstByPublishedAtLessThanEqualOrderByPublishedAtDesc(now)
+                .findFirstByPublishedAtLessThanEqualOrderByPublishedAtDescIdDesc(now)
                 .orElseThrow(() -> new CustomException(NoticeErrorCode.NO_PUBLISHED_NOTICE));
 
         int clearedReadCount = noticeReadRepository.deleteAllByNoticeId(notice.getId());

--- a/src/main/java/com/example/egobook_be/domain/notice/service/NoticeService.java
+++ b/src/main/java/com/example/egobook_be/domain/notice/service/NoticeService.java
@@ -34,7 +34,7 @@ public class NoticeService {
                 .orElseThrow(() -> new CustomException(NoticeErrorCode.USER_NOT_FOUND));
 
         Notice notice = noticeRepository
-                .findFirstByPublishedAtLessThanEqualOrderByPublishedAtDesc(LocalDateTime.now())
+                .findFirstByPublishedAtLessThanEqualOrderByPublishedAtDescIdDesc(LocalDateTime.now())
                 .orElse(null);
 
         NoticeLatestResDto result = null;
@@ -56,7 +56,7 @@ public class NoticeService {
                 .orElseThrow(() -> new CustomException(NoticeErrorCode.USER_NOT_FOUND));
 
         Notice notice = noticeRepository
-                .findFirstByPublishedAtLessThanEqualOrderByPublishedAtDesc(LocalDateTime.now())
+                .findFirstByPublishedAtLessThanEqualOrderByPublishedAtDescIdDesc(LocalDateTime.now())
                 .orElse(null);
 
         boolean hasUnreadNotice = notice != null && !noticeReadRepository.existsByUserAndNotice(user, notice);

--- a/src/main/java/com/example/egobook_be/domain/notification/entity/Notification.java
+++ b/src/main/java/com/example/egobook_be/domain/notification/entity/Notification.java
@@ -29,7 +29,7 @@ public class Notification extends BaseTimeEntity {
     @Column(nullable = false)
     private String title;
 
-    @Column(length = 17)
+    @Column(length = 50)
     private String content;
 
     @Column(nullable = false)

--- a/src/main/java/com/example/egobook_be/domain/notification/enums/NotificationType.java
+++ b/src/main/java/com/example/egobook_be/domain/notification/enums/NotificationType.java
@@ -11,7 +11,8 @@ public enum NotificationType {
     LETTER_NEW("새로운 편지가 도착했어요!"),
     LETTER_NEW_FRIEND("새로운 %s님 편지가 도착했어요!"),
     PRAISE("%s 일간 칭찬서가 도착했어요!"),
-    REPORT("지난주 주간 리포트가 도착했어요!");
+    REPORT("지난주 주간 리포트가 도착했어요!"),
+    COUPON("오늘의 질문 답변이 선정되어 쿠폰이 도착했어요!");
 
     private final String title;
 

--- a/src/main/java/com/example/egobook_be/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/example/egobook_be/domain/notification/service/NotificationService.java
@@ -75,6 +75,34 @@ public class NotificationService {
         log.info("[NotificationService] createNotification End - userId: {}, targetId: {}", userId, targetId);
     }
 
+    /**
+     * 개인 대상 쿠폰의 코드가 담긴 알림을 생성한다.
+     * - 오늘의 질문 답변 선정 보상으로 지급되는 쿠폰이며, 제목은 고정이고 content에 쿠폰 코드를 싣는다.
+     * @param user : 알림을 받을 유저
+     * @param couponId : 대상 쿠폰 PK
+     * @param code : 쿠폰 코드
+     * @return : 알림이 생성되었으면 true, 유저가 알림을 꺼두어 생성하지 않았으면 false
+     */
+    @Transactional
+    public boolean createCouponNotification(User user, Long couponId, String code) {
+        if (!user.isNotificationEnabled()) {
+            log.warn("[NotificationService] 알림 설정 꺼짐으로 쿠폰 알림 미생성 - userId: {}", user.getId());
+            return false;
+        }
+
+        Notification notification = Notification.builder()
+                .user(user)
+                .type(NotificationType.COUPON)
+                .title(NotificationType.COUPON.getTitle())
+                .content("쿠폰코드 : " + code)
+                .targetId(couponId)
+                .build();
+
+        notificationRepository.save(notification);
+        fcmService.sendPushNotification(user, notification);
+        return true;
+    }
+
     /** 알림 목록 (공지사항은 /notices API로 분리되어 있음) */
     @Transactional
     public SliceResponse<NotificationResDto> getNotifications(Long userId, int page, int size) {

--- a/src/main/java/com/example/egobook_be/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/user/repository/UserRepository.java
@@ -97,4 +97,7 @@ public interface UserRepository extends JpaRepository<User, Long>,UserRepository
     Slice<SearchUserResDto> findUsersByStatus(@Param("status") UserStatus status, Pageable pageable);
 
     Long countByCreatedAtBefore(LocalDateTime createdAtBefore);
+
+    /** 개인 대상 쿠폰 알림 전송 시 계정 고유 코드로 유저를 조회한다. */
+    Optional<User> findByAccountCode(String accountCode);
 }

--- a/src/test/java/com/example/egobook_be/domain/coupon/service/AdminCouponServiceUnitTest.java
+++ b/src/test/java/com/example/egobook_be/domain/coupon/service/AdminCouponServiceUnitTest.java
@@ -211,8 +211,9 @@ public class AdminCouponServiceUnitTest {
         void success_updateUsedCouponExpiresOnly() {
             // Given
             Long couponId = 1L;
+            CouponReward originalReward = inkReward(100, 0);
             Coupon coupon = buildCoupon(couponId, "USED01", CouponTargetType.INDIVIDUAL, "USER01", FUTURE,
-                    List.of(inkReward(100, 0)));
+                    List.of(originalReward));
 
             given(couponRepository.findByIdWithRewards(couponId)).willReturn(Optional.of(coupon));
             given(userCouponRepository.existsByCouponId(couponId)).willReturn(true);
@@ -226,8 +227,11 @@ public class AdminCouponServiceUnitTest {
             // When
             CouponAdminResDto result = adminCouponService.updateCoupon(couponId, reqDto);
 
-            // Then
+            // ========= Then =========
             assertThat(result.expiresAt()).isEqualTo(extended);
+            // 사용 이력이 있으면 보상 인스턴스가 그대로 유지되어야 한다.
+            assertThat(coupon.getRewards()).hasSize(1);
+            assertThat(coupon.getRewards().get(0)).isSameAs(originalReward);
         }
 
         @Test

--- a/src/test/java/com/example/egobook_be/domain/coupon/service/AdminCouponServiceUnitTest.java
+++ b/src/test/java/com/example/egobook_be/domain/coupon/service/AdminCouponServiceUnitTest.java
@@ -255,7 +255,7 @@ public class AdminCouponServiceUnitTest {
     class NotifySuccessCases {
 
         @Test
-        @DisplayName("[성공 7] 개인 쿠폰 알림 전송 - 전송 후 notifiedAt 기록")
+        @DisplayName("[성공 7] 개인 쿠폰 알림 전송 - 조건부 UPDATE 선점 후 전송")
         void success_sendNotification() {
             // Given
             Long couponId = 1L;
@@ -264,6 +264,7 @@ public class AdminCouponServiceUnitTest {
                     List.of(inkReward(100, 0)));
 
             given(couponRepository.findById(couponId)).willReturn(Optional.of(coupon));
+            given(couponRepository.markNotifiedIfNotYet(eq(couponId), any(LocalDateTime.class))).willReturn(1);
             given(userRepository.findByAccountCode("USER01")).willReturn(Optional.of(mockUser));
             given(notificationService.createCouponNotification(mockUser, couponId, "PRIVATE01"))
                     .willReturn(true);
@@ -275,9 +276,6 @@ public class AdminCouponServiceUnitTest {
             assertThat(result.notified()).isTrue();
             assertThat(result.notifiedAt()).isNotNull();
             assertThat(result.sentCount()).isEqualTo(1);
-            assertThat(coupon.isNotified()).isTrue();
-            verify(notificationService, times(1))
-                    .createCouponNotification(mockUser, couponId, "PRIVATE01");
         }
     }
 
@@ -465,15 +463,15 @@ public class AdminCouponServiceUnitTest {
         }
 
         @Test
-        @DisplayName("[실패 11] 이미 알림을 전송한 쿠폰")
+        @DisplayName("[실패 11] 이미 알림을 전송한 쿠폰 - 조건부 UPDATE가 0건이면 차단")
         void fail_alreadyNotified() {
             // Given
             Long couponId = 1L;
             Coupon coupon = buildCoupon(couponId, "PRIVATE01", CouponTargetType.INDIVIDUAL, "USER01", FUTURE,
                     List.of(inkReward(100, 0)));
-            coupon.markNotified();
 
             given(couponRepository.findById(couponId)).willReturn(Optional.of(coupon));
+            given(couponRepository.markNotifiedIfNotYet(eq(couponId), any(LocalDateTime.class))).willReturn(0);
 
             // When & Then
             CustomException exception = assertThrows(CustomException.class,
@@ -502,7 +500,7 @@ public class AdminCouponServiceUnitTest {
         }
 
         @Test
-        @DisplayName("[실패 13] 대상 유저가 알림을 꺼둔 경우 - notifiedAt을 기록하지 않아 재전송 가능")
+        @DisplayName("[실패 13] 대상 유저가 알림을 꺼둔 경우 - 예외로 롤백되어 재전송 가능")
         void fail_receiverNotificationDisabled() {
             // Given
             Long couponId = 1L;
@@ -511,6 +509,7 @@ public class AdminCouponServiceUnitTest {
                     List.of(inkReward(100, 0)));
 
             given(couponRepository.findById(couponId)).willReturn(Optional.of(coupon));
+            given(couponRepository.markNotifiedIfNotYet(eq(couponId), any(LocalDateTime.class))).willReturn(1);
             given(userRepository.findByAccountCode("USER01")).willReturn(Optional.of(mockUser));
             given(notificationService.createCouponNotification(mockUser, couponId, "PRIVATE01"))
                     .willReturn(false);
@@ -520,8 +519,6 @@ public class AdminCouponServiceUnitTest {
                     () -> adminCouponService.sendCouponNotification(couponId));
 
             assertThat(exception.getErrorCode()).isEqualTo(CouponErrorCode.RECEIVER_NOTIFICATION_DISABLED);
-            assertThat(coupon.isNotified()).isFalse();
-            assertThat(coupon.getNotifiedAt()).isNull();
         }
 
         @Test
@@ -533,6 +530,7 @@ public class AdminCouponServiceUnitTest {
                     List.of(inkReward(100, 0)));
 
             given(couponRepository.findById(couponId)).willReturn(Optional.of(coupon));
+            given(couponRepository.markNotifiedIfNotYet(eq(couponId), any(LocalDateTime.class))).willReturn(1);
             given(userRepository.findByAccountCode("GONE01")).willReturn(Optional.empty());
 
             // When & Then
@@ -540,7 +538,7 @@ public class AdminCouponServiceUnitTest {
                     () -> adminCouponService.sendCouponNotification(couponId));
 
             assertThat(exception.getErrorCode()).isEqualTo(CouponErrorCode.TARGET_USER_NOT_FOUND);
-            assertThat(coupon.isNotified()).isFalse();
+            verify(notificationService, never()).createCouponNotification(any(), anyLong(), anyString());
         }
     }
 }

--- a/src/test/java/com/example/egobook_be/domain/coupon/service/AdminCouponServiceUnitTest.java
+++ b/src/test/java/com/example/egobook_be/domain/coupon/service/AdminCouponServiceUnitTest.java
@@ -1,0 +1,542 @@
+package com.example.egobook_be.domain.coupon.service;
+
+import com.example.egobook_be.domain.coupon.dto.CouponAdminCreateReqDto;
+import com.example.egobook_be.domain.coupon.dto.CouponAdminNotifyResDto;
+import com.example.egobook_be.domain.coupon.dto.CouponAdminResDto;
+import com.example.egobook_be.domain.coupon.dto.CouponAdminRewardReqDto;
+import com.example.egobook_be.domain.coupon.dto.CouponAdminUpdateReqDto;
+import com.example.egobook_be.domain.coupon.entity.Coupon;
+import com.example.egobook_be.domain.coupon.entity.CouponReward;
+import com.example.egobook_be.domain.coupon.enums.CouponRewardType;
+import com.example.egobook_be.domain.coupon.enums.CouponTargetType;
+import com.example.egobook_be.domain.coupon.exception.CouponErrorCode;
+import com.example.egobook_be.domain.coupon.mapper.CouponMapper;
+import com.example.egobook_be.domain.coupon.repository.CouponRepository;
+import com.example.egobook_be.domain.coupon.repository.UserCouponRepository;
+import com.example.egobook_be.domain.notification.service.NotificationService;
+import com.example.egobook_be.domain.shop.entity.Item;
+import com.example.egobook_be.domain.shop.repository.ItemRepository;
+import com.example.egobook_be.domain.user.entity.User;
+import com.example.egobook_be.domain.user.repository.UserRepository;
+import com.example.egobook_be.global.exception.CustomException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class AdminCouponServiceUnitTest {
+
+    @InjectMocks private AdminCouponService adminCouponService;
+    @Mock private CouponRepository couponRepository;
+    @Mock private UserCouponRepository userCouponRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private ItemRepository itemRepository;
+    @Mock private NotificationService notificationService;
+
+    @Spy private CouponMapper couponMapper = new CouponMapper();
+
+    private static final LocalDateTime FUTURE = LocalDateTime.now().plusDays(30);
+
+    private Coupon buildCoupon(Long id, String code, CouponTargetType targetType,
+                               String targetAccountCode, LocalDateTime expiresAt,
+                               List<CouponReward> rewards) {
+        return Coupon.builder()
+                .id(id)
+                .code(code)
+                .targetType(targetType)
+                .targetAccountCode(targetAccountCode)
+                .expiresAt(expiresAt)
+                .rewards(new ArrayList<>(rewards))
+                .build();
+    }
+
+    private CouponReward inkReward(int amount, int sortOrder) {
+        return CouponReward.builder()
+                .rewardType(CouponRewardType.INK)
+                .inkAmount(amount)
+                .sortOrder(sortOrder)
+                .build();
+    }
+
+    private CouponAdminRewardReqDto inkReq(int amount) {
+        return new CouponAdminRewardReqDto(CouponRewardType.INK, amount, null);
+    }
+
+    private CouponAdminRewardReqDto itemReq(Long itemId) {
+        return new CouponAdminRewardReqDto(CouponRewardType.ITEM, null, itemId);
+    }
+
+    private CouponAdminCreateReqDto createReq(String code, CouponTargetType targetType,
+                                              String accountCode, List<CouponAdminRewardReqDto> rewards) {
+        return new CouponAdminCreateReqDto(code, targetType, accountCode, rewards, FUTURE);
+    }
+
+    private CouponAdminUpdateReqDto updateReq(String code, CouponTargetType targetType,
+                                              String accountCode, List<CouponAdminRewardReqDto> rewards,
+                                              LocalDateTime expiresAt) {
+        return new CouponAdminUpdateReqDto(code, targetType, accountCode, rewards, expiresAt);
+    }
+
+    /** save()가 인자로 받은 엔티티를 그대로 돌려주도록 설정한다. */
+    private void givenSaveReturnsArgument() {
+        given(couponRepository.save(any(Coupon.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    @Nested
+    @DisplayName("createCoupon() 성공 케이스")
+    class CreateSuccessCases {
+
+        @Test
+        @DisplayName("[성공 1] 전체 대상 쿠폰 등록 - 보상 배열 순서가 sortOrder로 저장됨")
+        void success_createAllTargetCoupon() {
+            // Given
+            CouponAdminCreateReqDto reqDto = createReq("EVENT01", CouponTargetType.ALL, null,
+                    List.of(inkReq(100), inkReq(24)));
+
+            given(couponRepository.existsByCode("EVENT01")).willReturn(false);
+            givenSaveReturnsArgument();
+
+            // When
+            CouponAdminResDto result = adminCouponService.createCoupon(reqDto);
+
+            // Then
+            assertThat(result.code()).isEqualTo("EVENT01");
+            assertThat(result.targetType()).isEqualTo(CouponTargetType.ALL);
+            assertThat(result.targetAccountCode()).isNull();
+            assertThat(result.rewards()).hasSize(2);
+            assertThat(result.rewards().get(0).inkAmount()).isEqualTo(100);
+            assertThat(result.rewards().get(1).inkAmount()).isEqualTo(24);
+            assertThat(result.notified()).isFalse();
+            verify(userRepository, never()).existsByAccountCode(anyString());
+        }
+
+        @Test
+        @DisplayName("[성공 2] 개인 대상 쿠폰 등록 - 계정 고유 코드 검증 후 저장")
+        void success_createIndividualCoupon() {
+            // Given
+            CouponAdminCreateReqDto reqDto = createReq("PRIVATE01", CouponTargetType.INDIVIDUAL, "USER01",
+                    List.of(inkReq(12)));
+
+            given(couponRepository.existsByCode("PRIVATE01")).willReturn(false);
+            given(userRepository.existsByAccountCode("USER01")).willReturn(true);
+            givenSaveReturnsArgument();
+
+            // When
+            CouponAdminResDto result = adminCouponService.createCoupon(reqDto);
+
+            // Then
+            assertThat(result.targetType()).isEqualTo(CouponTargetType.INDIVIDUAL);
+            assertThat(result.targetAccountCode()).isEqualTo("USER01");
+            verify(couponRepository, times(1)).save(any(Coupon.class));
+        }
+
+        @Test
+        @DisplayName("[성공 3] 혼합 보상 쿠폰 등록 - 아이템 존재 여부를 IN 절로 일괄 검증")
+        void success_createMixedRewards() {
+            // Given
+            Long itemId = 10L;
+            Item mockItem = mock(Item.class);
+            given(mockItem.getId()).willReturn(itemId);
+
+            CouponAdminCreateReqDto reqDto = createReq("MIXED01", CouponTargetType.ALL, null,
+                    List.of(inkReq(50), itemReq(itemId), inkReq(30)));
+
+            given(couponRepository.existsByCode("MIXED01")).willReturn(false);
+            given(itemRepository.findAllById(List.of(itemId))).willReturn(List.of(mockItem));
+            givenSaveReturnsArgument();
+
+            // When
+            CouponAdminResDto result = adminCouponService.createCoupon(reqDto);
+
+            // Then
+            assertThat(result.rewards()).hasSize(3);
+            assertThat(result.rewards().get(0).rewardType()).isEqualTo(CouponRewardType.INK);
+            assertThat(result.rewards().get(1).rewardType()).isEqualTo(CouponRewardType.ITEM);
+            assertThat(result.rewards().get(1).itemId()).isEqualTo(itemId);
+            assertThat(result.rewards().get(2).inkAmount()).isEqualTo(30);
+            verify(itemRepository, times(1)).findAllById(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("updateCoupon() / deleteCoupon() 성공 케이스")
+    class UpdateDeleteSuccessCases {
+
+        @Test
+        @DisplayName("[성공 4] 쿠폰 수정 - 보상 목록이 전달받은 값으로 전체 교체됨")
+        void success_updateReplacesRewards() {
+            // Given
+            Long couponId = 1L;
+            Coupon coupon = buildCoupon(couponId, "OLD01", CouponTargetType.ALL, null, FUTURE,
+                    List.of(inkReward(100, 0), inkReward(24, 1)));
+
+            given(couponRepository.findByIdWithRewards(couponId)).willReturn(Optional.of(coupon));
+            given(userCouponRepository.existsByCouponId(couponId)).willReturn(false);
+            given(couponRepository.existsByCodeAndIdNot("NEW01", couponId)).willReturn(false);
+
+            CouponAdminUpdateReqDto reqDto = updateReq("NEW01", CouponTargetType.ALL, null,
+                    List.of(inkReq(500)), FUTURE);
+
+            // When
+            CouponAdminResDto result = adminCouponService.updateCoupon(couponId, reqDto);
+
+            // Then
+            assertThat(result.code()).isEqualTo("NEW01");
+            assertThat(result.rewards()).hasSize(1);
+            assertThat(result.rewards().get(0).inkAmount()).isEqualTo(500);
+            assertThat(coupon.getRewards()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("[성공 5] 사용 이력 있는 쿠폰 - 만료일만 변경하면 수정 허용")
+        void success_updateUsedCouponExpiresOnly() {
+            // Given
+            Long couponId = 1L;
+            Coupon coupon = buildCoupon(couponId, "USED01", CouponTargetType.INDIVIDUAL, "USER01", FUTURE,
+                    List.of(inkReward(100, 0)));
+
+            given(couponRepository.findByIdWithRewards(couponId)).willReturn(Optional.of(coupon));
+            given(userCouponRepository.existsByCouponId(couponId)).willReturn(true);
+            given(couponRepository.existsByCodeAndIdNot("USED01", couponId)).willReturn(false);
+            given(userRepository.existsByAccountCode("USER01")).willReturn(true);
+
+            LocalDateTime extended = FUTURE.plusDays(30);
+            CouponAdminUpdateReqDto reqDto = updateReq("USED01", CouponTargetType.INDIVIDUAL, "USER01",
+                    List.of(inkReq(100)), extended);
+
+            // When
+            CouponAdminResDto result = adminCouponService.updateCoupon(couponId, reqDto);
+
+            // Then
+            assertThat(result.expiresAt()).isEqualTo(extended);
+        }
+
+        @Test
+        @DisplayName("[성공 6] 사용 이력 없는 쿠폰 삭제")
+        void success_deleteUnusedCoupon() {
+            // Given
+            Long couponId = 1L;
+            given(couponRepository.existsById(couponId)).willReturn(true);
+            given(userCouponRepository.existsByCouponId(couponId)).willReturn(false);
+
+            // When
+            adminCouponService.deleteCoupon(couponId);
+
+            // Then
+            verify(couponRepository, times(1)).deleteById(couponId);
+        }
+    }
+
+    @Nested
+    @DisplayName("sendCouponNotification() 성공 케이스")
+    class NotifySuccessCases {
+
+        @Test
+        @DisplayName("[성공 7] 개인 쿠폰 알림 전송 - 전송 후 notifiedAt 기록")
+        void success_sendNotification() {
+            // Given
+            Long couponId = 1L;
+            User mockUser = mock(User.class);
+            Coupon coupon = buildCoupon(couponId, "PRIVATE01", CouponTargetType.INDIVIDUAL, "USER01", FUTURE,
+                    List.of(inkReward(100, 0)));
+
+            given(couponRepository.findById(couponId)).willReturn(Optional.of(coupon));
+            given(userRepository.findByAccountCode("USER01")).willReturn(Optional.of(mockUser));
+            given(notificationService.createCouponNotification(mockUser, couponId, "PRIVATE01"))
+                    .willReturn(true);
+
+            // When
+            CouponAdminNotifyResDto result = adminCouponService.sendCouponNotification(couponId);
+
+            // Then
+            assertThat(result.notified()).isTrue();
+            assertThat(result.notifiedAt()).isNotNull();
+            assertThat(result.sentCount()).isEqualTo(1);
+            assertThat(coupon.isNotified()).isTrue();
+            verify(notificationService, times(1))
+                    .createCouponNotification(mockUser, couponId, "PRIVATE01");
+        }
+    }
+
+    @Nested
+    @DisplayName("createCoupon() 실패 케이스")
+    class CreateFailCases {
+
+        @Test
+        @DisplayName("[실패 1] 중복된 쿠폰 코드")
+        void fail_duplicatedCode() {
+            // Given
+            given(couponRepository.existsByCode("DUP01")).willReturn(true);
+            CouponAdminCreateReqDto reqDto = createReq("DUP01", CouponTargetType.ALL, null, List.of(inkReq(100)));
+
+            // When & Then
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> adminCouponService.createCoupon(reqDto));
+
+            assertThat(exception.getErrorCode()).isEqualTo(CouponErrorCode.DUPLICATED_CODE);
+            verify(couponRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("[실패 2] 개인 대상인데 계정 고유 코드 누락")
+        void fail_accountCodeRequired() {
+            // Given
+            given(couponRepository.existsByCode("PRIVATE01")).willReturn(false);
+            CouponAdminCreateReqDto reqDto = createReq("PRIVATE01", CouponTargetType.INDIVIDUAL, null,
+                    List.of(inkReq(100)));
+
+            // When & Then
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> adminCouponService.createCoupon(reqDto));
+
+            assertThat(exception.getErrorCode()).isEqualTo(CouponErrorCode.TARGET_ACCOUNT_CODE_REQUIRED);
+            verify(couponRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("[실패 3] 전체 대상인데 계정 고유 코드 지정")
+        void fail_accountCodeNotAllowed() {
+            // Given
+            given(couponRepository.existsByCode("EVENT01")).willReturn(false);
+            CouponAdminCreateReqDto reqDto = createReq("EVENT01", CouponTargetType.ALL, "USER01",
+                    List.of(inkReq(100)));
+
+            // When & Then
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> adminCouponService.createCoupon(reqDto));
+
+            assertThat(exception.getErrorCode()).isEqualTo(CouponErrorCode.TARGET_ACCOUNT_CODE_NOT_ALLOWED);
+            verify(couponRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("[실패 4] 존재하지 않는 계정 고유 코드")
+        void fail_targetUserNotFound() {
+            // Given
+            given(couponRepository.existsByCode("PRIVATE01")).willReturn(false);
+            given(userRepository.existsByAccountCode("NOBODY")).willReturn(false);
+            CouponAdminCreateReqDto reqDto = createReq("PRIVATE01", CouponTargetType.INDIVIDUAL, "NOBODY",
+                    List.of(inkReq(100)));
+
+            // When & Then
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> adminCouponService.createCoupon(reqDto));
+
+            assertThat(exception.getErrorCode()).isEqualTo(CouponErrorCode.TARGET_USER_NOT_FOUND);
+            verify(couponRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("[실패 5] 존재하지 않는 보상 아이템")
+        void fail_rewardItemNotFound() {
+            // Given
+            given(couponRepository.existsByCode("EVENT01")).willReturn(false);
+            given(itemRepository.findAllById(List.of(999L))).willReturn(List.of());
+            CouponAdminCreateReqDto reqDto = createReq("EVENT01", CouponTargetType.ALL, null,
+                    List.of(itemReq(999L)));
+
+            // When & Then
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> adminCouponService.createCoupon(reqDto));
+
+            assertThat(exception.getErrorCode()).isEqualTo(CouponErrorCode.REWARD_ITEM_NOT_FOUND);
+            verify(couponRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("[실패 6] 잉크 보상인데 수량 누락")
+        void fail_invalidInkReward() {
+            // Given
+            given(couponRepository.existsByCode("EVENT01")).willReturn(false);
+            CouponAdminCreateReqDto reqDto = createReq("EVENT01", CouponTargetType.ALL, null,
+                    List.of(new CouponAdminRewardReqDto(CouponRewardType.INK, null, null)));
+
+            // When & Then
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> adminCouponService.createCoupon(reqDto));
+
+            assertThat(exception.getErrorCode()).isEqualTo(CouponErrorCode.INVALID_REWARD);
+            verify(couponRepository, never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("updateCoupon() / deleteCoupon() 실패 케이스")
+    class UpdateDeleteFailCases {
+
+        @Test
+        @DisplayName("[실패 7] 사용 이력 있는 쿠폰의 보상 변경 시도")
+        void fail_updateUsedCouponRewards() {
+            // Given
+            Long couponId = 1L;
+            Coupon coupon = buildCoupon(couponId, "USED01", CouponTargetType.ALL, null, FUTURE,
+                    List.of(inkReward(100, 0)));
+
+            given(couponRepository.findByIdWithRewards(couponId)).willReturn(Optional.of(coupon));
+            given(userCouponRepository.existsByCouponId(couponId)).willReturn(true);
+
+            CouponAdminUpdateReqDto reqDto = updateReq("USED01", CouponTargetType.ALL, null,
+                    List.of(inkReq(9999)), FUTURE);
+
+            // When & Then
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> adminCouponService.updateCoupon(couponId, reqDto));
+
+            assertThat(exception.getErrorCode()).isEqualTo(CouponErrorCode.USED_COUPON_LIMITED_UPDATE);
+            assertThat(coupon.getRewards().get(0).getInkAmount()).isEqualTo(100);
+        }
+
+        @Test
+        @DisplayName("[실패 8] 사용 이력 있는 쿠폰 삭제 시도")
+        void fail_deleteUsedCoupon() {
+            // Given
+            Long couponId = 1L;
+            given(couponRepository.existsById(couponId)).willReturn(true);
+            given(userCouponRepository.existsByCouponId(couponId)).willReturn(true);
+
+            // When & Then
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> adminCouponService.deleteCoupon(couponId));
+
+            assertThat(exception.getErrorCode()).isEqualTo(CouponErrorCode.COUPON_ALREADY_USED_CANNOT_DELETE);
+            verify(couponRepository, never()).deleteById(anyLong());
+        }
+
+        @Test
+        @DisplayName("[실패 9] 존재하지 않는 쿠폰 삭제 시도")
+        void fail_deleteCouponNotFound() {
+            // Given
+            Long couponId = 999L;
+            given(couponRepository.existsById(couponId)).willReturn(false);
+
+            // When & Then
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> adminCouponService.deleteCoupon(couponId));
+
+            assertThat(exception.getErrorCode()).isEqualTo(CouponErrorCode.COUPON_NOT_FOUND);
+            verify(userCouponRepository, never()).existsByCouponId(anyLong());
+        }
+    }
+
+    @Nested
+    @DisplayName("sendCouponNotification() 실패 케이스")
+    class NotifyFailCases {
+
+        @Test
+        @DisplayName("[실패 10] 전체 대상 쿠폰에 알림 전송 시도")
+        void fail_notifyAllTargetCoupon() {
+            // Given
+            Long couponId = 1L;
+            Coupon coupon = buildCoupon(couponId, "EVENT01", CouponTargetType.ALL, null, FUTURE,
+                    List.of(inkReward(100, 0)));
+
+            given(couponRepository.findById(couponId)).willReturn(Optional.of(coupon));
+
+            // When & Then
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> adminCouponService.sendCouponNotification(couponId));
+
+            assertThat(exception.getErrorCode()).isEqualTo(CouponErrorCode.NOTIFY_TARGET_NOT_INDIVIDUAL);
+            assertThat(coupon.isNotified()).isFalse();
+            verify(notificationService, never()).createCouponNotification(any(), anyLong(), anyString());
+        }
+
+        @Test
+        @DisplayName("[실패 11] 이미 알림을 전송한 쿠폰")
+        void fail_alreadyNotified() {
+            // Given
+            Long couponId = 1L;
+            Coupon coupon = buildCoupon(couponId, "PRIVATE01", CouponTargetType.INDIVIDUAL, "USER01", FUTURE,
+                    List.of(inkReward(100, 0)));
+            coupon.markNotified();
+
+            given(couponRepository.findById(couponId)).willReturn(Optional.of(coupon));
+
+            // When & Then
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> adminCouponService.sendCouponNotification(couponId));
+
+            assertThat(exception.getErrorCode()).isEqualTo(CouponErrorCode.COUPON_ALREADY_NOTIFIED);
+            verify(notificationService, never()).createCouponNotification(any(), anyLong(), anyString());
+        }
+
+        @Test
+        @DisplayName("[실패 12] 만료된 쿠폰에 알림 전송 시도")
+        void fail_notifyExpiredCoupon() {
+            // Given
+            Long couponId = 1L;
+            Coupon coupon = buildCoupon(couponId, "EXPIRED01", CouponTargetType.INDIVIDUAL, "USER01",
+                    LocalDateTime.now().minusDays(1), List.of(inkReward(100, 0)));
+
+            given(couponRepository.findById(couponId)).willReturn(Optional.of(coupon));
+
+            // When & Then
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> adminCouponService.sendCouponNotification(couponId));
+
+            assertThat(exception.getErrorCode()).isEqualTo(CouponErrorCode.COUPON_EXPIRED);
+            assertThat(coupon.isNotified()).isFalse();
+        }
+
+        @Test
+        @DisplayName("[실패 13] 대상 유저가 알림을 꺼둔 경우 - notifiedAt을 기록하지 않아 재전송 가능")
+        void fail_receiverNotificationDisabled() {
+            // Given
+            Long couponId = 1L;
+            User mockUser = mock(User.class);
+            Coupon coupon = buildCoupon(couponId, "PRIVATE01", CouponTargetType.INDIVIDUAL, "USER01", FUTURE,
+                    List.of(inkReward(100, 0)));
+
+            given(couponRepository.findById(couponId)).willReturn(Optional.of(coupon));
+            given(userRepository.findByAccountCode("USER01")).willReturn(Optional.of(mockUser));
+            given(notificationService.createCouponNotification(mockUser, couponId, "PRIVATE01"))
+                    .willReturn(false);
+
+            // When & Then
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> adminCouponService.sendCouponNotification(couponId));
+
+            assertThat(exception.getErrorCode()).isEqualTo(CouponErrorCode.RECEIVER_NOTIFICATION_DISABLED);
+            assertThat(coupon.isNotified()).isFalse();
+            assertThat(coupon.getNotifiedAt()).isNull();
+        }
+
+        @Test
+        @DisplayName("[실패 14] 대상 유저를 찾을 수 없음")
+        void fail_notifyTargetUserNotFound() {
+            // Given
+            Long couponId = 1L;
+            Coupon coupon = buildCoupon(couponId, "PRIVATE01", CouponTargetType.INDIVIDUAL, "GONE01", FUTURE,
+                    List.of(inkReward(100, 0)));
+
+            given(couponRepository.findById(couponId)).willReturn(Optional.of(coupon));
+            given(userRepository.findByAccountCode("GONE01")).willReturn(Optional.empty());
+
+            // When & Then
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> adminCouponService.sendCouponNotification(couponId));
+
+            assertThat(exception.getErrorCode()).isEqualTo(CouponErrorCode.TARGET_USER_NOT_FOUND);
+            assertThat(coupon.isNotified()).isFalse();
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
- closes #260 

## 📝작업 내용

### 1. 관리자 쿠폰 CRUD

| Method | Path | 설명 |
| --- | --- | --- |
| POST | `/admin/coupons` | 쿠폰 등록 |
| GET | `/admin/coupons` | 전체 조회 (등록 최신순, 만료 포함) |
| GET | `/admin/coupons/{couponId}` | 단건 조회 (수정 팝업 프리필) |
| PATCH | `/admin/coupons/{couponId}` | 수정 |
| DELETE | `/admin/coupons/{couponId}` | 삭제 |
| POST | `/admin/coupons/{couponId}/notify` | 개인 쿠폰 알림 전송 |

### 2. 공지 읽음 기록 초기화

`POST /admin/notices/reads/reset`

최신 발행 공지의 `notice_read`를 전부 삭제합니다.
읽음 row가 없으면 안 읽음으로 간주하는 기존 구조를 그대로 활용해, 결과적으로 모든 유저의 공지 아이콘에 레드닷이 다시 노출됩니다.

### 3. 알림 도메인 변경

- `NotificationType.COUPON` 추가
  - title: `오늘의 질문 답변이 선정되어 쿠폰이 도착했어요.` (고정)
  - content: `쿠폰코드 : XJKSJ`
- `Notification.content` 길이 17 → 50
  - 기존 값은 편지 미리보기(17자) 기준이었고, 쿠폰 코드가 최대 20자라 확장이 필요했습니다.

## ➕주요 확인 사항

**보상 항목 삭제에 대한 별도 API X**
- 등록·수정 팝업 안에서만 쓰이는 UI 동작이라, 별도 API로 만들면 팝업 취소 시 롤백 필요

**목록 조회 N+1 방지**
- 컬렉션 fetch join과 페이징을 함께 쓰면 Hibernate가 전체 행을 메모리에 적재하므로, 정렬·페이징된 `couponId`만 먼저 조회한 뒤 그 ID로 보상을 일괄 fetch

**사용 이력이 있는 쿠폰은 변경 제한**
- 사용 후 보상을 바꾸면 이력이 실제 지급과 어긋나므로, 삭제는 차단하고 수정은 만료일만 허용

## ✅테스트

- `AdminCouponServiceUnitTest` 단위 테스트 작성 (성공 7 / 실패 14)
- Swagger에서 전체 플로우 수동 확인 완료
(쿠폰 등록 → 목록 조회 → 수정 → 알림 전송 → 유저 사용 → 삭제 차단)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 관리자 쿠폰을 등록·조회·수정·삭제할 수 있습니다.
  - 쿠폰 보상으로 잉크 또는 아이템을 설정할 수 있습니다.
  - 개인 대상 쿠폰 알림을 발송하고 발송 결과를 확인할 수 있습니다.
  - 쿠폰 코드와 보상, 대상 계정, 만료일을 검증합니다.
  - 최신 공지의 전체 읽음 기록을 초기화할 수 있습니다.

- **개선**
  - 쿠폰 알림 유형과 푸시 알림을 지원합니다.
  - 알림 내용 표시 길이가 늘어났습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->