### PR TITLE
🐛 Fix: 오늘의 질문 조회 조건 수정

### DIFF
--- a/src/main/java/com/example/egobook_be/domain/question/repository/TodayQuestionRepository.java
+++ b/src/main/java/com/example/egobook_be/domain/question/repository/TodayQuestionRepository.java
@@ -9,7 +9,7 @@ import java.time.LocalDate;
 import java.util.Optional;
 
 public interface TodayQuestionRepository extends JpaRepository<TodayQuestion, Long> {
-    Optional<TodayQuestion> findByQuestionDate(LocalDate date);
+    Optional<TodayQuestion> findByQuestionDateAndDeletedAtIsNull(LocalDate date);
 
     // 해당 날짜에 삭제되지 않은 질문이 있는지 확인
     boolean existsByQuestionDateAndDeletedAtIsNull(LocalDate questionDate);

--- a/src/main/java/com/example/egobook_be/domain/question/service/TodayQuestionService.java
+++ b/src/main/java/com/example/egobook_be/domain/question/service/TodayQuestionService.java
@@ -60,7 +60,7 @@ public class TodayQuestionService {
         log.info("[TodayQuestionService] getTodayQuestion Start - userId: {}", userId);
 
         TodayQuestion question = todayQuestionRepository
-                .findByQuestionDate(LocalDate.now())
+                .findByQuestionDateAndDeletedAtIsNull(LocalDate.now())
                 .orElseThrow(() ->
                         new CustomException(QuestionErrorCode.TODAY_QUESTION_NOT_FOUND)
                 );
@@ -114,7 +114,7 @@ public class TodayQuestionService {
         Ability userAbility = abilityRepository.findByUser(user).orElseThrow(() -> new CustomException(UserErrorCode.ABILITY_NOT_FOUND));
 
         TodayQuestion todayQuestion = todayQuestionRepository
-                .findByQuestionDate(LocalDate.now())
+                .findByQuestionDateAndDeletedAtIsNull(LocalDate.now())
                 .orElseThrow(() ->
                         new CustomException(QuestionErrorCode.TODAY_QUESTION_NOT_FOUND)
                 );
@@ -186,7 +186,7 @@ public class TodayQuestionService {
         log.info("[TodayQuestionService] getPublicAnswers Start");
 
         TodayQuestion todayQuestion = todayQuestionRepository
-                .findByQuestionDate(LocalDate.now())
+                .findByQuestionDateAndDeletedAtIsNull(LocalDate.now())
                 .orElseThrow(() -> new CustomException(QuestionErrorCode.TODAY_QUESTION_NOT_FOUND));
 
         PageRequest pageable = PageRequest.of(
@@ -237,7 +237,7 @@ public class TodayQuestionService {
                 );
 
         TodayQuestion todayQuestion = todayQuestionRepository
-                .findByQuestionDate(LocalDate.now())
+                .findByQuestionDateAndDeletedAtIsNull(LocalDate.now())
                 .orElseThrow(() ->
                         new CustomException(QuestionErrorCode.TODAY_QUESTION_NOT_FOUND)
                 );
@@ -265,7 +265,7 @@ public class TodayQuestionService {
                 .orElseThrow(() -> new IllegalStateException("로그인 사용자 정보가 존재하지 않습니다."));
 
         TodayQuestion todayQuestion = todayQuestionRepository
-                .findByQuestionDate(LocalDate.now())
+                .findByQuestionDateAndDeletedAtIsNull(LocalDate.now())
                 .orElseThrow(() -> new CustomException(QuestionErrorCode.TODAY_QUESTION_NOT_FOUND));
 
         List<Long> friendIds = friendRepository.findFriendIdsByUser(me);

--- a/src/test/java/com/example/egobook_be/domain/question/TodayQuestionAnsweredStatusServiceTest.java
+++ b/src/test/java/com/example/egobook_be/domain/question/TodayQuestionAnsweredStatusServiceTest.java
@@ -10,6 +10,7 @@ import com.example.egobook_be.domain.question.exception.QuestionErrorCode;
 import com.example.egobook_be.domain.question.repository.QuestionAnswerRepository;
 import com.example.egobook_be.domain.question.repository.TodayQuestionRepository;
 import com.example.egobook_be.domain.question.service.TodayQuestionService;
+import com.example.egobook_be.domain.user.entity.User;
 import com.example.egobook_be.domain.user.repository.AbilityRepository;
 import com.example.egobook_be.domain.user.repository.InkLogRepository;
 import com.example.egobook_be.domain.user.repository.UserRepository;
@@ -48,17 +49,19 @@ class TodayQuestionAnsweredStatusServiceTest {
     @Mock private InkLogUtil inkLogUtil;
 
     private TodayQuestion todayQuestion;
+    private User user;
 
     @BeforeEach
     void setUp() {
         todayQuestion = mock(TodayQuestion.class);
+        user = mock(User.class);
     }
 
     @Test
     @DisplayName("getTodayQuestion_오늘의질문없음_실패")
     void getTodayQuestion_questionNotFound_fail() {
 
-        given(todayQuestionRepository.findByQuestionDate(LocalDate.now()))
+        given(todayQuestionRepository.findByQuestionDateAndDeletedAtIsNull(LocalDate.now()))
                 .willReturn(Optional.empty());
 
         assertThatThrownBy(() -> todayQuestionService.getTodayQuestion(1L))
@@ -71,15 +74,24 @@ class TodayQuestionAnsweredStatusServiceTest {
     @DisplayName("getTodayQuestion_답변안한경우_answered가false_성공")
     void getTodayQuestion_notAnsweredYet_answeredFalse() {
 
+        given(userRepository.findById(1L))
+                .willReturn(Optional.of(user));
+
+        given(user.getMarketingEnabled())
+                .willReturn(false);
+
         given(todayQuestion.getId()).willReturn(100L);
         given(todayQuestion.getContent()).willReturn("오늘의 질문입니다.");
         given(todayQuestion.getQuestionDate()).willReturn(LocalDate.now());
-        given(todayQuestionRepository.findByQuestionDate(LocalDate.now()))
+
+        given(todayQuestionRepository.findByQuestionDateAndDeletedAtIsNull(LocalDate.now()))
                 .willReturn(Optional.of(todayQuestion));
+
         given(questionAnswerRepository.findByUserIdAndQuestionIdWithQuestion(1L, 100L))
                 .willReturn(Optional.empty());
 
-        TodayQuestionResDto result = todayQuestionService.getTodayQuestion(1L);
+        TodayQuestionResDto result =
+                todayQuestionService.getTodayQuestion(1L);
 
         assertThat(result.answered()).isFalse();
         assertThat(result.myAnswer()).isNull();
@@ -89,26 +101,37 @@ class TodayQuestionAnsweredStatusServiceTest {
     @DisplayName("getTodayQuestion_이미답변한경우_answered가true_성공")
     void getTodayQuestion_alreadyAnswered_answeredTrue() {
 
+        given(userRepository.findById(1L))
+                .willReturn(Optional.of(user));
+
+        given(user.getMarketingEnabled())
+                .willReturn(false);
+
         given(todayQuestion.getId()).willReturn(100L);
         given(todayQuestion.getContent()).willReturn("오늘의 질문입니다.");
         given(todayQuestion.getQuestionDate()).willReturn(LocalDate.now());
-        given(todayQuestionRepository.findByQuestionDate(LocalDate.now()))
+
+        given(todayQuestionRepository.findByQuestionDateAndDeletedAtIsNull(LocalDate.now()))
                 .willReturn(Optional.of(todayQuestion));
 
         QuestionAnswer answer = mock(QuestionAnswer.class);
+
         given(answer.getId()).willReturn(10L);
         given(answer.getContent()).willReturn("내 답변");
         given(answer.getVisibility()).willReturn(AnswerVisibility.PUBLIC);
         given(answer.getCreatedAt()).willReturn(LocalDateTime.now());
+
         given(questionAnswerRepository.findByUserIdAndQuestionIdWithQuestion(1L, 100L))
                 .willReturn(Optional.of(answer));
 
-        TodayQuestionResDto result = todayQuestionService.getTodayQuestion(1L);
+        TodayQuestionResDto result =
+                todayQuestionService.getTodayQuestion(1L);
 
         assertThat(result.answered()).isTrue();
         assertThat(result.myAnswer()).isNotNull();
         assertThat(result.myAnswer().content()).isEqualTo("내 답변");
-        assertThat(result.myAnswer().visibility()).isEqualTo(AnswerVisibility.PUBLIC);
+        assertThat(result.myAnswer().visibility())
+                .isEqualTo(AnswerVisibility.PUBLIC);
     }
 
     @Test
@@ -117,7 +140,7 @@ class TodayQuestionAnsweredStatusServiceTest {
 
         given(todayQuestion.getContent()).willReturn("오늘의 질문입니다.");
         given(todayQuestion.getQuestionDate()).willReturn(LocalDate.now());
-        given(todayQuestionRepository.findByQuestionDate(LocalDate.now()))
+        given(todayQuestionRepository.findByQuestionDateAndDeletedAtIsNull(LocalDate.now()))
                 .willReturn(Optional.of(todayQuestion));
 
         TodayQuestionResDto result = todayQuestionService.getTodayQuestion(null);

--- a/src/test/java/com/example/egobook_be/domain/question/TodayQuestionCreateAnswerServiceTest.java
+++ b/src/test/java/com/example/egobook_be/domain/question/TodayQuestionCreateAnswerServiceTest.java
@@ -80,7 +80,7 @@ class TodayQuestionCreateAnswerServiceTest {
         given(userRepository.findById(1L)).willReturn(Optional.of(user));
         given(missionRepository.findByUser(user)).willReturn(Optional.of(mission));
         given(abilityRepository.findByUser(user)).willReturn(Optional.of(ability));
-        given(todayQuestionRepository.findByQuestionDate(LocalDate.now()))
+        given(todayQuestionRepository.findByQuestionDateAndDeletedAtIsNull(LocalDate.now()))
                 .willReturn(Optional.of(todayQuestion));
         given(questionAnswerRepository.existsByUserAndQuestion(user, todayQuestion)).willReturn(false);
         given(questionAnswerRepository.existsByUserAndCreatedAtBetween(
@@ -143,7 +143,7 @@ class TodayQuestionCreateAnswerServiceTest {
         given(userRepository.findById(1L)).willReturn(Optional.of(user));
         given(missionRepository.findByUser(user)).willReturn(Optional.of(mission));
         given(abilityRepository.findByUser(user)).willReturn(Optional.of(ability));
-        given(todayQuestionRepository.findByQuestionDate(LocalDate.now()))
+        given(todayQuestionRepository.findByQuestionDateAndDeletedAtIsNull(LocalDate.now()))
                 .willReturn(Optional.empty());
 
         assertThatThrownBy(() -> todayQuestionService.createAnswer(1L, reqDto))
@@ -159,7 +159,7 @@ class TodayQuestionCreateAnswerServiceTest {
         given(userRepository.findById(1L)).willReturn(Optional.of(user));
         given(missionRepository.findByUser(user)).willReturn(Optional.of(mission));
         given(abilityRepository.findByUser(user)).willReturn(Optional.of(ability));
-        given(todayQuestionRepository.findByQuestionDate(LocalDate.now()))
+        given(todayQuestionRepository.findByQuestionDateAndDeletedAtIsNull(LocalDate.now()))
                 .willReturn(Optional.of(todayQuestion));
         given(questionAnswerRepository.existsByUserAndQuestion(user, todayQuestion)).willReturn(true);
 
@@ -176,7 +176,7 @@ class TodayQuestionCreateAnswerServiceTest {
         given(userRepository.findById(1L)).willReturn(Optional.of(user));
         given(missionRepository.findByUser(user)).willReturn(Optional.of(mission));
         given(abilityRepository.findByUser(user)).willReturn(Optional.of(ability));
-        given(todayQuestionRepository.findByQuestionDate(LocalDate.now()))
+        given(todayQuestionRepository.findByQuestionDateAndDeletedAtIsNull(LocalDate.now()))
                 .willReturn(Optional.of(todayQuestion));
         given(questionAnswerRepository.existsByUserAndQuestion(user, todayQuestion)).willReturn(false);
         given(questionAnswerRepository.existsByUserAndCreatedAtBetween(
@@ -197,7 +197,7 @@ class TodayQuestionCreateAnswerServiceTest {
         given(userRepository.findById(1L)).willReturn(Optional.of(user));
         given(missionRepository.findByUser(user)).willReturn(Optional.of(mission));
         given(abilityRepository.findByUser(user)).willReturn(Optional.of(ability));
-        given(todayQuestionRepository.findByQuestionDate(LocalDate.now()))
+        given(todayQuestionRepository.findByQuestionDateAndDeletedAtIsNull(LocalDate.now()))
                 .willReturn(Optional.of(todayQuestion));
         given(questionAnswerRepository.existsByUserAndQuestion(user, todayQuestion)).willReturn(false);
         given(questionAnswerRepository.existsByUserAndCreatedAtBetween(
@@ -221,7 +221,7 @@ class TodayQuestionCreateAnswerServiceTest {
         given(userRepository.findById(1L)).willReturn(Optional.of(user));
         given(missionRepository.findByUser(user)).willReturn(Optional.of(mission));
         given(abilityRepository.findByUser(user)).willReturn(Optional.of(ability));
-        given(todayQuestionRepository.findByQuestionDate(LocalDate.now()))
+        given(todayQuestionRepository.findByQuestionDateAndDeletedAtIsNull(LocalDate.now()))
                 .willReturn(Optional.of(todayQuestion));
         given(questionAnswerRepository.existsByUserAndQuestion(user, todayQuestion)).willReturn(false);
         willThrow(new CustomException(RestrictionErrorCode.QUESTION_ANSWER_RESTRICTED))

--- a/src/test/java/com/example/egobook_be/domain/question/TodayQuestionUpdateAnswerServiceTest.java
+++ b/src/test/java/com/example/egobook_be/domain/question/TodayQuestionUpdateAnswerServiceTest.java
@@ -72,7 +72,7 @@ class TodayQuestionUpdateAnswerServiceTest {
     void updateAnswer_validRequest_success() {
 
         QuestionAnswer answer = mock(QuestionAnswer.class);
-        given(todayQuestionRepository.findByQuestionDate(LocalDate.now()))
+        given(todayQuestionRepository.findByQuestionDateAndDeletedAtIsNull(LocalDate.now()))
                 .willReturn(Optional.of(todayQuestion));
         given(questionAnswerRepository.findByUserAndQuestion(user, todayQuestion))
                 .willReturn(Optional.of(answer));
@@ -86,7 +86,7 @@ class TodayQuestionUpdateAnswerServiceTest {
     @DisplayName("updateAnswer_오늘의질문없음_실패")
     void updateAnswer_todayQuestionNotFound_fail() {
 
-        given(todayQuestionRepository.findByQuestionDate(LocalDate.now()))
+        given(todayQuestionRepository.findByQuestionDateAndDeletedAtIsNull(LocalDate.now()))
                 .willReturn(Optional.empty());
 
         assertThatThrownBy(() -> todayQuestionService.updateAnswer(1L, reqDto))
@@ -99,7 +99,7 @@ class TodayQuestionUpdateAnswerServiceTest {
     @DisplayName("updateAnswer_답변없음_실패")
     void updateAnswer_answerNotFound_fail() {
 
-        given(todayQuestionRepository.findByQuestionDate(LocalDate.now()))
+        given(todayQuestionRepository.findByQuestionDateAndDeletedAtIsNull(LocalDate.now()))
                 .willReturn(Optional.of(todayQuestion));
         given(questionAnswerRepository.findByUserAndQuestion(user, todayQuestion))
                 .willReturn(Optional.empty());
@@ -117,7 +117,7 @@ class TodayQuestionUpdateAnswerServiceTest {
     void updateAnswer_questionAnswerRestricted_fail() {
         // given
         QuestionAnswer answer = mock(QuestionAnswer.class);
-        given(todayQuestionRepository.findByQuestionDate(LocalDate.now()))
+        given(todayQuestionRepository.findByQuestionDateAndDeletedAtIsNull(LocalDate.now()))
                 .willReturn(Optional.of(todayQuestion));
         given(questionAnswerRepository.findByUserAndQuestion(user, todayQuestion))
                 .willReturn(Optional.of(answer));


### PR DESCRIPTION
## #️⃣연관된 이슈
- #262 

## 📝작업 내용
- 오늘의 질문 조회 시 Soft Delete된 질문이 함께 조회되어 발생하는 중복 조회 오류 수정
- deletedAt IS NULL 조건을 추가하여 현재 활성화된 오늘의 질문만 조회하도록 수정
- 기존 질문 데이터 및 답변 이력은 삭제하지 않고 유지

### 작업 API
- 오늘의 질문 조회 API
- 오늘의 질문 답변 작성 API
- 오늘의 질문 공개 답변 조회 API
- 오늘의 질문 답변 수정 API
- 친구 답변 조회 API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 오늘의 질문 조회 시 삭제된 질문이 표시되거나 사용되지 않도록 개선했습니다.
  * 답변 작성·수정, 공개 답변 조회, 친구 답변 조회에서도 삭제되지 않은 질문만 처리합니다.

* **테스트**
  * 삭제된 질문을 제외하는 동작을 검증하도록 관련 테스트를 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->